### PR TITLE
Fix riichi tile selection after ankan

### DIFF
--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -5,6 +5,7 @@
 use macroquad::prelude::*;
 use mahjong_core::hand::Hand;
 use mahjong_core::hand_info::hand_analyzer::HandAnalyzer;
+use mahjong_core::hand_info::opened::{OpenFrom, OpenTiles, OpenType};
 use mahjong_core::tile::{Tile, Wind};
 use mahjong_server::protocol::{AvailableCall, CallType, ClientAction, DrawReason, ServerEvent};
 
@@ -422,7 +423,7 @@ impl GameState {
             return false;
         }
 
-        let mut hand = Hand::new(self.hand.clone(), self.drawn);
+        let mut hand = Hand::new_with_opened(self.hand.clone(), self.opened_tiles_for_analysis(), self.drawn);
         match tile {
             Some(target) => {
                 let drawn = hand.drawn();
@@ -446,6 +447,30 @@ impl GameState {
             Ok(analyzer) => analyzer.shanten == 0,
             Err(_) => false,
         }
+    }
+
+    fn opened_tiles_for_analysis(&self) -> Vec<OpenTiles> {
+        self.melds
+            .iter()
+            .filter_map(|meld| match meld.call_type {
+                CallType::Chi => Some(OpenTiles {
+                    tiles: [meld.tiles[0], meld.tiles[1], meld.tiles[2]],
+                    category: OpenType::Chi,
+                    from: OpenFrom::Unknown,
+                }),
+                CallType::Pon => Some(OpenTiles {
+                    tiles: [meld.tiles[0], meld.tiles[1], meld.tiles[2]],
+                    category: OpenType::Pon,
+                    from: OpenFrom::Unknown,
+                }),
+                CallType::Daiminkan | CallType::Ankan | CallType::Kakan => Some(OpenTiles {
+                    tiles: [meld.tiles[0], meld.tiles[1], meld.tiles[2]],
+                    category: OpenType::Kan,
+                    from: OpenFrom::Unknown,
+                }),
+                CallType::Ron => None,
+            })
+            .collect()
     }
 
     fn enter_riichi_selection(&mut self) {
@@ -774,6 +799,26 @@ mod tests {
         assert!(state.can_discard_for_riichi(Some(Tile::new(Tile::Z4))));
         assert!(state.can_discard_for_riichi(Some(Tile::new(Tile::Z5))));
     }
-}
 
+    #[test]
+    fn test_can_discard_for_riichi_after_ankan_uses_opened_melds() {
+        let mut state = GameState::new();
+        let hand = Hand::from("1m1m5m5m7m7m9m1s2s3s 3m3m3m3m 8m");
+        state.hand = hand.tiles().to_vec();
+        state.hand.sort();
+        state.drawn = hand.drawn();
+        state.melds.push(MeldInfo {
+            call_type: CallType::Ankan,
+            tiles: vec![
+                Tile::new(Tile::M3),
+                Tile::new(Tile::M3),
+                Tile::new(Tile::M3),
+                Tile::new(Tile::M3),
+            ],
+        });
+
+        assert!(state.can_discard_for_riichi(Some(Tile::new(Tile::M5))));
+        assert!(state.can_discard_for_riichi(Some(Tile::new(Tile::M7))));
+    }
+}
 

--- a/crates/mahjong-server/src/player.rs
+++ b/crates/mahjong-server/src/player.rs
@@ -410,6 +410,12 @@ impl Player {
                 .position(|t| t.get() == tile_type)
                 .expect("加カンに必要な牌が手牌にありません");
             self.hand.tiles_mut().remove(idx);
+
+            if let Some(drawn_tile) = self.hand.drawn() {
+                self.hand.tiles_mut().push(drawn_tile);
+                self.hand.sort();
+                self.hand.set_drawn(None);
+            }
         }
 
         let open = self
@@ -730,6 +736,20 @@ mod tests {
         assert_eq!(player.hand.opened().len(), 1);
         assert_eq!(player.hand.opened()[0].category, OpenType::Kan);
         assert!(!player.is_menzen());
+    }
+
+    #[test]
+    fn test_do_kakan_preserves_unrelated_drawn_tile() {
+        let mut player = Player::new(Wind::South, vec![], 25000);
+        player.hand = Hand::from("127m234p567s1z 111m 9s");
+
+        player.do_kakan(Tile::M1);
+
+        assert!(player.hand.drawn().is_none());
+        assert_eq!(player.hand.tiles().len(), 10);
+        assert!(player.hand.tiles().contains(&Tile::new(Tile::S9)));
+        assert_eq!(player.hand.opened().len(), 1);
+        assert_eq!(player.hand.opened()[0].category, OpenType::Kan);
     }
 
     #[test]

--- a/crates/mahjong-server/src/round.rs
+++ b/crates/mahjong-server/src/round.rs
@@ -1853,6 +1853,27 @@ mod tests {
     }
 
     #[test]
+    fn test_do_kakan_keeps_unrelated_drawn_tile_in_hand() {
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0);
+        let seat_wind = round.players[0].seat_wind;
+        let mut player = Player::new(seat_wind, vec![], 25000);
+        player.hand = mahjong_core::hand::Hand::from("127m234p567s1z 111m 9s");
+        round.players[0] = player;
+        round.current_player = 0;
+        round.phase = TurnPhase::WaitForDiscard;
+        round.drain_events();
+
+        assert!(round.do_kan(Tile::M1));
+        assert_eq!(round.phase, TurnPhase::WaitForDiscard);
+        assert!(round.players[0].hand.drawn().is_some());
+        assert_eq!(round.players[0].hand.tiles().len(), 10);
+        assert!(round.players[0]
+            .hand
+            .tiles()
+            .contains(&mahjong_core::tile::Tile::new(Tile::S9)));
+    }
+
+    #[test]
     fn test_kakan_offers_rob_ron() {
         let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0);
 
@@ -1886,7 +1907,5 @@ mod tests {
         }
     }
 }
-
-
 
 


### PR DESCRIPTION
## Summary
- include opened melds when the client recalculates riichi discard candidates
- restore kan melds as analysis opens so ankan and kakan hands are evaluated correctly
- add a regression test for the ankan + riichi selection case

Closes #53