### PR TITLE
符計算・点数計算モジュールを追加

### DIFF
--- a/src/hand.rs
+++ b/src/hand.rs
@@ -29,6 +29,11 @@ impl Hand {
         self.drawn
     }
 
+    /// 副露を返す
+    pub fn opened(&self) -> &[OpenTiles] {
+        &self.opened
+    }
+
     /// 手牌をソートする
     pub fn sort(&mut self) {
         self.tiles.sort();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,7 @@ pub mod hand;
 pub mod hand_info;
 /// 和了役
 pub mod winning_hand;
+/// 符計算・点数計算
+pub mod scoring;
 /// 卓
 pub mod board;

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -1,0 +1,5 @@
+/// 符計算
+pub mod fu;
+
+/// 点数計算
+pub mod score;

--- a/src/scoring/fu.rs
+++ b/src/scoring/fu.rs
@@ -1,0 +1,668 @@
+use anyhow::Result;
+
+use crate::hand::Hand;
+use crate::hand_info::hand_analyzer::HandAnalyzer;
+use crate::hand_info::opened::{OpenFrom, OpenType};
+use crate::hand_info::status::Status;
+use crate::tile::{Dragon, Tile, TileType, Wind};
+use crate::winning_hand::name::Form;
+
+/// 符計算の結果
+#[derive(Debug, PartialEq, Eq)]
+pub struct FuResult {
+    /// 合計符（10符単位に切り上げ済み）
+    pub total: u32,
+    /// 符の内訳
+    pub details: Vec<FuDetail>,
+}
+
+/// 符の内訳を表す構造体
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct FuDetail {
+    /// 符の名称
+    pub name: &'static str,
+    /// 符の値
+    pub fu: u32,
+}
+
+/// 符を計算する
+///
+/// # Arguments
+/// * `analyzer` - 手牌解析結果
+/// * `hand` - 手牌
+/// * `status` - 局の状態
+///
+/// # Returns
+/// 符計算の結果（切り上げ済み合計 + 内訳）
+pub fn calculate_fu(
+    analyzer: &HandAnalyzer,
+    hand: &Hand,
+    status: &Status,
+) -> Result<FuResult> {
+    // 七対子は固定25符
+    if analyzer.form == Form::SevenPairs {
+        return Ok(FuResult {
+            total: 25,
+            details: vec![FuDetail {
+                name: "七対子",
+                fu: 25,
+            }],
+        });
+    }
+
+    // 国士無双は符計算なし（便宜上30符）
+    if analyzer.form == Form::ThirteenOrphans {
+        return Ok(FuResult {
+            total: 30,
+            details: vec![FuDetail {
+                name: "国士無双",
+                fu: 30,
+            }],
+        });
+    }
+
+    let mut details: Vec<FuDetail> = Vec::new();
+
+    // 副底（基本符）：20符
+    details.push(FuDetail {
+        name: "副底",
+        fu: 20,
+    });
+
+    // 面子の符
+    calculate_mentsu_fu(analyzer, hand, status, &mut details)?;
+
+    // 雀頭の符
+    calculate_jantou_fu(analyzer, status, &mut details)?;
+
+    // 待ちの符
+    calculate_machi_fu(analyzer, hand, &mut details)?;
+
+    // ツモ符
+    calculate_tsumo_fu(analyzer, status, &mut details)?;
+
+    // 門前ロン加符
+    calculate_menzen_ron_fu(status, &mut details)?;
+
+    let raw_total: u32 = details.iter().map(|d| d.fu).sum();
+
+    // 平和ツモは20符固定
+    if is_pinfu(analyzer, hand, status) && status.is_self_picked {
+        return Ok(FuResult {
+            total: 20,
+            details: vec![FuDetail {
+                name: "平和ツモ",
+                fu: 20,
+            }],
+        });
+    }
+
+    // 鳴き平和形（副底のみ）のロンは30符
+    let total = if raw_total == 20 && !status.is_self_picked && status.has_claimed_open {
+        30
+    } else {
+        // 10符単位に切り上げ
+        round_up_to_10(raw_total)
+    };
+
+    Ok(FuResult { total, details })
+}
+
+/// 10符単位に切り上げる
+fn round_up_to_10(fu: u32) -> u32 {
+    (fu + 9) / 10 * 10
+}
+
+/// 平和判定（簡易版：符計算用）
+fn is_pinfu(analyzer: &HandAnalyzer, hand: &Hand, status: &Status) -> bool {
+    if status.has_claimed_open {
+        return false;
+    }
+    if analyzer.form != Form::Normal {
+        return false;
+    }
+    if analyzer.sequential3.len() != 4 || analyzer.same2.len() != 1 {
+        return false;
+    }
+    // 雀頭が役牌でないこと
+    for head in &analyzer.same2 {
+        let tile = head.get()[0];
+        if is_yakuhai_tile(tile, status) {
+            return false;
+        }
+    }
+    // 両面待ちであること
+    if let Some(winning_tile) = hand.drawn() {
+        for seq in &analyzer.sequential3 {
+            let tiles = seq.get();
+            if winning_tile.get() == tiles[0] && tiles[0] % 9 != 6 {
+                return true;
+            }
+            if winning_tile.get() == tiles[2] && tiles[2] % 9 != 2 {
+                return true;
+            }
+        }
+        return false;
+    }
+    false
+}
+
+/// 役牌かどうかを判定する
+fn is_yakuhai_tile(tile: TileType, status: &Status) -> bool {
+    // 三元牌
+    if Dragon::is_tile_type(tile).is_some() {
+        return true;
+    }
+    // 自風牌
+    if Wind::is_tile_type(tile) == Some(status.player_wind) {
+        return true;
+    }
+    // 場風牌
+    if Wind::is_tile_type(tile) == Some(status.prevailing_wind) {
+        return true;
+    }
+    false
+}
+
+/// 面子（刻子・槓子・順子）の符を計算する
+fn calculate_mentsu_fu(
+    analyzer: &HandAnalyzer,
+    hand: &Hand,
+    status: &Status,
+    details: &mut Vec<FuDetail>,
+) -> Result<()> {
+    // 副露面子の牌種を収集（analyzer.same3 との重複排除用）
+    let opened_triplet_tiles: Vec<TileType> = hand
+        .opened()
+        .iter()
+        .filter(|o| o.category == OpenType::Pon || o.category == OpenType::Kan)
+        .map(|o| o.tiles[0].get())
+        .collect();
+
+    // 門前手の刻子（暗刻）
+    for same in &analyzer.same3 {
+        let tile = same.get()[0];
+
+        // 副露面子として既にカウントされる刻子はスキップ
+        if opened_triplet_tiles.contains(&tile) {
+            continue;
+        }
+
+        let is_terminal_or_honor = is_terminal_or_honor(tile);
+
+        // 和了牌を含む刻子がロン和了の場合は明刻扱い
+        let is_concealed = if !status.is_self_picked {
+            if let Some(drawn) = hand.drawn() {
+                drawn.get() != tile
+            } else {
+                true
+            }
+        } else {
+            true
+        };
+
+        let fu = if is_concealed {
+            if is_terminal_or_honor { 8 } else { 4 }
+        } else {
+            if is_terminal_or_honor { 4 } else { 2 }
+        };
+
+        let name = if is_concealed {
+            if is_terminal_or_honor {
+                "么九牌暗刻"
+            } else {
+                "中張牌暗刻"
+            }
+        } else {
+            if is_terminal_or_honor {
+                "么九牌明刻"
+            } else {
+                "中張牌明刻"
+            }
+        };
+
+        details.push(FuDetail { name, fu });
+    }
+
+    // 副露面子
+    for open in hand.opened() {
+        match open.category {
+            OpenType::Pon => {
+                let tile = open.tiles[0].get();
+                let is_terminal_or_honor = is_terminal_or_honor(tile);
+                let fu = if is_terminal_or_honor { 4 } else { 2 };
+                let name = if is_terminal_or_honor {
+                    "么九牌明刻"
+                } else {
+                    "中張牌明刻"
+                };
+                details.push(FuDetail { name, fu });
+            }
+            OpenType::Kan => {
+                let tile = open.tiles[0].get();
+                let is_terminal_or_honor = is_terminal_or_honor(tile);
+                let is_concealed = open.from == OpenFrom::Myself;
+                let fu = if is_concealed {
+                    if is_terminal_or_honor { 32 } else { 16 }
+                } else {
+                    if is_terminal_or_honor { 16 } else { 8 }
+                };
+                let name = if is_concealed {
+                    if is_terminal_or_honor {
+                        "么九牌暗槓"
+                    } else {
+                        "中張牌暗槓"
+                    }
+                } else {
+                    if is_terminal_or_honor {
+                        "么九牌明槓"
+                    } else {
+                        "中張牌明槓"
+                    }
+                };
+                details.push(FuDetail { name, fu });
+            }
+            OpenType::Chi => {
+                // チーの順子は0符
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// 雀頭の符を計算する
+fn calculate_jantou_fu(
+    analyzer: &HandAnalyzer,
+    status: &Status,
+    details: &mut Vec<FuDetail>,
+) -> Result<()> {
+    for head in &analyzer.same2 {
+        let tile = head.get()[0];
+
+        // 三元牌の雀頭：2符
+        if Dragon::is_tile_type(tile).is_some() {
+            details.push(FuDetail {
+                name: "三元牌雀頭",
+                fu: 2,
+            });
+        }
+
+        // 自風牌の雀頭：2符
+        if Wind::is_tile_type(tile) == Some(status.player_wind) {
+            details.push(FuDetail {
+                name: "自風牌雀頭",
+                fu: 2,
+            });
+        }
+
+        // 場風牌の雀頭：2符
+        if Wind::is_tile_type(tile) == Some(status.prevailing_wind) {
+            details.push(FuDetail {
+                name: "場風牌雀頭",
+                fu: 2,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// 待ちの形による符を計算する
+fn calculate_machi_fu(
+    analyzer: &HandAnalyzer,
+    hand: &Hand,
+    details: &mut Vec<FuDetail>,
+) -> Result<()> {
+    if let Some(winning_tile) = hand.drawn() {
+        let wt = winning_tile.get();
+
+        // 単騎待ち: 雀頭で待っていた場合
+        for head in &analyzer.same2 {
+            if head.get()[0] == wt {
+                details.push(FuDetail {
+                    name: "単騎待ち",
+                    fu: 2,
+                });
+                return Ok(());
+            }
+        }
+
+        // 嵌張待ち・辺張待ち
+        for seq in &analyzer.sequential3 {
+            let tiles = seq.get();
+            // 嵌張待ち: 真ん中の牌で待っていた
+            if wt == tiles[1] {
+                details.push(FuDetail {
+                    name: "嵌張待ち",
+                    fu: 2,
+                });
+                return Ok(());
+            }
+            // 辺張待ち: 12の3待ち or 89の7待ち
+            if wt == tiles[2] && tiles[2] % 9 == 2 {
+                details.push(FuDetail {
+                    name: "辺張待ち",
+                    fu: 2,
+                });
+                return Ok(());
+            }
+            if wt == tiles[0] && tiles[0] % 9 == 6 {
+                details.push(FuDetail {
+                    name: "辺張待ち",
+                    fu: 2,
+                });
+                return Ok(());
+            }
+        }
+
+        // 両面待ちや双碰待ちは0符
+    }
+
+    Ok(())
+}
+
+/// ツモの符を計算する
+fn calculate_tsumo_fu(
+    _analyzer: &HandAnalyzer,
+    status: &Status,
+    details: &mut Vec<FuDetail>,
+) -> Result<()> {
+    // ツモ和了は2符（ただし平和ツモの場合は別途処理するため、ここでは常に加算）
+    if status.is_self_picked {
+        details.push(FuDetail {
+            name: "自摸",
+            fu: 2,
+        });
+    }
+
+    Ok(())
+}
+
+/// 門前ロンの加符を計算する
+fn calculate_menzen_ron_fu(
+    status: &Status,
+    details: &mut Vec<FuDetail>,
+) -> Result<()> {
+    // 門前でロン和了した場合は10符加算
+    if !status.has_claimed_open && !status.is_self_picked {
+        details.push(FuDetail {
+            name: "門前加符",
+            fu: 10,
+        });
+    }
+
+    Ok(())
+}
+
+/// 么九牌（1,9）または字牌かを判定する
+fn is_terminal_or_honor(tile: TileType) -> bool {
+    matches!(
+        tile,
+        Tile::M1
+            | Tile::M9
+            | Tile::P1
+            | Tile::P9
+            | Tile::S1
+            | Tile::S9
+            | Tile::Z1
+            | Tile::Z2
+            | Tile::Z3
+            | Tile::Z4
+            | Tile::Z5
+            | Tile::Z6
+            | Tile::Z7
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hand::Hand;
+    use crate::hand_info::hand_analyzer::HandAnalyzer;
+    use crate::hand_info::status::Status;
+    use crate::tile::Wind;
+
+    /// 平和ツモは20符
+    #[test]
+    fn test_pinfu_tsumo() {
+        let hand = Hand::from("123456m234p6799s 5s");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.is_self_picked = true;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        assert_eq!(result.total, 20);
+    }
+
+    /// 平和ロンは30符
+    #[test]
+    fn test_pinfu_ron() {
+        let hand = Hand::from("123456m234p6799s 5s");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.is_self_picked = false;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        // 副底20 + 門前加符10 = 30
+        assert_eq!(result.total, 30);
+    }
+
+    /// 七対子は25符固定
+    #[test]
+    fn test_seven_pairs() {
+        let hand = Hand::from("1122m3344p5566s7z 7z");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let status = Status::new();
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        assert_eq!(result.total, 25);
+    }
+
+    /// 中張牌暗刻のみの手（順子+暗刻+雀頭、ツモ）
+    #[test]
+    fn test_concealed_triplet_simple() {
+        // 222m 123p 789s 456s 33m: ツモ和了
+        // 手牌: 222m123p456789s3m ツモ3m
+        let hand = Hand::from("222m123p456789s3m 3m");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.is_self_picked = true;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        // 副底20 + 中張牌暗刻4(222m) + 単騎待ち2(3m) + ツモ2 = 28 -> 30
+        assert_eq!(result.total, 30);
+    }
+
+    /// 么九牌暗刻を含む手（ロン和了）
+    #[test]
+    fn test_concealed_triplet_terminal() {
+        // 111m 456p 789s 234m 55m: ロン5m（単騎）
+        let hand = Hand::from("111m456p789s2345m 5m");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.is_self_picked = false;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        // 副底20 + 門前加符10 + 么九牌暗刻8(111m) + 単騎待ち2 = 40
+        assert_eq!(result.total, 40);
+    }
+
+    /// ポンした明刻（中張牌）: 2符
+    #[test]
+    fn test_open_triplet_simple() {
+        // 123p 789s 456s 33m + ポン222m + ツモ3m
+        let hand = Hand::from("123p456789s3m 222m 3m");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.has_claimed_open = true;
+        status.is_self_picked = true;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        // 副底20 + 中張牌明刻2(222m) + 単騎待ち2(3m) + ツモ2 = 26 -> 30
+        assert_eq!(result.total, 30);
+    }
+
+    /// ポンした明刻（么九牌）: 4符
+    #[test]
+    fn test_open_triplet_terminal() {
+        // 123p 456s 789s 33m + ポン111m + ツモ3m
+        let hand = Hand::from("123p456789s3m 111m 3m");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.has_claimed_open = true;
+        status.is_self_picked = true;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        // 副底20 + 么九牌明刻4(111m) + 単騎待ち2(3m) + ツモ2 = 28 -> 30
+        assert_eq!(result.total, 30);
+    }
+
+    /// 明槓（中張牌）: 8符
+    #[test]
+    fn test_open_kan_simple() {
+        // 123p 789s 456s 33m + 明槓2222m + ツモ3m
+        let hand = Hand::from("123p456789s3m 2222m 3m");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.has_claimed_open = true;
+        status.is_self_picked = true;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        // from=Unknownなので明槓扱い
+        // 副底20 + 中張牌明槓8 + 単騎待ち2(3m) + ツモ2 = 32 -> 40
+        assert_eq!(result.total, 40);
+    }
+
+    /// 三元牌の雀頭: 2符
+    #[test]
+    fn test_dragon_pair() {
+        let hand = Hand::from("123456m234p789s5z 5z");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.is_self_picked = false;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        // 副底20 + 門前加符10 + 三元牌雀頭2 + 単騎待ち2 = 34 -> 40
+        assert_eq!(result.total, 40);
+    }
+
+    /// 自風牌の雀頭: 2符
+    #[test]
+    fn test_player_wind_pair() {
+        let hand = Hand::from("123456m234p789s1z 1z");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.is_self_picked = false;
+        status.player_wind = Wind::East;
+        status.prevailing_wind = Wind::South;
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        // 副底20 + 門前加符10 + 自風牌雀頭2 + 単騎待ち2 = 34 -> 40
+        assert_eq!(result.total, 40);
+    }
+
+    /// 場風牌の雀頭: 2符
+    #[test]
+    fn test_prevailing_wind_pair() {
+        let hand = Hand::from("123456m234p789s1z 1z");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.is_self_picked = false;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        // 副底20 + 門前加符10 + 場風牌雀頭2 + 単騎待ち2 = 34 -> 40
+        assert_eq!(result.total, 40);
+    }
+
+    /// 連風牌の雀頭（自風=場風=東）: 4符
+    #[test]
+    fn test_double_wind_pair() {
+        let hand = Hand::from("123456m234p789s1z 1z");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.is_self_picked = false;
+        status.player_wind = Wind::East;
+        status.prevailing_wind = Wind::East;
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        // 副底20 + 門前加符10 + 自風牌雀頭2 + 場風牌雀頭2 + 単騎待ち2 = 36 -> 40
+        assert_eq!(result.total, 40);
+    }
+
+    /// 嵌張待ち: 2符
+    #[test]
+    fn test_kanchan_wait() {
+        let hand = Hand::from("123456m234p79s11z 8s");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.is_self_picked = false;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::South;
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        // 副底20 + 門前加符10 + 嵌張待ち2 = 32 -> 40
+        assert_eq!(result.total, 40);
+    }
+
+    /// 辺張待ち（12の3待ち）: 2符
+    #[test]
+    fn test_penchan_wait_low() {
+        let hand = Hand::from("12m456m234p789s1z 3m");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.is_self_picked = false;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::South;
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        // 副底20 + 門前加符10 + 辺張待ち2 + 場風牌雀頭2(南=2z? いや1z=東) = 32 -> 40
+        // 1z=東、場風南なので雀頭加符なし
+        // 副底20 + 門前加符10 + 辺張待ち2 = 32 -> 40
+        assert_eq!(result.total, 40);
+    }
+
+    /// 辺張待ち（89の7待ち）: 2符
+    #[test]
+    fn test_penchan_wait_high() {
+        let hand = Hand::from("123m456m234p89s1z 7s");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.is_self_picked = false;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::South;
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        // 副底20 + 門前加符10 + 辺張待ち2 = 32 -> 40
+        assert_eq!(result.total, 40);
+    }
+
+    /// 10符単位の切り上げ
+    #[test]
+    fn test_round_up_to_10() {
+        assert_eq!(round_up_to_10(20), 20);
+        assert_eq!(round_up_to_10(21), 30);
+        assert_eq!(round_up_to_10(25), 30);
+        assert_eq!(round_up_to_10(29), 30);
+        assert_eq!(round_up_to_10(30), 30);
+        assert_eq!(round_up_to_10(31), 40);
+        assert_eq!(round_up_to_10(32), 40);
+    }
+
+    /// 鳴き平和形のロンは30符
+    #[test]
+    fn test_open_pinfu_ron() {
+        let hand = Hand::from("456m789s33z 123p 234s 3z");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.has_claimed_open = true;
+        status.is_self_picked = false;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let result = calculate_fu(&analyzer, &hand, &status).unwrap();
+        assert_eq!(result.total, 30);
+    }
+}

--- a/src/scoring/score.rs
+++ b/src/scoring/score.rs
@@ -1,0 +1,481 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+use crate::hand::Hand;
+use crate::hand_info::hand_analyzer::HandAnalyzer;
+use crate::hand_info::status::Status;
+use crate::scoring::fu::{calculate_fu, FuResult};
+use crate::winning_hand::checker;
+use crate::winning_hand::name::Kind;
+use crate::settings::Settings;
+
+/// 点数計算の結果
+#[derive(Debug, PartialEq, Eq)]
+pub struct ScoreResult {
+    /// 翻数
+    pub han: u32,
+    /// 符
+    pub fu: u32,
+    /// 点数等級名称
+    pub rank: ScoreRank,
+    /// 親の場合のロン和了点
+    pub dealer_ron: u32,
+    /// 親の場合のツモ和了点（各子の支払い）
+    pub dealer_tsumo_all: u32,
+    /// 子の場合のロン和了点
+    pub non_dealer_ron: u32,
+    /// 子の場合のツモ和了点（親の支払い）
+    pub non_dealer_tsumo_dealer: u32,
+    /// 子の場合のツモ和了点（子の支払い）
+    pub non_dealer_tsumo_non_dealer: u32,
+    /// 成立した役の一覧
+    pub yaku_list: Vec<(&'static str, u32)>,
+    /// 符の内訳
+    pub fu_result: FuResult,
+}
+
+/// 点数の等級
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ScoreRank {
+    /// 通常（満貫未満）
+    Normal,
+    /// 満貫（5翻以上、または役満以外で3翻60符以上・4翻30符以上）
+    Mangan,
+    /// 跳満（6～7翻）
+    Haneman,
+    /// 倍満（8～10翻）
+    Baiman,
+    /// 三倍満（11～12翻）
+    Sanbaiman,
+    /// 役満（13翻以上）
+    Yakuman,
+}
+
+/// 点数を計算する
+///
+/// # Arguments
+/// * `analyzer` - 手牌解析結果
+/// * `hand` - 手牌
+/// * `status` - 局の状態
+/// * `settings` - ルール設定
+///
+/// # Returns
+/// 点数計算の結果。役がない場合はNone。
+pub fn calculate_score(
+    analyzer: &HandAnalyzer,
+    hand: &Hand,
+    status: &Status,
+    settings: &Settings,
+) -> Result<Option<ScoreResult>> {
+    // 役判定
+    let yaku_result = checker::check(analyzer, hand, status, settings)?;
+
+    // 成立した役を抽出
+    let yaku_list = extract_yaku_list(&yaku_result);
+
+    if yaku_list.is_empty() {
+        return Ok(None);
+    }
+
+    // 翻数の合計
+    let han: u32 = yaku_list.iter().map(|(_, h)| h).sum();
+
+    // 役満判定
+    let has_yakuman = yaku_list.iter().any(|(_, h)| *h >= 13);
+
+    // 符計算
+    let fu_result = calculate_fu(analyzer, hand, status)?;
+    let fu = fu_result.total;
+
+    // 等級を決定
+    let rank = determine_rank(han, fu, has_yakuman);
+
+    // 基本点を計算
+    let base_points = calculate_base_points(han, fu, rank);
+
+    // 各支払い額を計算
+    let dealer_ron = round_up_to_100(base_points * 6);
+    let dealer_tsumo_all = round_up_to_100(base_points * 2);
+    let non_dealer_ron = round_up_to_100(base_points * 4);
+    let non_dealer_tsumo_dealer = round_up_to_100(base_points * 2);
+    let non_dealer_tsumo_non_dealer = round_up_to_100(base_points);
+
+    Ok(Some(ScoreResult {
+        han,
+        fu,
+        rank,
+        dealer_ron,
+        dealer_tsumo_all,
+        non_dealer_ron,
+        non_dealer_tsumo_dealer,
+        non_dealer_tsumo_non_dealer,
+        yaku_list,
+        fu_result,
+    }))
+}
+
+/// 役判定結果から成立した役のリストを抽出する
+fn extract_yaku_list(
+    yaku_result: &HashMap<Kind, (&'static str, bool, u32)>,
+) -> Vec<(&'static str, u32)> {
+    let mut list: Vec<(&'static str, u32)> = Vec::new();
+    let mut has_yakuman = false;
+
+    // まず役満があるか確認
+    for (_, (_, is_valid, han)) in yaku_result {
+        if *is_valid && *han >= 13 {
+            has_yakuman = true;
+            break;
+        }
+    }
+
+    for (_, (name, is_valid, han)) in yaku_result {
+        if *is_valid && *han > 0 {
+            // 役満がある場合は通常役を除外
+            if has_yakuman && *han < 13 {
+                continue;
+            }
+            list.push((name, *han));
+        }
+    }
+
+    // 翻数の降順でソートし、同じ翻数の場合は名前でソート
+    list.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    list
+}
+
+/// 等級を決定する
+fn determine_rank(han: u32, fu: u32, has_yakuman: bool) -> ScoreRank {
+    if has_yakuman || han >= 13 {
+        ScoreRank::Yakuman
+    } else if han >= 11 {
+        ScoreRank::Sanbaiman
+    } else if han >= 8 {
+        ScoreRank::Baiman
+    } else if han >= 6 {
+        ScoreRank::Haneman
+    } else if han >= 5 {
+        ScoreRank::Mangan
+    } else if han == 4 && fu >= 30 {
+        ScoreRank::Mangan
+    } else if han == 3 && fu >= 60 {
+        ScoreRank::Mangan
+    } else {
+        ScoreRank::Normal
+    }
+}
+
+/// 基本点を計算する
+fn calculate_base_points(han: u32, fu: u32, rank: ScoreRank) -> u32 {
+    match rank {
+        ScoreRank::Yakuman => 8000,
+        ScoreRank::Sanbaiman => 6000,
+        ScoreRank::Baiman => 4000,
+        ScoreRank::Haneman => 3000,
+        ScoreRank::Mangan => 2000,
+        ScoreRank::Normal => {
+            // 基本点 = 符 × 2^(翻+2)
+            let base = fu * (1 << (han + 2));
+            // 満貫を超えないようにする
+            if base > 2000 { 2000 } else { base }
+        }
+    }
+}
+
+/// 100点単位に切り上げる
+fn round_up_to_100(points: u32) -> u32 {
+    (points + 99) / 100 * 100
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hand::Hand;
+    use crate::hand_info::hand_analyzer::HandAnalyzer;
+    use crate::hand_info::status::Status;
+    use crate::settings::Settings;
+    use crate::tile::Wind;
+
+    /// 満貫の子ロン: 8000点
+    #[test]
+    fn test_mangan_non_dealer_ron() {
+        let rank = ScoreRank::Mangan;
+        let base = calculate_base_points(5, 30, rank);
+        assert_eq!(base, 2000);
+        assert_eq!(round_up_to_100(base * 4), 8000);
+    }
+
+    /// 満貫の親ロン: 12000点
+    #[test]
+    fn test_mangan_dealer_ron() {
+        let rank = ScoreRank::Mangan;
+        let base = calculate_base_points(5, 30, rank);
+        assert_eq!(base, 2000);
+        assert_eq!(round_up_to_100(base * 6), 12000);
+    }
+
+    /// 跳満の子ロン: 12000点
+    #[test]
+    fn test_haneman_non_dealer_ron() {
+        let rank = ScoreRank::Haneman;
+        let base = calculate_base_points(6, 30, rank);
+        assert_eq!(base, 3000);
+        assert_eq!(round_up_to_100(base * 4), 12000);
+    }
+
+    /// 倍満の子ロン: 16000点
+    #[test]
+    fn test_baiman_non_dealer_ron() {
+        let rank = ScoreRank::Baiman;
+        let base = calculate_base_points(8, 30, rank);
+        assert_eq!(base, 4000);
+        assert_eq!(round_up_to_100(base * 4), 16000);
+    }
+
+    /// 三倍満の子ロン: 24000点
+    #[test]
+    fn test_sanbaiman_non_dealer_ron() {
+        let rank = ScoreRank::Sanbaiman;
+        let base = calculate_base_points(11, 30, rank);
+        assert_eq!(base, 6000);
+        assert_eq!(round_up_to_100(base * 4), 24000);
+    }
+
+    /// 役満の子ロン: 32000点
+    #[test]
+    fn test_yakuman_non_dealer_ron() {
+        let rank = ScoreRank::Yakuman;
+        let base = calculate_base_points(13, 30, rank);
+        assert_eq!(base, 8000);
+        assert_eq!(round_up_to_100(base * 4), 32000);
+    }
+
+    /// 1翻30符の子ロン: 1000点
+    #[test]
+    fn test_1han_30fu_non_dealer_ron() {
+        let rank = determine_rank(1, 30, false);
+        assert_eq!(rank, ScoreRank::Normal);
+        let base = calculate_base_points(1, 30, rank);
+        // 30 * 2^3 = 240
+        assert_eq!(base, 240);
+        // 240 * 4 = 960 -> 切り上げ 1000
+        assert_eq!(round_up_to_100(base * 4), 1000);
+    }
+
+    /// 1翻40符の子ロン: 1300点
+    #[test]
+    fn test_1han_40fu_non_dealer_ron() {
+        let rank = determine_rank(1, 40, false);
+        assert_eq!(rank, ScoreRank::Normal);
+        let base = calculate_base_points(1, 40, rank);
+        // 40 * 2^3 = 320
+        assert_eq!(base, 320);
+        // 320 * 4 = 1280 -> 切り上げ 1300
+        assert_eq!(round_up_to_100(base * 4), 1300);
+    }
+
+    /// 2翻30符の子ロン: 2000点
+    #[test]
+    fn test_2han_30fu_non_dealer_ron() {
+        let rank = determine_rank(2, 30, false);
+        assert_eq!(rank, ScoreRank::Normal);
+        let base = calculate_base_points(2, 30, rank);
+        // 30 * 2^4 = 480
+        assert_eq!(base, 480);
+        // 480 * 4 = 1920 -> 切り上げ 2000
+        assert_eq!(round_up_to_100(base * 4), 2000);
+    }
+
+    /// 3翻30符の子ロン: 4000点
+    #[test]
+    fn test_3han_30fu_non_dealer_ron() {
+        let rank = determine_rank(3, 30, false);
+        assert_eq!(rank, ScoreRank::Normal);
+        let base = calculate_base_points(3, 30, rank);
+        // 30 * 2^5 = 960
+        assert_eq!(base, 960);
+        // 960 * 4 = 3840 -> 切り上げ 3900
+        assert_eq!(round_up_to_100(base * 4), 3900);
+    }
+
+    /// 3翻60符の子ロンは満貫: 8000点
+    #[test]
+    fn test_3han_60fu_is_mangan() {
+        let rank = determine_rank(3, 60, false);
+        assert_eq!(rank, ScoreRank::Mangan);
+    }
+
+    /// 4翻30符の子ロンは満貫: 8000点
+    #[test]
+    fn test_4han_30fu_is_mangan() {
+        let rank = determine_rank(4, 30, false);
+        assert_eq!(rank, ScoreRank::Mangan);
+    }
+
+    /// 4翻25符は通常計算（七対子）: 子ロン6400点
+    #[test]
+    fn test_4han_25fu_is_normal() {
+        let rank = determine_rank(4, 25, false);
+        assert_eq!(rank, ScoreRank::Normal);
+        let base = calculate_base_points(4, 25, rank);
+        // 25 * 2^6 = 1600
+        assert_eq!(base, 1600);
+        // 1600 * 4 = 6400
+        assert_eq!(round_up_to_100(base * 4), 6400);
+    }
+
+    /// 100点単位の切り上げ
+    #[test]
+    fn test_round_up_to_100() {
+        assert_eq!(round_up_to_100(100), 100);
+        assert_eq!(round_up_to_100(101), 200);
+        assert_eq!(round_up_to_100(960), 1000);
+        assert_eq!(round_up_to_100(1920), 2000);
+        assert_eq!(round_up_to_100(3840), 3900);
+    }
+
+    /// 等級の判定
+    #[test]
+    fn test_determine_rank() {
+        assert_eq!(determine_rank(1, 30, false), ScoreRank::Normal);
+        assert_eq!(determine_rank(2, 30, false), ScoreRank::Normal);
+        assert_eq!(determine_rank(3, 30, false), ScoreRank::Normal);
+        assert_eq!(determine_rank(3, 60, false), ScoreRank::Mangan);
+        assert_eq!(determine_rank(4, 25, false), ScoreRank::Normal);
+        assert_eq!(determine_rank(4, 30, false), ScoreRank::Mangan);
+        assert_eq!(determine_rank(5, 30, false), ScoreRank::Mangan);
+        assert_eq!(determine_rank(6, 30, false), ScoreRank::Haneman);
+        assert_eq!(determine_rank(7, 30, false), ScoreRank::Haneman);
+        assert_eq!(determine_rank(8, 30, false), ScoreRank::Baiman);
+        assert_eq!(determine_rank(10, 30, false), ScoreRank::Baiman);
+        assert_eq!(determine_rank(11, 30, false), ScoreRank::Sanbaiman);
+        assert_eq!(determine_rank(12, 30, false), ScoreRank::Sanbaiman);
+        assert_eq!(determine_rank(13, 30, false), ScoreRank::Yakuman);
+        assert_eq!(determine_rank(13, 30, true), ScoreRank::Yakuman);
+    }
+
+    /// 満貫の子ツモ: 親4000 + 子2000×2 = 8000
+    #[test]
+    fn test_mangan_non_dealer_tsumo() {
+        let base = calculate_base_points(5, 30, ScoreRank::Mangan);
+        let dealer_pay = round_up_to_100(base * 2);  // 4000
+        let non_dealer_pay = round_up_to_100(base);   // 2000
+        assert_eq!(dealer_pay, 4000);
+        assert_eq!(non_dealer_pay, 2000);
+    }
+
+    /// 満貫の親ツモ: 子4000×3 = 12000
+    #[test]
+    fn test_mangan_dealer_tsumo() {
+        let base = calculate_base_points(5, 30, ScoreRank::Mangan);
+        let each_pay = round_up_to_100(base * 2);  // 4000
+        assert_eq!(each_pay, 4000);
+    }
+
+    /// 立直のみ（門前ロン）: 1翻30符 -> 子ロン1000点
+    #[test]
+    fn test_calculate_score_riichi_only() {
+        let hand = Hand::from("123456m234p6799s 5s");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.has_claimed_ready = true;
+        status.is_self_picked = false;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let settings = Settings::new();
+        let result = calculate_score(&analyzer, &hand, &status, &settings)
+            .unwrap()
+            .unwrap();
+        // 平和 + 立直 = 2翻, 30符
+        assert_eq!(result.han, 2);
+        assert_eq!(result.fu, 30);
+        assert_eq!(result.non_dealer_ron, 2000);
+    }
+
+    /// ツモで和了（門前清自摸和 + 平和）: 2翻20符 -> 子ツモ: 親700 + 子400×2
+    #[test]
+    fn test_calculate_score_tsumo_pinfu() {
+        let hand = Hand::from("123456m234p6799s 5s");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.is_self_picked = true;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let settings = Settings::new();
+        let result = calculate_score(&analyzer, &hand, &status, &settings)
+            .unwrap()
+            .unwrap();
+        // 門前清自摸和 + 平和 = 2翻, 20符
+        assert_eq!(result.han, 2);
+        assert_eq!(result.fu, 20);
+        // 基本点 = 20 * 2^4 = 320
+        // 子ツモ: 親700(640->700) + 子400(320->400)×2
+        assert_eq!(result.non_dealer_tsumo_dealer, 700);
+        assert_eq!(result.non_dealer_tsumo_non_dealer, 400);
+    }
+
+    /// 役がない手は None を返す
+    #[test]
+    fn test_calculate_score_no_yaku() {
+        let hand = Hand::from("123456m234p789s3z 3z");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.is_self_picked = false;
+        status.has_claimed_open = true;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let settings = Settings::new();
+        let result = calculate_score(&analyzer, &hand, &status, &settings).unwrap();
+        assert!(result.is_none());
+    }
+
+    /// 役満（国士無双）: 子ロン32000点
+    #[test]
+    fn test_calculate_score_yakuman() {
+        let hand = Hand::from("19m19p19s1234567z 1m");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.is_self_picked = false;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let settings = Settings::new();
+        let result = calculate_score(&analyzer, &hand, &status, &settings)
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.rank, ScoreRank::Yakuman);
+        assert_eq!(result.non_dealer_ron, 32000);
+        assert_eq!(result.dealer_ron, 48000);
+    }
+
+    /// 2翻40符の親ロン: 2600点
+    #[test]
+    fn test_2han_40fu_dealer_ron() {
+        let rank = determine_rank(2, 40, false);
+        let base = calculate_base_points(2, 40, rank);
+        // 40 * 2^4 = 640
+        assert_eq!(base, 640);
+        // 640 * 6 = 3840 -> 切り上げ 3900
+        assert_eq!(round_up_to_100(base * 6), 3900);
+    }
+
+    /// 1翻30符の親ツモ: 各子500点
+    #[test]
+    fn test_1han_30fu_dealer_tsumo() {
+        let base = calculate_base_points(1, 30, ScoreRank::Normal);
+        // 30 * 2^3 = 240
+        assert_eq!(base, 240);
+        // 240 * 2 = 480 -> 切り上げ 500
+        assert_eq!(round_up_to_100(base * 2), 500);
+    }
+
+    /// 1翻30符の子ツモ: 親500点, 子300点
+    #[test]
+    fn test_1han_30fu_non_dealer_tsumo() {
+        let base = calculate_base_points(1, 30, ScoreRank::Normal);
+        // 親: 240 * 2 = 480 -> 500
+        assert_eq!(round_up_to_100(base * 2), 500);
+        // 子: 240 * 1 = 240 -> 300
+        assert_eq!(round_up_to_100(base), 300);
+    }
+}


### PR DESCRIPTION
符計算(fu.rs)と点数計算(score.rs)を独立したモジュールとして実装。
副底・面子符・雀頭符・待ち符・ツモ符・門前加符の各要素を個別に計算し、
翻数と符から満貫〜役満までの点数等級判定と親子別の支払い額を算出する。