### PR TITLE
Fix scoring, hand formatting, and draw progression bugs

### DIFF
--- a/crates/mahjong-core/src/hand.rs
+++ b/crates/mahjong-core/src/hand.rs
@@ -113,7 +113,11 @@ impl Hand {
                 self.opened[i].tiles[0].to_char(),
                 self.opened[i].tiles[1].to_char(),
                 self.opened[i].tiles[2].to_char()
-            ))
+            ));
+            // カンなら4枚目を追加する
+            if self.opened[i].category == OpenType::Kan {
+                result.push(self.opened[i].tiles[0].to_char());
+            }
         }
 
         if let Some(tsumo) = self.drawn {
@@ -155,7 +159,7 @@ impl Hand {
         if tiles.len() == 0 {
             return String::from("");
         } else if tiles.len() == 1 {
-            return tiles[1].to_string();
+            return tiles[0].to_string();
         }
         tiles.sort();
         let mut result = String::new();

--- a/crates/mahjong-core/src/hand_info/hand_analyzer.rs
+++ b/crates/mahjong-core/src/hand_info/hand_analyzer.rs
@@ -164,7 +164,7 @@ impl HandAnalyzer {
         let mut single: Vec<TileType> = Vec::new();
         for i in 0..Tile::LEN {
             if t[i] > 0 {
-                for _ in 0..i {
+                for _ in 0..t[i] {
                     single.push(i as TileType);
                 }
             }

--- a/crates/mahjong-core/src/hand_info/status.rs
+++ b/crates/mahjong-core/src/hand_info/status.rs
@@ -74,21 +74,21 @@ pub fn is_two_sided_wait(tile: TileType, counts: &TileSummarize) -> bool {
         tile - Tile::S1 + 1
     };
 
-    // 左側が存在する形 : xx[tile-2][tile-1] + tile かつ123または789にならない
+    // 左側が存在する形 : [tile-2][tile-1] + tile
+    // offset == 3 は辺張（12の3待ち）なので除外
     if offset >= 3
         && counts[(tile - 1) as usize] > 0
         && counts[(tile - 2) as usize] > 0
         && offset != 3
-        && offset != 9
     {
         return true;
     }
 
-    // 右側が存在する形 : tile + [tile+1][tile+2] かつ123または789にならない
+    // 右側が存在する形 : tile + [tile+1][tile+2]
+    // offset == 7 は辺張（89の7待ち）なので除外
     if offset <= 7
         && counts[(tile + 1) as usize] > 0
         && counts[(tile + 2) as usize] > 0
-        && offset != 1
         && offset != 7
     {
         return true;

--- a/crates/mahjong-core/src/winning_hand/check_1_han.rs
+++ b/crates/mahjong-core/src/winning_hand/check_1_han.rs
@@ -25,6 +25,10 @@ pub fn check_ready_hand(
     if status.has_claimed_open {
         return Ok((name, false, 0));
     }
+    // ダブル立直の場合は通常の立直とは複合しない（ダブル立直が立直を置き換える）
+    if status.is_double_ready {
+        return Ok((name, false, 0));
+    }
     if status.has_claimed_ready {
         Ok((name, true, 1))
     } else {
@@ -270,16 +274,28 @@ pub fn check_one_set_of_identical_sequences(
     if hand_analyzer.sequential3.len() < 2 {
         return Ok((name, false, 0));
     }
-    for i in 0..hand_analyzer.sequential3.len() - 1 {
-        if let Some(v) = hand_analyzer.sequential3.get(i) {
-            for j in i + 1..hand_analyzer.sequential3.len() {
-                if let Some(v2) = hand_analyzer.sequential3.get(j) {
-                    if *v == *v2 {
-                        return Ok((name, true, 1));
-                    }
-                }
+    // 同一順子ペアの数をカウント（二盃口との区別のため）
+    let mut used = vec![false; hand_analyzer.sequential3.len()];
+    let mut pair_count = 0;
+    for i in 0..hand_analyzer.sequential3.len() {
+        if used[i] {
+            continue;
+        }
+        for j in i + 1..hand_analyzer.sequential3.len() {
+            if used[j] {
+                continue;
+            }
+            if hand_analyzer.sequential3[i] == hand_analyzer.sequential3[j] {
+                used[i] = true;
+                used[j] = true;
+                pair_count += 1;
+                break;
             }
         }
+    }
+    // 二盃口（ペアが2組）の場合は一盃口とは複合しない
+    if pair_count == 1 {
+        return Ok((name, true, 1));
     }
     Ok((name, false, 0))
 }

--- a/crates/mahjong-server/src/round.rs
+++ b/crates/mahjong-server/src/round.rs
@@ -39,7 +39,10 @@ pub enum RoundResult {
         winning_tile: Tile,
     },
     /// 荒牌流局（牌山切れ）
-    ExhaustiveDraw,
+    ExhaustiveDraw {
+        /// 親がテンパイしているか
+        dealer_tenpai: bool,
+    },
     /// 途中流局（四風連打、四家立直、九種九牌）
     SpecialDraw,
 }
@@ -1472,8 +1475,10 @@ impl Round {
             .map(|&i| self.players[i].seat_wind)
             .collect();
 
+        let dealer_tenpai = tenpai_players.contains(&self.dealer);
+
         self.phase = TurnPhase::RoundOver;
-        self.result = Some(RoundResult::ExhaustiveDraw);
+        self.result = Some(RoundResult::ExhaustiveDraw { dealer_tenpai });
 
         for i in 0..4 {
             self.events.push((

--- a/crates/mahjong-server/src/table.rs
+++ b/crates/mahjong-server/src/table.rs
@@ -185,11 +185,19 @@ impl Table {
         self.riichi_sticks = round.riichi_sticks;
 
         match result {
-            Some(RoundResult::ExhaustiveDraw) | Some(RoundResult::SpecialDraw) => {
-                // 流局: 本場を増やし、親交代して局を進める
+            Some(RoundResult::ExhaustiveDraw { dealer_tenpai }) => {
                 self.honba += 1;
-                self.dealer = (self.dealer + 1) % 4;
-                self.advance_round_number();
+                if dealer_tenpai {
+                    // 親がテンパイなら連荘（親交代しない、局も進めない）
+                } else {
+                    // 親がノーテンなら親交代して局を進める
+                    self.dealer = (self.dealer + 1) % 4;
+                    self.advance_round_number();
+                }
+            }
+            Some(RoundResult::SpecialDraw) => {
+                // 途中流局: 本場を増やし、局は進めない（連荘扱い）
+                self.honba += 1;
             }
             Some(RoundResult::Tsumo { winner, .. }) | Some(RoundResult::Ron { winner, .. }) => {
                 if winner == self.dealer {
@@ -273,7 +281,7 @@ mod tests {
         let round = table.current_round_mut().unwrap();
         round.riichi_sticks = 3;
         round.phase = TurnPhase::RoundOver;
-        round.result = Some(RoundResult::ExhaustiveDraw);
+        round.result = Some(RoundResult::ExhaustiveDraw { dealer_tenpai: false });
 
         table.finish_round();
         assert_eq!(table.riichi_sticks, 3);


### PR DESCRIPTION
## Summary
- fix fatal hand formatting issues in `make_short_str()` and `to_emoji()`
- correct scoring logic for seven pairs analysis, two-sided wait detection, ready hand evaluation, and iipeikou/ryanpeikou handling
- fix exhaustive draw progression so dealer tenpai keeps the dealership and abortive draws are treated as continuations

## Details
- fix an out-of-bounds access in `Hand::make_short_str()` when `tiles.len() == 1`
- fix seven pairs single-tile reconstruction to use the remaining tile count instead of the tile index
- fix `is_two_sided_wait()` to recognize `1-4` and `6-9` waits as two-sided waits, which restores correct Pinfu evaluation
- prevent double-counting Riichi with Double Riichi and Iipeikou with Ryanpeikou
- make `Hand::to_emoji()` render kans with the fourth tile, matching `to_string()`
- add dealer tenpai tracking to exhaustive draws and apply the correct dealership/round progression rules

## Testing
- `cargo test`

closes #51