### PR TITLE
feat: Implement Kan actions including Ankan and Daiminkan

### DIFF
--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -49,6 +49,8 @@ pub struct GameState {
     pub can_tsumo: bool,
     /// リーチ宣言可能か
     pub can_riichi: bool,
+    /// 自分の手番で暗カン可能な牌
+    pub self_kan_options: Vec<Tile>,
     /// 自分がリーチ中か
     pub is_riichi: bool,
     /// リーチ宣言のための打牌選択中か
@@ -105,6 +107,7 @@ impl GameState {
             selected_drawn: false,
             can_tsumo: false,
             can_riichi: false,
+            self_kan_options: Vec::new(),
             is_riichi: false,
             riichi_selection_mode: false,
             riichi_selectable_tiles: Vec::new(),
@@ -145,9 +148,11 @@ impl GameState {
                 self.phase = GamePhase::Playing;
                 self.available_calls.clear();
                 self.call_target_tile = None;
+                self.refresh_self_kan_options();
                 self.call_discarder = None;
                 self.can_tsumo = false;
                 self.can_riichi = false;
+                self.self_kan_options.clear();
                 self.is_riichi = false;
                 self.clear_riichi_selection();
                 self.melds.clear();
@@ -169,6 +174,7 @@ impl GameState {
                 self.clear_riichi_selection();
                 self.available_calls.clear();
                 self.call_target_tile = None;
+                self.refresh_self_kan_options();
             }
 
             ServerEvent::OtherPlayerDrew {
@@ -196,6 +202,7 @@ impl GameState {
                     self.selected_tile = None;
                     self.selected_drawn = false;
                     self.clear_riichi_selection();
+                    self.self_kan_options.clear();
                 }
             }
 
@@ -218,6 +225,7 @@ impl GameState {
                 // 鳴き選択肢をクリア
                 self.available_calls.clear();
                 self.call_target_tile = None;
+                self.refresh_self_kan_options();
                 self.call_discarder = None;
 
                 // 自分が鳴いた場合、副露情報を保存し打牌待ちへ
@@ -226,20 +234,40 @@ impl GameState {
                         CallType::Ron => {
                             // ロンの場合は局終了イベントが続く
                         }
-                        CallType::Pon | CallType::Chi | CallType::Daiminkan => {
-                            // 副露情報を保存
+                        CallType::Pon | CallType::Chi | CallType::Daiminkan | CallType::Ankan => {
                             self.melds.push(MeldInfo {
                                 call_type: call_type.clone(),
                                 tiles: tiles.clone(),
                             });
-                            // ポン/チー/カンの場合、自分の手牌を更新
-                            // （サーバ側で処理済みなので、次のイベントで反映）
                             self.is_my_turn = true;
-                            self.drawn = None; // 鳴き後はdrawnなし
+                            self.drawn = None;
                             self.clear_riichi_selection();
+                            self.self_kan_options.clear();
+                        }
+                        CallType::Kakan => {
+                            if let Some(meld) = self.melds.iter_mut().find(|meld| {
+                                meld.call_type == CallType::Pon
+                                    && meld.tiles.first().map(|tile| tile.get()) == tiles.first().map(|tile| tile.get())
+                            }) {
+                                meld.call_type = CallType::Kakan;
+                                meld.tiles = tiles.clone();
+                            } else {
+                                self.melds.push(MeldInfo {
+                                    call_type: call_type.clone(),
+                                    tiles: tiles.clone(),
+                                });
+                            }
+                            self.is_my_turn = true;
+                            self.drawn = None;
+                            self.clear_riichi_selection();
+                            self.self_kan_options.clear();
                         }
                     }
                 }
+            }
+
+            ServerEvent::DoraIndicatorsUpdated { dora_indicators } => {
+                self.dora_indicators = dora_indicators;
             }
 
             ServerEvent::PlayerRiichi { player } => {
@@ -254,6 +282,7 @@ impl GameState {
             ServerEvent::HandUpdated { hand } => {
                 self.hand = hand;
                 self.hand.sort();
+                self.refresh_self_kan_options();
             }
 
             ServerEvent::RoundWon {
@@ -319,6 +348,7 @@ impl GameState {
                 self.is_my_turn = false;
                 self.available_calls.clear();
                 self.clear_riichi_selection();
+                self.self_kan_options.clear();
             }
 
             ServerEvent::RoundDraw { scores, reason, tenpai } => {
@@ -344,6 +374,7 @@ impl GameState {
                 self.is_my_turn = false;
                 self.available_calls.clear();
                 self.clear_riichi_selection();
+                self.self_kan_options.clear();
             }
         }
     }
@@ -398,6 +429,36 @@ impl GameState {
             .filter_map(|(idx, &tile)| self.can_discard_for_riichi(Some(tile)).then_some(idx))
             .collect();
         self.riichi_selectable_drawn = self.can_discard_for_riichi(None);
+    }
+
+    fn refresh_self_kan_options(&mut self) {
+        self.self_kan_options.clear();
+        if self.drawn.is_none() || self.is_riichi {
+            return;
+        }
+
+        let mut counts = [0u8; Tile::LEN as usize];
+        for tile in &self.hand {
+            counts[tile.get() as usize] += 1;
+        }
+        if let Some(drawn) = self.drawn {
+            counts[drawn.get() as usize] += 1;
+        }
+
+        for (idx, count) in counts.iter().enumerate() {
+            if *count == 4 {
+                self.self_kan_options.push(Tile::new(idx as u32));
+                continue;
+            }
+
+            let has_pon = self.melds.iter().any(|meld| {
+                meld.call_type == CallType::Pon
+                    && meld.tiles.first().map(|tile| tile.get()) == Some(idx as u32)
+            });
+            if has_pon && *count >= 1 {
+                self.self_kan_options.push(Tile::new(idx as u32));
+            }
+        }
     }
 
     fn apply_local_discard_from_hand(&mut self, idx: usize) -> Tile {
@@ -466,6 +527,18 @@ impl GameState {
                         self.enter_riichi_selection();
                     }
                     return None;
+                }
+            }
+
+            for (idx, tile) in self.self_kan_options.iter().enumerate() {
+                let x = 720.0 + idx as f32 * 110.0;
+                let y = 670.0;
+                let btn_w = 100.0;
+                let btn_h = 40.0;
+                if mx >= x && mx <= x + btn_w && my >= y && my <= y + btn_h {
+                    return Some(ClientAction::Kan {
+                        tile_index: tile.get() as usize,
+                    });
                 }
             }
 
@@ -564,6 +637,13 @@ impl GameState {
                     AvailableCall::Pon => {
                         self.available_calls.clear();
                         return Some(ClientAction::Pon);
+                    }
+                    AvailableCall::Daiminkan => {
+                        let tile = self.call_target_tile?;
+                        self.available_calls.clear();
+                        return Some(ClientAction::Kan {
+                            tile_index: tile.get() as usize,
+                        });
                     }
                     AvailableCall::Chi { options } => {
                         // 最初の選択肢を使う（複数ある場合はMVPでは最初を選択）

--- a/crates/mahjong-client/src/renderer.rs
+++ b/crates/mahjong-client/src/renderer.rs
@@ -84,7 +84,11 @@ fn draw_info_panel(state: &GameState, font: Option<&Font>) {
     } else {
         String::new()
     };
-    let riichi_marker = if state.is_riichi { " 【リーチ】" } else { "" };
+    let riichi_marker = if state.is_riichi {
+        " 【リーチ】"
+    } else {
+        ""
+    };
 
     draw_jp_text(
         font,
@@ -180,11 +184,20 @@ fn draw_hand(state: &GameState, font: Option<&Font>) {
     for (i, tile) in state.hand.iter().enumerate() {
         let x = hand_start_x + i as f32 * TILE_W;
         let selected = state.selected_tile == Some(i);
-        let riichi_selectable = state.riichi_selection_mode && state.riichi_selectable_tiles.contains(&i);
+        let riichi_selectable =
+            state.riichi_selection_mode && state.riichi_selectable_tiles.contains(&i);
         let y_offset = if selected { -10.0 } else { 0.0 };
 
         let riichi_disabled = state.riichi_selection_mode && !riichi_selectable;
-        draw_tile(x, hand_y + y_offset, tile, selected, riichi_selectable, riichi_disabled, font);
+        draw_tile(
+            x,
+            hand_y + y_offset,
+            tile,
+            selected,
+            riichi_selectable,
+            riichi_disabled,
+            font,
+        );
     }
 
     // ツモ牌（少し間隔を開けて表示）
@@ -194,7 +207,15 @@ fn draw_hand(state: &GameState, font: Option<&Font>) {
         let riichi_selectable = state.riichi_selection_mode && state.riichi_selectable_drawn;
         let y_offset = if selected { -10.0 } else { 0.0 };
         let riichi_disabled = state.riichi_selection_mode && !riichi_selectable;
-        draw_tile(drawn_x, hand_y + y_offset, drawn, selected, riichi_selectable, riichi_disabled, font);
+        draw_tile(
+            drawn_x,
+            hand_y + y_offset,
+            drawn,
+            selected,
+            riichi_selectable,
+            riichi_disabled,
+            font,
+        );
 
         // ツモ牌ラベル
         draw_jp_text(
@@ -237,7 +258,14 @@ fn draw_melds(state: &GameState, font: Option<&Font>) {
 }
 
 /// 副露の牌1枚を描画する（少し小さめ）
-fn draw_meld_tile(x: f32, y: f32, tile: &mahjong_core::tile::Tile, w: f32, h: f32, font: Option<&Font>) {
+fn draw_meld_tile(
+    x: f32,
+    y: f32,
+    tile: &mahjong_core::tile::Tile,
+    w: f32,
+    h: f32,
+    font: Option<&Font>,
+) {
     let bg = Color::new(0.9, 0.95, 1.0, 1.0); // 薄い青系で副露を区別
     draw_rectangle(x, y, w - 2.0, h - 2.0, bg);
     draw_rectangle_lines(x, y, w - 2.0, h - 2.0, 2.0, TILE_BORDER);
@@ -261,7 +289,15 @@ fn draw_meld_tile(x: f32, y: f32, tile: &mahjong_core::tile::Tile, w: f32, h: f3
 }
 
 /// 牌1枚を描画する
-fn draw_tile(x: f32, y: f32, tile: &mahjong_core::tile::Tile, selected: bool, riichi_selectable: bool, riichi_disabled: bool, font: Option<&Font>) {
+fn draw_tile(
+    x: f32,
+    y: f32,
+    tile: &mahjong_core::tile::Tile,
+    selected: bool,
+    riichi_selectable: bool,
+    riichi_disabled: bool,
+    font: Option<&Font>,
+) {
     // 背景
     let bg = if selected {
         SELECTED_BG
@@ -354,6 +390,21 @@ fn draw_action_buttons(state: &GameState, font: Option<&Font>) {
             draw_jp_text(font, "リーチ", 1008.0, 747.0, SMALL_FONT, WHITE);
         }
 
+        for (idx, tile) in state.self_kan_options.iter().enumerate() {
+            let x = 720.0 + idx as f32 * 110.0;
+            let kan_bg = Color::new(0.1, 0.3, 0.8, 1.0);
+            draw_rectangle(x, 670.0, 100.0, 40.0, kan_bg);
+            draw_rectangle_lines(x, 670.0, 100.0, 40.0, 2.0, WHITE);
+            draw_jp_text(
+                font,
+                &format!("{}カン", tile.to_string()),
+                x + 10.0,
+                697.0,
+                SMALL_FONT,
+                WHITE,
+            );
+        }
+
         // 操作説明
         if state.riichi_selection_mode {
             draw_jp_text(
@@ -399,8 +450,8 @@ fn draw_call_buttons(state: &GameState, font: Option<&Font>) {
     let btn_spacing = 10.0;
 
     let call_btn_bg = Color::new(0.8, 0.2, 0.2, 1.0); // 赤系
-    let ron_btn_bg = Color::new(0.9, 0.1, 0.1, 1.0);   // 濃い赤
-    let pass_btn_bg = Color::new(0.4, 0.4, 0.4, 1.0);  // グレー
+    let ron_btn_bg = Color::new(0.9, 0.1, 0.1, 1.0); // 濃い赤
+    let pass_btn_bg = Color::new(0.4, 0.4, 0.4, 1.0); // グレー
 
     let mut btn_idx = 0;
 
@@ -416,6 +467,11 @@ fn draw_call_buttons(state: &GameState, font: Option<&Font>) {
                 draw_rectangle(x, base_y, btn_w, btn_h, call_btn_bg);
                 draw_rectangle_lines(x, base_y, btn_w, btn_h, 2.0, WHITE);
                 draw_jp_text(font, "ポン", x + 28.0, base_y + 27.0, FONT_SIZE, WHITE);
+            }
+            AvailableCall::Daiminkan => {
+                draw_rectangle(x, base_y, btn_w, btn_h, call_btn_bg);
+                draw_rectangle_lines(x, base_y, btn_w, btn_h, 2.0, WHITE);
+                draw_jp_text(font, "カン", x + 18.0, base_y + 27.0, SMALL_FONT, WHITE);
             }
             AvailableCall::Chi { .. } => {
                 draw_rectangle(x, base_y, btn_w, btn_h, call_btn_bg);
@@ -436,13 +492,7 @@ fn draw_call_buttons(state: &GameState, font: Option<&Font>) {
 /// 局の結果を表示する
 fn draw_result(state: &GameState, font: Option<&Font>) {
     // 半透明背景（大きめ）
-    draw_rectangle(
-        150.0,
-        150.0,
-        980.0,
-        420.0,
-        Color::new(0.0, 0.0, 0.0, 0.85),
-    );
+    draw_rectangle(150.0, 150.0, 980.0, 420.0, Color::new(0.0, 0.0, 0.0, 0.85));
 
     if let Some(msg) = &state.result_message {
         let lines: Vec<&str> = msg.lines().collect();
@@ -453,14 +503,7 @@ fn draw_result(state: &GameState, font: Option<&Font>) {
             } else {
                 (22, Color::new(0.9, 0.9, 0.7, 1.0))
             };
-            draw_jp_text(
-                font,
-                line,
-                220.0,
-                240.0 + i as f32 * 35.0,
-                font_size,
-                color,
-            );
+            draw_jp_text(font, line, 220.0, 240.0 + i as f32 * 35.0, font_size, color);
         }
     }
 
@@ -476,18 +519,12 @@ fn draw_result(state: &GameState, font: Option<&Font>) {
 
 /// ゲーム終了画面
 fn draw_game_over(state: &GameState, font: Option<&Font>) {
-    draw_rectangle(
-        200.0,
-        150.0,
-        880.0,
-        500.0,
-        Color::new(0.0, 0.0, 0.0, 0.9),
-    );
+    draw_rectangle(200.0, 150.0, 880.0, 500.0, Color::new(0.0, 0.0, 0.0, 0.9));
 
     draw_jp_text(font, "ゲーム終了", 520.0, 250.0, 36, WHITE);
 
     // 最終順位を表示
-    let wind_names = ["東家", "南家", "西家", "北家"];
+    let wind_names = ["プレイヤー", "CPU1", "CPU2", "CPU3"];
     let mut rankings: Vec<(usize, i32)> = state
         .scores
         .iter()
@@ -504,12 +541,7 @@ fn draw_game_over(state: &GameState, font: Option<&Font>) {
         };
         draw_jp_text(
             font,
-            &format!(
-                "{}位: {} {}点",
-                rank + 1,
-                wind_names[*player_idx],
-                score
-            ),
+            &format!("{}位: {} {}点", rank + 1, wind_names[*player_idx], score),
             440.0,
             330.0 + rank as f32 * 40.0,
             24,
@@ -536,12 +568,3 @@ fn wind_to_str(wind: mahjong_core::tile::Wind) -> &'static str {
         mahjong_core::tile::Wind::North => "北",
     }
 }
-
-
-
-
-
-
-
-
-

--- a/crates/mahjong-core/src/hand.rs
+++ b/crates/mahjong-core/src/hand.rs
@@ -64,6 +64,11 @@ impl Hand {
         &self.opened
     }
 
+    /// 副露の可変参照を返す
+    pub fn opened_mut(&mut self) -> &mut Vec<OpenTiles> {
+        &mut self.opened
+    }
+
     /// 手牌をソートする
     pub fn sort(&mut self) {
         self.tiles.sort();
@@ -81,6 +86,9 @@ impl Hand {
         for i in 0..self.opened.len() {
             for j in 0..self.opened[i].tiles.len() {
                 result[self.opened[i].tiles[j].get() as usize] += 1;
+            }
+            if self.opened[i].category == OpenType::Kan {
+                result[self.opened[i].tiles[0].get() as usize] += 1;
             }
         }
 

--- a/crates/mahjong-server/src/player.rs
+++ b/crates/mahjong-server/src/player.rs
@@ -212,6 +212,50 @@ impl Player {
         options
     }
 
+    /// 大明カン可能か判定する
+    pub fn can_daiminkan(&self, tile: Tile) -> bool {
+        let count = self.hand.tiles().iter().filter(|t| t.get() == tile.get()).count();
+        count >= 3
+    }
+
+    /// 暗カン可能な牌種一覧を返す
+    pub fn ankan_options(&self) -> Vec<TileType> {
+        let mut counts = [0u8; Tile::LEN as usize];
+        for tile in self.hand.tiles() {
+            counts[tile.get() as usize] += 1;
+        }
+        if let Some(drawn) = self.hand.drawn() {
+            counts[drawn.get() as usize] += 1;
+        }
+
+        counts
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, &count)| (count == 4).then_some(idx as TileType))
+            .collect()
+    }
+
+    /// 加カン可能な牌種一覧を返す
+    pub fn kakan_options(&self) -> Vec<TileType> {
+        let mut counts = [0u8; Tile::LEN as usize];
+        for tile in self.hand.tiles() {
+            counts[tile.get() as usize] += 1;
+        }
+        if let Some(drawn) = self.hand.drawn() {
+            counts[drawn.get() as usize] += 1;
+        }
+
+        self.hand
+            .opened()
+            .iter()
+            .filter(|open| open.category == OpenType::Pon)
+            .filter_map(|open| {
+                let tile_type = open.tiles[0].get();
+                (counts[tile_type as usize] >= 1).then_some(tile_type)
+            })
+            .collect()
+    }
+
     /// フリテン状態か判定する
     ///
     /// 自分の待ち牌のいずれかが自分の捨て牌に含まれている場合、フリテン。
@@ -288,6 +332,105 @@ impl Player {
 
         self.is_first_turn = false;
         self.is_ippatsu = false;
+    }
+
+    /// 大明カンを実行する
+    pub fn do_daiminkan(&mut self, called_tile: Tile, from: OpenFrom) {
+        let tt = called_tile.get();
+        let mut indices: Vec<usize> = Vec::new();
+        for (i, t) in self.hand.tiles().iter().enumerate() {
+            if t.get() == tt && indices.len() < 3 {
+                indices.push(i);
+            }
+        }
+        assert_eq!(indices.len(), 3, "大明カンに必要な3枚がありません");
+
+        let t1 = self.hand.tiles()[indices[0]];
+        let t2 = self.hand.tiles()[indices[1]];
+        let t3 = self.hand.tiles()[indices[2]];
+
+        self.hand.remove_tiles_by_indices(&mut indices);
+        self.hand.add_opened(OpenTiles {
+            tiles: [t1, t2, t3],
+            category: OpenType::Kan,
+            from,
+        });
+
+        self.is_first_turn = false;
+        self.is_ippatsu = false;
+    }
+
+    /// 暗カンを実行する
+    pub fn do_ankan(&mut self, tile_type: TileType) {
+        let mut indices: Vec<usize> = Vec::new();
+        for (i, t) in self.hand.tiles().iter().enumerate() {
+            if t.get() == tile_type {
+                indices.push(i);
+            }
+        }
+
+        let drawn = self.hand.drawn();
+        let drawn_matches = drawn.map(|t| t.get() == tile_type).unwrap_or(false);
+        assert_eq!(
+            indices.len() + usize::from(drawn_matches),
+            4,
+            "暗カンに必要な4枚が揃っていません"
+        );
+
+        let mut kan_tiles: Vec<Tile> = indices
+            .iter()
+            .map(|&idx| self.hand.tiles()[idx])
+            .collect();
+        if drawn_matches {
+            kan_tiles.push(drawn.unwrap());
+            self.hand.set_drawn(None);
+        }
+
+        self.hand.remove_tiles_by_indices(&mut indices);
+        self.hand.add_opened(OpenTiles {
+            tiles: [kan_tiles[0], kan_tiles[1], kan_tiles[2]],
+            category: OpenType::Kan,
+            from: OpenFrom::Myself,
+        });
+
+        self.is_first_turn = false;
+        self.is_ippatsu = false;
+    }
+
+    /// 加カンを実行する
+    pub fn do_kakan(&mut self, tile_type: TileType) {
+        let drawn_matches = self.hand.drawn().map(|t| t.get() == tile_type).unwrap_or(false);
+        if drawn_matches {
+            self.hand.set_drawn(None);
+        } else {
+            let idx = self
+                .hand
+                .tiles()
+                .iter()
+                .position(|t| t.get() == tile_type)
+                .expect("加カンに必要な牌が手牌にありません");
+            self.hand.tiles_mut().remove(idx);
+        }
+
+        let open = self
+            .hand
+            .opened_mut()
+            .iter_mut()
+            .find(|open| open.category == OpenType::Pon && open.tiles[0].get() == tile_type)
+            .expect("加カン対象のポンがありません");
+        open.category = OpenType::Kan;
+
+        self.is_first_turn = false;
+        self.is_ippatsu = false;
+    }
+
+    /// 手牌に含まれる槓子の数を返す
+    pub fn kan_count(&self) -> usize {
+        self.hand
+            .opened()
+            .iter()
+            .filter(|open| open.category == OpenType::Kan)
+            .count()
     }
 
     /// 捨てたプレイヤーと自分の相対位置から OpenFrom を返す
@@ -513,6 +656,79 @@ mod tests {
         assert_eq!(player.hand.opened().len(), 1);
         assert_eq!(player.hand.opened()[0].category, OpenType::Chi);
         // 門前でなくなる
+        assert!(!player.is_menzen());
+    }
+
+    #[test]
+    fn test_can_daiminkan() {
+        let tiles = vec![
+            Tile::new(Tile::M1),
+            Tile::new(Tile::M1),
+            Tile::new(Tile::M1),
+            Tile::new(Tile::M3),
+            Tile::new(Tile::P4),
+            Tile::new(Tile::P5),
+            Tile::new(Tile::P6),
+            Tile::new(Tile::S7),
+            Tile::new(Tile::S8),
+            Tile::new(Tile::S9),
+            Tile::new(Tile::Z1),
+            Tile::new(Tile::Z2),
+            Tile::new(Tile::Z3),
+        ];
+        let player = Player::new(Wind::East, tiles, 25000);
+        assert!(player.can_daiminkan(Tile::new(Tile::M1)));
+        assert!(!player.can_daiminkan(Tile::new(Tile::M3)));
+    }
+
+    #[test]
+    fn test_ankan_options() {
+        let hand = Hand::from("111m234p567s789m1z 1m");
+        let mut player = Player::new(Wind::East, hand.tiles().to_vec(), 25000);
+        player.draw(hand.drawn().unwrap());
+
+        assert_eq!(player.ankan_options(), vec![Tile::M1]);
+    }
+
+    #[test]
+    fn test_do_daiminkan() {
+        let hand = Hand::from("111m234p567s789m1z");
+        let mut player = Player::new(Wind::South, hand.tiles().to_vec(), 25000);
+
+        player.do_daiminkan(Tile::new(Tile::M1), OpenFrom::Previous);
+
+        assert_eq!(player.hand.tiles().len(), 10);
+        assert_eq!(player.hand.opened().len(), 1);
+        assert_eq!(player.hand.opened()[0].category, OpenType::Kan);
+        assert!(!player.is_menzen());
+    }
+
+    #[test]
+    fn test_do_ankan() {
+        let hand = Hand::from("111m234p567s789m1z 1m");
+        let mut player = Player::new(Wind::South, hand.tiles().to_vec(), 25000);
+        player.draw(hand.drawn().unwrap());
+
+        player.do_ankan(Tile::M1);
+
+        assert_eq!(player.hand.tiles().len(), 10);
+        assert!(player.hand.drawn().is_none());
+        assert_eq!(player.hand.opened().len(), 1);
+        assert_eq!(player.hand.opened()[0].category, OpenType::Kan);
+        assert!(player.is_menzen());
+    }
+
+    #[test]
+    fn test_do_kakan() {
+        let mut player = Player::new(Wind::South, vec![], 25000);
+        player.hand = Hand::from("234p567s789m1z 111m 1m");
+
+        player.do_kakan(Tile::M1);
+
+        assert_eq!(player.hand.tiles().len(), 10);
+        assert!(player.hand.drawn().is_none());
+        assert_eq!(player.hand.opened().len(), 1);
+        assert_eq!(player.hand.opened()[0].category, OpenType::Kan);
         assert!(!player.is_menzen());
     }
 

--- a/crates/mahjong-server/src/protocol.rs
+++ b/crates/mahjong-server/src/protocol.rs
@@ -28,8 +28,12 @@ pub enum CallType {
     Pon,
     /// チー
     Chi,
+    /// 暗カン
+    Ankan,
     /// 大明カン
     Daiminkan,
+    /// 加カン
+    Kakan,
 }
 
 /// 利用可能な鳴きアクション（CallAvailableイベント内で使用）
@@ -39,6 +43,8 @@ pub enum AvailableCall {
     Ron,
     /// ポン可能
     Pon,
+    /// 大明カン可能
+    Daiminkan,
     /// チー可能（使える手牌の組み合わせのリスト: 各要素は [TileType; 2]）
     Chi { options: Vec<[TileType; 2]> },
 }
@@ -114,6 +120,12 @@ pub enum ServerEvent {
         called_tile: Tile,
         /// 副露で公開された牌
         tiles: Vec<Tile>,
+    },
+
+    /// ドラ表示牌の更新
+    DoraIndicatorsUpdated {
+        /// 現在公開されているドラ表示牌
+        dora_indicators: Vec<Tile>,
     },
 
     /// リーチ宣言

--- a/crates/mahjong-server/src/round.rs
+++ b/crates/mahjong-server/src/round.rs
@@ -44,6 +44,15 @@ pub enum RoundResult {
     SpecialDraw,
 }
 
+/// 鳴き解決後の進行先
+#[derive(Debug, Clone)]
+enum CallResolution {
+    /// 通常の打牌後処理
+    AfterDiscard,
+    /// 加カンに対する搶槓判定後の処理
+    AfterKakan { caller: usize, tile_type: TileType },
+}
+
 /// 鳴き待ち中の状態
 #[derive(Debug, Clone)]
 pub struct CallState {
@@ -59,8 +68,12 @@ pub struct CallState {
     pub ron_declared: Vec<usize>,
     /// ポンを宣言したプレイヤー
     pub pon_declared: Option<usize>,
+    /// 大明カンを宣言したプレイヤー
+    pub daiminkan_declared: Option<usize>,
     /// チーを宣言したプレイヤーと使う牌種
     pub chi_declared: Option<(usize, [TileType; 2])>,
+    /// 全員応答後の進行先
+    resolution: CallResolution,
 }
 
 /// 1局分の状態
@@ -85,6 +98,8 @@ pub struct Round {
     events: Vec<(usize, ServerEvent)>,
     /// 鳴き待ち中の状態
     pub call_state: Option<CallState>,
+    /// 直前のツモが嶺上牌か
+    pub last_draw_was_dead_wall: bool,
 }
 
 impl Round {
@@ -142,6 +157,7 @@ impl Round {
             result: None,
             events,
             call_state: None,
+            last_draw_was_dead_wall: false,
         }
     }
 
@@ -177,6 +193,7 @@ impl Round {
         let tile = self.wall.draw().unwrap();
         let remaining = self.wall.remaining();
         self.players[self.current_player].draw(tile);
+        self.last_draw_was_dead_wall = false;
 
         // ツモ和了チェック
         let can_tsumo = self.can_tsumo();
@@ -333,6 +350,11 @@ impl Round {
                 available_calls[i].push(AvailableCall::Pon);
             }
 
+            // 大明カン判定
+            if player.can_daiminkan(discarded_tile) {
+                available_calls[i].push(AvailableCall::Daiminkan);
+            }
+
             // チー判定（上家からのみ＝次のプレイヤー）
             let next_player = (discarder + 1) % 4;
             if i == next_player {
@@ -354,7 +376,9 @@ impl Round {
             responded,
             ron_declared: Vec::new(),
             pon_declared: None,
+            daiminkan_declared: None,
             chi_declared: None,
+            resolution: CallResolution::AfterDiscard,
         }
     }
 
@@ -400,6 +424,16 @@ impl Round {
                     return false;
                 }
             }
+            CallResponse::Daiminkan => {
+                if call_state.available_calls[player_idx]
+                    .iter()
+                    .any(|c| matches!(c, AvailableCall::Daiminkan))
+                {
+                    call_state.daiminkan_declared = Some(player_idx);
+                } else {
+                    return false;
+                }
+            }
             CallResponse::Chi { hand_tile_types } => {
                 // チーの組み合わせが有効か確認
                 let valid = call_state.available_calls[player_idx].iter().any(|c| {
@@ -430,13 +464,13 @@ impl Round {
         true
     }
 
-    /// 鳴きを解決する（優先度: ロン > ポン > チー > パス）
+    /// 鳴きを解決する（優先度: ロン > 大明カン > ポン > チー > パス）
     fn resolve_calls(&mut self) {
         let call_state = self.call_state.take().unwrap();
 
         // 1. ロン（最優先）
         if !call_state.ron_declared.is_empty() {
-            // 複数ロンの場合、捨てたプレイヤーから反時計回りで最初のプレイヤーが和了
+            let is_robbing_a_quad = matches!(call_state.resolution, CallResolution::AfterKakan { .. });
             let discarder = call_state.discarder;
             let winner = call_state
                 .ron_declared
@@ -445,23 +479,35 @@ impl Round {
                 .copied()
                 .unwrap();
 
-            self.execute_ron(winner, discarder, call_state.discarded_tile);
+            self.execute_ron(winner, discarder, call_state.discarded_tile, is_robbing_a_quad);
             return;
         }
 
-        // 2. ポン
+        if let CallResolution::AfterKakan { caller, tile_type } = call_state.resolution {
+            self.execute_kakan(caller, tile_type);
+            return;
+        }
+
+
+        // 2. 大明カン
+        if let Some(caller) = call_state.daiminkan_declared {
+            self.execute_daiminkan(caller, call_state.discarder, call_state.discarded_tile);
+            return;
+        }
+
+        // 3. ポン
         if let Some(caller) = call_state.pon_declared {
             self.execute_pon(caller, call_state.discarder, call_state.discarded_tile);
             return;
         }
 
-        // 3. チー
+        // 4. チー
         if let Some((caller, hand_tile_types)) = call_state.chi_declared {
             self.execute_chi(caller, call_state.discarder, call_state.discarded_tile, hand_tile_types);
             return;
         }
 
-        // 4. 全員パス → 次のプレイヤーへ
+        // 5. 全員パス → 次のプレイヤーへ
         self.current_player = (call_state.discarder + 1) % 4;
         self.phase = TurnPhase::Draw;
 
@@ -470,15 +516,16 @@ impl Round {
     }
 
     /// ロン和了を実行する
-    fn execute_ron(&mut self, winner: usize, loser: usize, winning_tile: Tile) {
+    fn execute_ron(&mut self, winner: usize, loser: usize, winning_tile: Tile, is_robbing_a_quad: bool) {
         let is_last_tile = self.wall.is_empty();
 
         // 一時的にdrawnを設定して点数計算
-        let win_result = scoring::check_ron(
+        let win_result = scoring::check_ron_with_flags(
             &self.players[winner],
             winning_tile,
             self.prevailing_wind,
             is_last_tile,
+            is_robbing_a_quad,
         );
 
         if !win_result.is_win {
@@ -519,9 +566,11 @@ impl Round {
             self.players[i].score += deltas[i];
         }
 
-        // 捨て牌を「鳴かれた」としてマーク
-        if let Some(last_discard) = self.players[loser].discards.last_mut() {
-            last_discard.is_called = true;
+        if !is_robbing_a_quad {
+            // 捨て牌を「鳴かれた」としてマーク
+            if let Some(last_discard) = self.players[loser].discards.last_mut() {
+                last_discard.is_called = true;
+            }
         }
 
         let scores = self.get_scores();
@@ -613,6 +662,49 @@ impl Round {
         self.phase = TurnPhase::WaitForDiscard;
     }
 
+    /// 大明カンを実行する
+    fn execute_daiminkan(&mut self, caller: usize, discarder: usize, called_tile: Tile) {
+        let from = Player::open_from_relative(caller, discarder);
+        self.players[caller].do_daiminkan(called_tile, from);
+
+        if let Some(last_discard) = self.players[discarder].discards.last_mut() {
+            last_discard.is_called = true;
+        }
+
+        for i in 0..4 {
+            self.players[i].is_ippatsu = false;
+            self.players[i].first_turn_interrupted = true;
+        }
+
+        let caller_wind = self.players[caller].seat_wind;
+        let open = self.players[caller].hand.opened().last().unwrap();
+        let mut tiles = open.tiles.to_vec();
+        tiles.push(called_tile);
+
+        for i in 0..4 {
+            self.events.push((
+                i,
+                ServerEvent::PlayerCalled {
+                    player: caller_wind,
+                    call_type: CallType::Daiminkan,
+                    called_tile,
+                    tiles: tiles.clone(),
+                },
+            ));
+        }
+
+        self.events.push((
+            caller,
+            ServerEvent::HandUpdated {
+                hand: self.players[caller].hand.tiles().to_vec(),
+            },
+        ));
+
+        self.reveal_new_dora_indicator();
+        self.current_player = caller;
+        self.draw_after_kan(caller);
+    }
+
     /// チーを実行する
     fn execute_chi(
         &mut self,
@@ -667,6 +759,207 @@ impl Round {
         // チーしたプレイヤーの打牌待ちへ
         self.current_player = caller;
         self.phase = TurnPhase::WaitForDiscard;
+    }
+
+    fn execute_kakan(&mut self, caller: usize, tile_type: TileType) {
+        self.players[caller].do_kakan(tile_type);
+        for i in 0..4 {
+            self.players[i].is_ippatsu = false;
+            self.players[i].first_turn_interrupted = true;
+        }
+
+        let caller_wind = self.players[caller].seat_wind;
+        let open = self.players[caller].hand.opened().iter().rev().find(|open| open.category == mahjong_core::hand_info::opened::OpenType::Kan && open.tiles[0].get() == tile_type).unwrap();
+        let mut tiles = open.tiles.to_vec();
+        tiles.push(Tile::new(tile_type));
+
+        for i in 0..4 {
+            self.events.push((
+                i,
+                ServerEvent::PlayerCalled {
+                    player: caller_wind,
+                    call_type: CallType::Kakan,
+                    called_tile: Tile::new(tile_type),
+                    tiles: tiles.clone(),
+                },
+            ));
+        }
+
+        self.events.push((
+            caller,
+            ServerEvent::HandUpdated {
+                hand: self.players[caller].hand.tiles().to_vec(),
+            },
+        ));
+
+        self.reveal_new_dora_indicator();
+        self.draw_after_kan(caller);
+    }
+
+    fn check_kakan_ron_and_resolve(&mut self, caller: usize, tile_type: TileType) {
+        let called_tile = Tile::new(tile_type);
+        let is_last_tile = self.wall.is_empty();
+        let mut available_calls: [Vec<AvailableCall>; 4] = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+        let mut responded = [true; 4];
+
+        for i in 0..4 {
+            if i == caller {
+                continue;
+            }
+
+            let player = &self.players[i];
+            if !player.is_furiten() {
+                let win_result = scoring::check_ron_with_flags(
+                    player,
+                    called_tile,
+                    self.prevailing_wind,
+                    is_last_tile,
+                    true,
+                );
+                if win_result.is_win {
+                    available_calls[i].push(AvailableCall::Ron);
+                    responded[i] = false;
+                }
+            }
+        }
+
+        let has_any_calls = available_calls.iter().any(|calls| !calls.is_empty());
+        if has_any_calls {
+            self.phase = TurnPhase::WaitForCalls;
+            let caller_wind = self.players[caller].seat_wind;
+            for i in 0..4 {
+                if !available_calls[i].is_empty() {
+                    self.events.push((
+                        i,
+                        ServerEvent::CallAvailable {
+                            tile: called_tile,
+                            discarder: caller_wind,
+                            calls: available_calls[i].clone(),
+                        },
+                    ));
+                }
+            }
+
+            self.call_state = Some(CallState {
+                discarded_tile: called_tile,
+                discarder: caller,
+                available_calls,
+                responded,
+                ron_declared: Vec::new(),
+                pon_declared: None,
+                daiminkan_declared: None,
+                chi_declared: None,
+                resolution: CallResolution::AfterKakan { caller, tile_type },
+            });
+        } else {
+            self.execute_kakan(caller, tile_type);
+        }
+    }
+
+    /// 暗カン/加カンを実行する
+    pub fn do_kan(&mut self, tile_type: TileType) -> bool {
+        if self.phase != TurnPhase::WaitForDiscard {
+            return false;
+        }
+
+        let player_idx = self.current_player;
+        if self.players[player_idx].is_riichi {
+            return false;
+        }
+
+        if self.players[player_idx].ankan_options().contains(&tile_type) {
+            self.players[player_idx].do_ankan(tile_type);
+        } else if self.players[player_idx].kakan_options().contains(&tile_type) {
+            self.check_kakan_ron_and_resolve(player_idx, tile_type);
+            return true;
+        } else {
+            return false;
+        }
+        for i in 0..4 {
+            self.players[i].is_ippatsu = false;
+            self.players[i].first_turn_interrupted = true;
+        }
+
+        let caller_wind = self.players[player_idx].seat_wind;
+        let open = self.players[player_idx].hand.opened().last().unwrap();
+        let mut tiles = open.tiles.to_vec();
+        tiles.push(open.tiles[0]);
+        let called_tile = Tile::new(tile_type);
+
+        for i in 0..4 {
+            self.events.push((
+                i,
+                ServerEvent::PlayerCalled {
+                    player: caller_wind,
+                    call_type: CallType::Ankan,
+                    called_tile,
+                    tiles: tiles.clone(),
+                },
+            ));
+        }
+
+        self.events.push((
+            player_idx,
+            ServerEvent::HandUpdated {
+                hand: self.players[player_idx].hand.tiles().to_vec(),
+            },
+        ));
+
+        self.reveal_new_dora_indicator();
+        self.draw_after_kan(player_idx);
+        true
+    }
+
+    fn reveal_new_dora_indicator(&mut self) {
+        self.wall.add_dora_indicator();
+        let dora_indicators = self.wall.dora_indicators();
+        for i in 0..4 {
+            self.events.push((
+                i,
+                ServerEvent::DoraIndicatorsUpdated {
+                    dora_indicators: dora_indicators.clone(),
+                },
+            ));
+        }
+    }
+
+    fn draw_after_kan(&mut self, player_idx: usize) {
+        let Some(tile) = self.wall.draw_rinshan() else {
+            self.do_exhaustive_draw();
+            return;
+        };
+
+        self.current_player = player_idx;
+        self.phase = TurnPhase::WaitForDiscard;
+        self.last_draw_was_dead_wall = true;
+        self.players[player_idx].draw(tile);
+
+        let remaining = self.wall.remaining();
+        let can_tsumo = self.can_tsumo();
+        let can_riichi = self.can_player_riichi(player_idx);
+
+        self.events.push((
+            player_idx,
+            ServerEvent::TileDrawn {
+                tile,
+                remaining_tiles: remaining,
+                can_tsumo,
+                can_riichi,
+            },
+        ));
+
+        let current_wind = self.players[player_idx].seat_wind;
+        for i in 0..4 {
+            if i != player_idx {
+                self.events.push((
+                    i,
+                    ServerEvent::OtherPlayerDrew {
+                        player: current_wind,
+                        remaining_tiles: remaining,
+                    },
+                ));
+            }
+        }
     }
 
     fn can_player_riichi_with_discard(&self, player_idx: usize, tile: Option<Tile>) -> bool {
@@ -847,7 +1140,13 @@ impl Round {
         }
         let player = &self.players[self.current_player];
         let is_last_tile = self.wall.is_empty();
-        let result = scoring::check_win(player, self.prevailing_wind, true, is_last_tile);
+        let result = scoring::check_win(
+            player,
+            self.prevailing_wind,
+            true,
+            is_last_tile,
+            self.last_draw_was_dead_wall,
+        );
         result.is_win
     }
 
@@ -860,7 +1159,13 @@ impl Round {
 
         let player = &self.players[self.current_player];
         let is_last_tile = self.wall.is_empty();
-        let win_result = scoring::check_win(player, self.prevailing_wind, true, is_last_tile);
+        let win_result = scoring::check_win(
+            player,
+            self.prevailing_wind,
+            true,
+            is_last_tile,
+            self.last_draw_was_dead_wall,
+        );
 
         if !win_result.is_win {
             return false;
@@ -1147,6 +1452,8 @@ pub enum CallResponse {
     Ron,
     /// ポン
     Pon,
+    /// 大明カン
+    Daiminkan,
     /// チー（手牌から使う牌の種類2つ）
     Chi { hand_tile_types: [TileType; 2] },
     /// パス
@@ -1363,6 +1670,89 @@ mod tests {
 
         assert!(round.do_riichi(Some(Tile::new(Tile::Z4))));
         assert!(round.players[0].is_riichi);
+    }
+
+    #[test]
+    fn test_check_available_calls_offers_daiminkan() {
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0);
+        let seat_wind = round.players[1].seat_wind;
+        let hand = mahjong_core::hand::Hand::from("111m234p567s789m");
+        round.players[1] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
+
+        let call_state = round.check_available_calls(Tile::new(Tile::M1), 0);
+        assert!(call_state.available_calls[1]
+            .iter()
+            .any(|call| matches!(call, AvailableCall::Daiminkan)));
+    }
+
+    #[test]
+    fn test_do_ankan_draws_rinshan_and_reveals_dora() {
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0);
+        let seat_wind = round.players[0].seat_wind;
+        let hand = mahjong_core::hand::Hand::from("111m234p567s789m 1m");
+        round.players[0] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
+        round.players[0].draw(hand.drawn().unwrap());
+        round.current_player = 0;
+        round.phase = TurnPhase::WaitForDiscard;
+        round.drain_events();
+
+        assert!(round.do_kan(Tile::M1));
+        assert_eq!(round.phase, TurnPhase::WaitForDiscard);
+        assert!(round.players[0].hand.drawn().is_some());
+        assert_eq!(round.players[0].hand.opened().len(), 1);
+        assert_eq!(round.wall.dora_indicators().len(), 2);
+    }
+
+    #[test]
+    fn test_do_kakan_draws_rinshan_and_reveals_dora() {
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0);
+        let seat_wind = round.players[0].seat_wind;
+        let mut player = Player::new(seat_wind, vec![], 25000);
+        player.hand = mahjong_core::hand::Hand::from("234p567s789m1z 111m 1m");
+        round.players[0] = player;
+        round.current_player = 0;
+        round.phase = TurnPhase::WaitForDiscard;
+        round.drain_events();
+
+        assert!(round.do_kan(Tile::M1));
+        assert_eq!(round.phase, TurnPhase::WaitForDiscard);
+        assert!(round.players[0].hand.drawn().is_some());
+        assert_eq!(round.players[0].hand.opened()[0].category, mahjong_core::hand_info::opened::OpenType::Kan);
+        assert_eq!(round.wall.dora_indicators().len(), 2);
+    }
+
+    #[test]
+    fn test_kakan_offers_rob_ron() {
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0);
+
+        let seat0 = round.players[0].seat_wind;
+        let mut player0 = Player::new(seat0, vec![], 25000);
+        player0.hand = mahjong_core::hand::Hand::from("234p567s789m1z 111m 1m");
+        round.players[0] = player0;
+
+        let seat1 = round.players[1].seat_wind;
+        let hand1 = mahjong_core::hand::Hand::from("11m234p567p789s55z");
+        round.players[1] = Player::new(seat1, hand1.tiles().to_vec(), 25000);
+
+        round.current_player = 0;
+        round.phase = TurnPhase::WaitForDiscard;
+        round.drain_events();
+
+        assert!(round.do_kan(Tile::M1));
+        assert_eq!(round.phase, TurnPhase::WaitForCalls);
+        let call_state = round.call_state.as_ref().unwrap();
+        assert!(call_state.available_calls[1].iter().any(|call| matches!(call, AvailableCall::Ron)));
+
+        assert!(round.respond_to_call(1, CallResponse::Ron));
+        assert_eq!(round.phase, TurnPhase::RoundOver);
+        match round.result {
+            Some(RoundResult::Ron { winner, loser, winning_tile }) => {
+                assert_eq!(winner, 1);
+                assert_eq!(loser, 0);
+                assert_eq!(winning_tile, Tile::new(Tile::M1));
+            }
+            _ => panic!("expected ron result after robbing a quad"),
+        }
     }
 }
 

--- a/crates/mahjong-server/src/scoring.rs
+++ b/crates/mahjong-server/src/scoring.rs
@@ -33,6 +33,7 @@ pub fn check_win(
     prevailing_wind: Wind,
     is_tsumo: bool,
     is_last_tile: bool,
+    is_dead_wall_draw: bool,
 ) -> WinCheckResult {
     let hand = &player.hand;
 
@@ -68,6 +69,8 @@ pub fn check_win(
     status.is_first_turn = player.is_first_turn;
     status.is_last_tile_from_the_wall = is_last_tile && is_tsumo;
     status.is_last_discard = is_last_tile && !is_tsumo;
+    status.is_dead_wall_draw = is_dead_wall_draw;
+    status.kan_count = player.kan_count() as u32;
 
     let settings = Settings::new();
 
@@ -92,6 +95,17 @@ pub fn check_ron(
     discarded_tile: Tile,
     prevailing_wind: Wind,
     is_last_tile: bool,
+) -> WinCheckResult {
+    check_ron_with_flags(player, discarded_tile, prevailing_wind, is_last_tile, false)
+}
+
+/// ロン和了が可能か判定する（搶槓などの状態フラグ付き）
+pub fn check_ron_with_flags(
+    player: &Player,
+    discarded_tile: Tile,
+    prevailing_wind: Wind,
+    is_last_tile: bool,
+    is_robbing_a_quad: bool,
 ) -> WinCheckResult {
     // 手牌をクローンして捨て牌をdrawnとしてセット
     let mut hand = player.hand.clone();
@@ -126,7 +140,9 @@ pub fn check_ron(
     status.is_dealer = player.is_dealer();
     status.is_first_turn = player.is_first_turn;
     status.is_last_tile_from_the_wall = false;
-    status.is_last_discard = is_last_tile;
+    status.is_last_discard = is_last_tile && !is_robbing_a_quad;
+    status.is_robbing_a_quad = is_robbing_a_quad;
+    status.kan_count = player.kan_count() as u32;
 
     let settings = Settings::new();
 
@@ -262,6 +278,9 @@ pub fn add_dora_to_score(
     for open in hand.opened() {
         for &tile in &open.tiles {
             all_tiles.push(tile);
+        }
+        if open.category == mahjong_core::hand_info::opened::OpenType::Kan {
+            all_tiles.push(open.tiles[0]);
         }
     }
 
@@ -469,7 +488,7 @@ mod tests {
         let mut player = Player::new(Wind::East, tiles, 25000);
         player.draw(Tile::new(Tile::Z5));
 
-        let result = check_win(&player, Wind::East, true, false);
+        let result = check_win(&player, Wind::East, true, false, false);
         assert!(!result.is_win);
         assert!(result.score_result.is_none());
     }
@@ -486,7 +505,7 @@ mod tests {
             player.draw(d);
         }
 
-        let result = check_win(&player, Wind::East, true, false);
+        let result = check_win(&player, Wind::East, true, false, false);
         assert!(result.is_win);
         let score = result.score_result.unwrap();
         // 門前ツモ(1翻) + 場風(1翻) = 2翻

--- a/crates/mahjong-server/src/table.rs
+++ b/crates/mahjong-server/src/table.rs
@@ -3,7 +3,7 @@
 //! 半荘（東風戦/東南戦）を通した状態を管理する。
 //! 局の生成・進行・終了判定を行う。
 
-use mahjong_core::tile::Wind;
+use mahjong_core::tile::{Tile, Wind};
 
 use crate::protocol::{ClientAction, ServerEvent};
 use crate::round::{CallResponse, Round, RoundResult, TurnPhase};
@@ -142,8 +142,18 @@ impl Table {
                 round.respond_to_call(player_idx, CallResponse::Pass)
             }
 
-            // カンは Phase 9 で実装予定
-            ClientAction::Kan { .. } => false,
+            ClientAction::Kan { tile_index } => {
+                if round.phase == TurnPhase::WaitForCalls {
+                    round.respond_to_call(player_idx, CallResponse::Daiminkan)
+                } else if round.current_player == player_idx && round.phase == TurnPhase::WaitForDiscard {
+                    if tile_index >= Tile::LEN {
+                        return false;
+                    }
+                    round.do_kan(tile_index as u32)
+                } else {
+                    false
+                }
+            },
         }
     }
 


### PR DESCRIPTION
- Added support for Ankan and Daiminkan actions in the player module.
- Updated the protocol to include new call types for Ankan and Kakan.
- Enhanced the round logic to handle Kan actions and their resolutions.
- Implemented scoring adjustments for Kan actions in the scoring module.
- Updated the renderer to display Kan options in the UI.
- Added tests for new Kan functionalities including robbing a quad.

closes #44 