### PR TITLE
Implement CPU AI players with hand display and performance optimization

### DIFF
--- a/crates/mahjong-client/src/adapter.rs
+++ b/crates/mahjong-client/src/adapter.rs
@@ -22,9 +22,16 @@ pub struct LocalAdapter {
 }
 
 impl LocalAdapter {
+    /// デフォルト設定でアダプターを作成する
+    #[allow(dead_code)]
     pub fn new() -> Self {
+        let configs = default_cpu_configs();
+        Self::with_cpu_configs(configs)
+    }
+
+    /// 指定したCPU設定でアダプターを作成する
+    pub fn with_cpu_configs(cpu_configs: [CpuConfig; 3]) -> Self {
         let human_player = 0;
-        let cpu_configs = default_cpu_configs();
 
         // 人間以外のプレイヤーにCPUクライアントを割り当て
         let mut cpu_clients: [Option<CpuClient>; 4] = [None, None, None, None];

--- a/crates/mahjong-client/src/adapter.rs
+++ b/crates/mahjong-client/src/adapter.rs
@@ -1,8 +1,11 @@
 //! ローカルアダプター
 //!
 //! サーバとクライアントを同一プロセス内で直接接続する。
-//! 将来的にWebSocket版に差し替え可能。
+//! CPUプレイヤーは人間と同じプロトコル（ServerEvent / ClientAction）で
+//! サーバとやり取りする。
 
+use mahjong_server::cpu::client::{CpuClient, CpuConfig};
+use mahjong_server::cpu::personalities::default_cpu_configs;
 use mahjong_server::protocol::{ClientAction, ServerEvent};
 use mahjong_server::round::TurnPhase;
 use mahjong_server::table::{GameSettings, Table};
@@ -12,43 +15,74 @@ pub struct LocalAdapter {
     table: Table,
     /// 人間プレイヤーのインデックス（0 = 東家/親）
     pub human_player: usize,
+    /// CPUクライアント（人間以外の3人）
+    cpu_clients: [Option<CpuClient>; 4],
+    /// 人間プレイヤー向けのイベントバッファ
+    human_event_buffer: Vec<ServerEvent>,
 }
 
 impl LocalAdapter {
     pub fn new() -> Self {
+        let human_player = 0;
+        let cpu_configs = default_cpu_configs();
+
+        // 人間以外のプレイヤーにCPUクライアントを割り当て
+        let mut cpu_clients: [Option<CpuClient>; 4] = [None, None, None, None];
+        let mut config_idx = 0;
+        for i in 0..4 {
+            if i != human_player {
+                cpu_clients[i] = Some(CpuClient::new(cpu_configs[config_idx].clone()));
+                config_idx += 1;
+            }
+        }
+
         LocalAdapter {
             table: Table::new(GameSettings::default()),
-            human_player: 0,
+            human_player,
+            cpu_clients,
+            human_event_buffer: Vec::new(),
+        }
+    }
+
+    /// CPU設定を変更する
+    #[allow(dead_code)]
+    pub fn set_cpu_config(&mut self, player_idx: usize, config: CpuConfig) {
+        if player_idx != self.human_player && player_idx < 4 {
+            self.cpu_clients[player_idx] = Some(CpuClient::new(config));
         }
     }
 
     /// ゲームを開始する（最初の局を開始）
     pub fn start_game(&mut self) {
         self.table.start_round();
+        // 局開始時のイベントをCPUに配信（人間イベントはバッファへ）
+        self.process_all_events();
     }
 
     /// 人間プレイヤー向けのイベントを取得する
     pub fn poll_events(&mut self, player_idx: usize) -> Vec<ServerEvent> {
-        let all_events = self.table.drain_events();
-        all_events
-            .into_iter()
-            .filter(|(idx, _)| *idx == player_idx)
-            .map(|(_, event)| event)
-            .collect()
+        // まず未処理イベントを処理
+        self.process_all_events();
+
+        if player_idx == self.human_player {
+            std::mem::take(&mut self.human_event_buffer)
+        } else {
+            Vec::new()
+        }
     }
 
     /// 人間プレイヤーのアクションを送信する
     pub fn send_action(&mut self, action: ClientAction) {
         self.table.handle_action(self.human_player, action);
+        // アクション後のイベントを処理
+        self.process_all_events();
     }
 
     /// ゲームを1ティック進める
-    /// - 人間プレイヤーの手番ならツモフェーズのみ実行
-    /// - CPUプレイヤーの手番なら自動進行
-    /// - 鳴き待ちならCPUプレイヤーを自動パスさせる
-    /// - リーチ中のCPUプレイヤーはツモ和了判定後にツモ切り
+    /// - Drawフェーズ: ツモを実行（全プレイヤー共通）
+    /// - 人間プレイヤーの手番ならUIで入力待ち
+    /// - CPUプレイヤーの手番ならイベント配信で自動判断
     pub fn tick(&mut self) {
-        let human = self.human_player;
         let round = match self.table.current_round_mut() {
             Some(r) => r,
             None => return,
@@ -60,39 +94,69 @@ impl LocalAdapter {
 
         match round.phase {
             TurnPhase::Draw => {
-                if round.current_player == human {
-                    // 人間プレイヤーのツモ
-                    round.do_draw();
-                } else {
-                    // CPUプレイヤー: ツモ和了チェック → ツモ切り
-                    round.do_draw();
-                    if !round.is_over() && round.phase == TurnPhase::WaitForDiscard {
-                        // ツモ和了チェック
-                        if round.can_tsumo() {
-                            round.do_tsumo();
-                        } else {
-                            // ツモ切り
-                            round.do_discard(None);
-                        }
-                    }
-                }
+                // ツモフェーズ: 牌を引く（全プレイヤー共通）
+                round.do_draw();
             }
-            TurnPhase::WaitForDiscard => {
-                // 人間プレイヤーの打牌待ち → 何もしない（入力で処理）
-                // CPUプレイヤーなら既に上記Drawで処理済み
-                if round.current_player != human {
-                    // リーチ中の人間プレイヤー以外が打牌待ちになることは通常ない
-                    // （鳴き後の打牌待ちの場合のみ）
-                    round.do_discard(None);
-                }
+            TurnPhase::WaitForDiscard | TurnPhase::WaitForCalls | TurnPhase::RoundOver => {
+                // 人間プレイヤーの入力待ち or 既に処理済み
             }
-            TurnPhase::WaitForCalls => {
-                // CPUプレイヤーを自動パスさせる
-                // 人間プレイヤーに鳴き候補がなければ自動的に全員パスで進行
-                round.auto_pass_cpu(human);
-            }
-            TurnPhase::RoundOver => {}
         }
+
+        // 生成されたイベントを処理（CPU配信 + 人間バッファリング）
+        self.process_all_events();
+    }
+
+    /// サーバからイベントを取得し、CPUに配信しつつ人間イベントをバッファする
+    ///
+    /// CPUのアクションが新たなイベントを生成する可能性があるためループする。
+    fn process_all_events(&mut self) {
+        loop {
+            let all_events = self.table.drain_events();
+            if all_events.is_empty() {
+                break;
+            }
+
+            // 人間プレイヤーのイベントをバッファに追加
+            for (idx, event) in &all_events {
+                if *idx == self.human_player {
+                    self.human_event_buffer.push(event.clone());
+                }
+            }
+
+            // CPUプレイヤーにイベントを配信してアクションを収集
+            let cpu_actions = self.collect_cpu_actions(&all_events);
+
+            if cpu_actions.is_empty() {
+                break;
+            }
+
+            // CPUのアクションをサーバに送信（これが新たなイベントを生成する）
+            for (player_idx, action) in cpu_actions {
+                self.table.handle_action(player_idx, action);
+            }
+        }
+    }
+
+    /// CPUプレイヤーにイベントを配信し、アクションを収集する
+    fn collect_cpu_actions(
+        &mut self,
+        events: &[(usize, ServerEvent)],
+    ) -> Vec<(usize, ClientAction)> {
+        let mut actions = Vec::new();
+
+        for (player_idx, event) in events {
+            if *player_idx == self.human_player {
+                continue;
+            }
+
+            if let Some(cpu) = &mut self.cpu_clients[*player_idx] {
+                if let Some(action) = cpu.handle_event(event) {
+                    actions.push((*player_idx, action));
+                }
+            }
+        }
+
+        actions
     }
 
     /// 現在の局が終了しているか
@@ -109,6 +173,8 @@ impl LocalAdapter {
         self.table.finish_round();
         if !self.table.is_game_over {
             self.table.start_round();
+            // 新局のイベントを処理
+            self.process_all_events();
         }
     }
 

--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -7,7 +7,7 @@ use mahjong_core::hand::Hand;
 use mahjong_core::hand_info::hand_analyzer::HandAnalyzer;
 use mahjong_core::hand_info::opened::{OpenFrom, OpenTiles, OpenType};
 use mahjong_core::tile::{Tile, TileType, Wind};
-use mahjong_server::protocol::{AvailableCall, CallType, ClientAction, DrawReason, ServerEvent};
+use mahjong_server::protocol::{AvailableCall, CallType, ClientAction, DrawReason, PlayerHandInfo, ServerEvent};
 
 /// 副露（鳴き）の表示情報
 #[derive(Debug, Clone)]
@@ -22,6 +22,32 @@ pub struct MeldInfo {
 pub struct DiscardInfo {
     pub tile: Tile,
     pub is_tsumogiri: bool,
+    /// リーチ宣言牌かどうか（横向きに表示）
+    pub is_riichi: bool,
+}
+
+/// 他プレイヤーの手牌表示情報（相対インデックスで管理）
+#[derive(Debug, Clone)]
+pub struct OtherPlayerHand {
+    /// 手牌（公開時のみ設定。非公開時は空）
+    pub hand: Vec<Tile>,
+    /// 副露（鳴き）一覧
+    pub melds: Vec<MeldInfo>,
+    /// 手牌が公開されているか（和了時・テンパイ時）
+    pub revealed: bool,
+    /// 非公開時の手牌枚数（裏向き表示用）
+    pub concealed_count: usize,
+}
+
+impl OtherPlayerHand {
+    fn new() -> Self {
+        OtherPlayerHand {
+            hand: Vec::new(),
+            melds: Vec::new(),
+            revealed: false,
+            concealed_count: 13,
+        }
+    }
 }
 
 /// クライアント側のゲーム状態
@@ -84,6 +110,10 @@ pub struct GameState {
     pub is_furiten: bool,
     /// 選択中の牌を捨てるとフリテンになるか
     pub selected_would_cause_furiten: bool,
+    /// 他プレイヤーの手牌情報（下家=0, 対面=1, 上家=2）
+    pub other_players: [OtherPlayerHand; 3],
+    /// リーチ宣言済みで次の打牌がリーチ宣言牌となるプレイヤーの風（一時フラグ）
+    pending_riichi_player: Option<Wind>,
 }
 
 /// ゲームフェーズ
@@ -131,6 +161,8 @@ impl GameState {
             riichi_sticks: 0,
             is_furiten: false,
             selected_would_cause_furiten: false,
+            other_players: [OtherPlayerHand::new(), OtherPlayerHand::new(), OtherPlayerHand::new()],
+            pending_riichi_player: None,
         }
     }
 
@@ -155,6 +187,7 @@ impl GameState {
                 self.prevailing_wind = Some(prevailing_wind);
                 self.dora_indicators = dora_indicators;
                 self.discards = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+                self.pending_riichi_player = None;
                 self.result_message = None;
                 self.phase = GamePhase::Playing;
                 self.available_calls.clear();
@@ -172,6 +205,7 @@ impl GameState {
                 self.riichi_sticks = riichi_sticks;
                 self.is_furiten = false;
                 self.selected_would_cause_furiten = false;
+                self.other_players = [OtherPlayerHand::new(), OtherPlayerHand::new(), OtherPlayerHand::new()];
             }
 
             ServerEvent::TileDrawn {
@@ -195,10 +229,14 @@ impl GameState {
             }
 
             ServerEvent::OtherPlayerDrew {
-                player: _,
+                player,
                 remaining_tiles,
             } => {
                 self.remaining_tiles = remaining_tiles;
+                let relative_idx = self.relative_player_index(player);
+                if relative_idx > 0 {
+                    self.other_players[relative_idx - 1].concealed_count += 1;
+                }
             }
 
             ServerEvent::TileDiscarded {
@@ -207,10 +245,22 @@ impl GameState {
                 is_tsumogiri,
             } => {
                 let relative_idx = self.relative_player_index(player);
+                let is_riichi = self.pending_riichi_player == Some(player);
+                if is_riichi {
+                    self.pending_riichi_player = None;
+                }
                 self.discards[relative_idx].push(DiscardInfo {
                     tile,
                     is_tsumogiri,
+                    is_riichi,
                 });
+
+                // 他プレイヤーが捨てた場合、隠し手牌の枚数を更新
+                if relative_idx > 0 {
+                    let other_idx = relative_idx - 1;
+                    self.other_players[other_idx].concealed_count =
+                        self.other_players[other_idx].concealed_count.saturating_sub(1);
+                }
 
                 // 自分が捨てた場合
                 if Some(player) == self.seat_wind {
@@ -244,6 +294,58 @@ impl GameState {
                 self.call_target_tile = None;
                 self.refresh_self_kan_options();
                 self.call_discarder = None;
+
+                // 他プレイヤーが鳴いた場合、副露情報を記録
+                let relative_idx = self.relative_player_index(player);
+                if relative_idx > 0 {
+                    let other_idx = relative_idx - 1;
+                    let other = &mut self.other_players[other_idx];
+                    match call_type {
+                        CallType::Ron => {}
+                        CallType::Kakan => {
+                            if let Some(meld) = other.melds.iter_mut().find(|m| {
+                                m.call_type == CallType::Pon
+                                    && m.tiles.first().map(|t| t.get()) == tiles.first().map(|t| t.get())
+                            }) {
+                                meld.call_type = CallType::Kakan;
+                                meld.tiles = tiles.clone();
+                                // 加カンは手牌1枚減（ポンの3枚→カンの4枚、手牌から1枚使用）
+                                other.concealed_count = other.concealed_count.saturating_sub(1);
+                            } else {
+                                other.melds.push(MeldInfo {
+                                    call_type: call_type.clone(),
+                                    tiles: tiles.clone(),
+                                });
+                                other.concealed_count = other.concealed_count.saturating_sub(1);
+                            }
+                        }
+                        CallType::Ankan => {
+                            other.melds.push(MeldInfo {
+                                call_type: call_type.clone(),
+                                tiles: tiles.clone(),
+                            });
+                            // 暗カンは手牌から4枚使うが、ツモ牌を含む
+                            other.concealed_count = other.concealed_count.saturating_sub(3);
+                        }
+                        CallType::Pon | CallType::Chi => {
+                            other.melds.push(MeldInfo {
+                                call_type: call_type.clone(),
+                                tiles: tiles.clone(),
+                            });
+                            // ポン/チーは手牌から2枚使用（1枚は捨て牌から取る）
+                            // 鳴き後に打牌するので結果として手牌枚数は同じ
+                            // ただし打牌前は手牌が1枚少ない状態
+                            other.concealed_count = other.concealed_count.saturating_sub(2);
+                        }
+                        CallType::Daiminkan => {
+                            other.melds.push(MeldInfo {
+                                call_type: call_type.clone(),
+                                tiles: tiles.clone(),
+                            });
+                            other.concealed_count = other.concealed_count.saturating_sub(3);
+                        }
+                    }
+                }
 
                 // 自分が鳴いた場合、副露情報を保存し打牌待ちへ
                 if Some(player) == self.seat_wind {
@@ -295,6 +397,9 @@ impl GameState {
                 self.scores = scores;
                 self.riichi_sticks = riichi_sticks;
 
+                // 次の打牌をリーチ宣言牌としてマーク
+                self.pending_riichi_player = Some(player);
+
                 // 自分がリーチした場合
                 if Some(player) == self.seat_wind {
                     self.is_riichi = true;
@@ -321,9 +426,11 @@ impl GameState {
                 rank_name,
                 uradora_indicators,
                 riichi_sticks,
+                player_hands,
             } => {
                 self.scores = scores;
                 self.riichi_sticks = 0;
+                self.update_other_player_hands_on_win(&player_hands, winner);
                 let winner_name = self.wind_to_name(winner);
                 let win_type = if loser.is_some() { "ロン" } else { "ツモ" };
                 let loser_text = if let Some(l) = loser {
@@ -389,9 +496,11 @@ impl GameState {
                 reason,
                 tenpai,
                 riichi_sticks,
+                player_hands,
             } => {
                 self.scores = scores;
                 self.riichi_sticks = riichi_sticks;
+                self.update_other_player_hands_on_draw(&player_hands, &tenpai);
                 let reason_text = match reason {
                     DrawReason::Exhaustive => "荒牌流局",
                     DrawReason::FourWinds => "四風連打",
@@ -417,6 +526,48 @@ impl GameState {
                 self.available_calls.clear();
                 self.clear_riichi_selection();
                 self.self_kan_options.clear();
+            }
+        }
+    }
+
+    /// 和了時に他プレイヤーの手牌を更新する（和了者の手牌を公開）
+    fn update_other_player_hands_on_win(&mut self, player_hands: &[PlayerHandInfo], winner: Wind) {
+        for info in player_hands {
+            let relative_idx = self.relative_player_index(info.wind);
+            if relative_idx == 0 {
+                continue; // 自分はスキップ
+            }
+            let other = &mut self.other_players[relative_idx - 1];
+            // 副露を更新
+            other.melds = info.melds.iter().map(|m| MeldInfo {
+                call_type: m.call_type.clone(),
+                tiles: m.tiles.clone(),
+            }).collect();
+            // 和了者の手牌を公開
+            if info.wind == winner {
+                other.hand = info.hand.clone();
+                other.revealed = true;
+            }
+        }
+    }
+
+    /// 流局時に他プレイヤーの手牌を更新する（テンパイ者の手牌を公開）
+    fn update_other_player_hands_on_draw(&mut self, player_hands: &[PlayerHandInfo], tenpai: &[Wind]) {
+        for info in player_hands {
+            let relative_idx = self.relative_player_index(info.wind);
+            if relative_idx == 0 {
+                continue; // 自分はスキップ
+            }
+            let other = &mut self.other_players[relative_idx - 1];
+            // 副露を更新
+            other.melds = info.melds.iter().map(|m| MeldInfo {
+                call_type: m.call_type.clone(),
+                tiles: m.tiles.clone(),
+            }).collect();
+            // テンパイ者の手牌を公開
+            if tenpai.contains(&info.wind) {
+                other.hand = info.hand.clone();
+                other.revealed = true;
             }
         }
     }

--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -7,6 +7,7 @@ use mahjong_core::hand::Hand;
 use mahjong_core::hand_info::hand_analyzer::HandAnalyzer;
 use mahjong_core::hand_info::opened::{OpenFrom, OpenTiles, OpenType};
 use mahjong_core::tile::{Tile, TileType, Wind};
+use mahjong_server::cpu::client::{CpuConfig, CpuLevel, CpuPersonality};
 use mahjong_server::protocol::{AvailableCall, CallType, ClientAction, DrawReason, PlayerHandInfo, ServerEvent};
 
 /// 副露（鳴き）の表示情報
@@ -114,11 +115,79 @@ pub struct GameState {
     pub other_players: [OtherPlayerHand; 3],
     /// リーチ宣言済みで次の打牌がリーチ宣言牌となるプレイヤーの風（一時フラグ）
     pending_riichi_player: Option<Wind>,
+    /// 対局開始前設定
+    pub setup_state: SetupState,
+}
+
+/// 対局開始前の設定画面の状態
+#[derive(Debug, Clone)]
+pub struct SetupState {
+    /// 各CPUの強さ設定（下家, 対面, 上家）
+    pub cpu_levels: [usize; 3],
+    /// 各CPUの性格設定（下家, 対面, 上家）
+    pub cpu_personalities: [usize; 3],
+}
+
+impl SetupState {
+    pub fn new() -> Self {
+        SetupState {
+            cpu_levels: [1, 1, 1],         // 全員 Normal
+            cpu_personalities: [0, 1, 2],  // Balanced, Speedy, HighValue
+        }
+    }
+
+    pub fn level_name(idx: usize) -> &'static str {
+        match idx {
+            0 => "Weak",
+            1 => "Normal",
+            2 => "Strong",
+            _ => "Normal",
+        }
+    }
+
+    pub fn personality_name(idx: usize) -> &'static str {
+        match idx {
+            0 => "Balanced",
+            1 => "Speedy",
+            2 => "HighValue",
+            3 => "Defensive",
+            _ => "Balanced",
+        }
+    }
+
+    pub fn level_count() -> usize { 3 }
+    pub fn personality_count() -> usize { 4 }
+
+    /// 設定からCpuConfigの配列を生成する
+    pub fn build_configs(&self) -> [CpuConfig; 3] {
+        let to_level = |idx: usize| -> CpuLevel {
+            match idx {
+                0 => CpuLevel::Weak,
+                2 => CpuLevel::Strong,
+                _ => CpuLevel::Normal,
+            }
+        };
+        let to_personality = |idx: usize| -> CpuPersonality {
+            match idx {
+                1 => CpuPersonality::Speedy,
+                2 => CpuPersonality::HighValue,
+                3 => CpuPersonality::Defensive,
+                _ => CpuPersonality::Balanced,
+            }
+        };
+        [
+            CpuConfig::new(to_level(self.cpu_levels[0]), to_personality(self.cpu_personalities[0])),
+            CpuConfig::new(to_level(self.cpu_levels[1]), to_personality(self.cpu_personalities[1])),
+            CpuConfig::new(to_level(self.cpu_levels[2]), to_personality(self.cpu_personalities[2])),
+        ]
+    }
 }
 
 /// ゲームフェーズ
 #[derive(Debug, Clone, PartialEq)]
 pub enum GamePhase {
+    /// 対局開始前の設定画面
+    Setup,
     /// ゲーム開始前
     WaitingForStart,
     /// 対局中
@@ -151,7 +220,7 @@ impl GameState {
             riichi_selectable_drawn: false,
             result_message: None,
             is_my_turn: false,
-            phase: GamePhase::WaitingForStart,
+            phase: GamePhase::Setup,
             available_calls: Vec::new(),
             call_target_tile: None,
             call_discarder: None,
@@ -163,6 +232,7 @@ impl GameState {
             selected_would_cause_furiten: false,
             other_players: [OtherPlayerHand::new(), OtherPlayerHand::new(), OtherPlayerHand::new()],
             pending_riichi_player: None,
+            setup_state: SetupState::new(),
         }
     }
 

--- a/crates/mahjong-client/src/main.rs
+++ b/crates/mahjong-client/src/main.rs
@@ -36,44 +36,54 @@ async fn main() {
         eprintln!("警告: 日本語フォントを読み込めませんでした。デフォルトフォントで表示します。");
     }
 
-    let mut adapter = LocalAdapter::new();
+    let mut adapter: Option<LocalAdapter> = None;
     let mut game_state = GameState::new();
-
-    adapter.start_game();
-
-    let events = adapter.poll_events(0);
-    for event in events {
-        game_state.handle_event(event);
-    }
 
     loop {
         clear_background(Color::from_rgba(0, 100, 0, 255));
 
         match game_state.phase {
-            GamePhase::Playing => {
-                let action = game_state.handle_input();
-                if let Some(act) = action {
-                    adapter.send_action(act);
+            GamePhase::Setup => {
+                // 設定画面の入力処理
+                if let Some(configs) = renderer::handle_setup_input(&mut game_state, font.as_ref()) {
+                    // 対局開始
+                    let mut new_adapter = LocalAdapter::with_cpu_configs(configs);
+                    new_adapter.start_game();
+                    let events = new_adapter.poll_events(0);
+                    for event in events {
+                        game_state.handle_event(event);
+                    }
+                    adapter = Some(new_adapter);
                 }
+            }
 
-                adapter.tick();
+            GamePhase::Playing => {
+                if let Some(ref mut adp) = adapter {
+                    let action = game_state.handle_input();
+                    if let Some(act) = action {
+                        adp.send_action(act);
+                    }
 
-                let events = adapter.poll_events(0);
-                for event in events {
-                    game_state.handle_event(event);
+                    adp.tick();
+
+                    let events = adp.poll_events(0);
+                    for event in events {
+                        game_state.handle_event(event);
+                    }
                 }
             }
 
             GamePhase::RoundResult => {
                 if is_mouse_button_pressed(MouseButton::Left) {
-                    if adapter.is_game_over() {
-                        game_state.phase = GamePhase::GameOver;
-                    } else {
-                        adapter.next_round();
-
-                        let events = adapter.poll_events(0);
-                        for event in events {
-                            game_state.handle_event(event);
+                    if let Some(ref mut adp) = adapter {
+                        if adp.is_game_over() {
+                            game_state.phase = GamePhase::GameOver;
+                        } else {
+                            adp.next_round();
+                            let events = adp.poll_events(0);
+                            for event in events {
+                                game_state.handle_event(event);
+                            }
                         }
                     }
                 }
@@ -81,14 +91,9 @@ async fn main() {
 
             GamePhase::GameOver => {
                 if is_mouse_button_pressed(MouseButton::Left) {
-                    adapter = LocalAdapter::new();
+                    // 設定画面に戻る
                     game_state = GameState::new();
-                    adapter.start_game();
-
-                    let events = adapter.poll_events(0);
-                    for event in events {
-                        game_state.handle_event(event);
-                    }
+                    adapter = None;
                 }
             }
 

--- a/crates/mahjong-client/src/renderer.rs
+++ b/crates/mahjong-client/src/renderer.rs
@@ -33,7 +33,6 @@ pub struct TileTextures {
     red_5m: Texture2D,
     red_5p: Texture2D,
     red_5s: Texture2D,
-    #[allow(dead_code)]
     back: Texture2D,
 }
 
@@ -123,6 +122,7 @@ pub fn draw_game(state: &GameState, font: Option<&Font>, tile_textures: &TileTex
         GamePhase::Playing => {
             draw_info_panel(state, font, tile_textures);
             draw_discards(state, font, tile_textures);
+            draw_other_player_hands(state, tile_textures);
             draw_hand(state, font, tile_textures);
             draw_melds(state, tile_textures);
             draw_action_buttons(state, font);
@@ -130,6 +130,7 @@ pub fn draw_game(state: &GameState, font: Option<&Font>, tile_textures: &TileTex
         GamePhase::RoundResult => {
             draw_info_panel(state, font, tile_textures);
             draw_discards(state, font, tile_textures);
+            draw_other_player_hands(state, tile_textures);
             draw_hand(state, font, tile_textures);
             draw_melds(state, tile_textures);
             draw_result(state, font);
@@ -219,17 +220,29 @@ fn draw_info_panel(state: &GameState, font: Option<&Font>, tile_textures: &TileT
 }
 
 fn draw_discards(state: &GameState, font: Option<&Font>, tile_textures: &TileTextures) {
-    let positions: [(f32, f32); 4] = [
-        (400.0, 500.0),
-        (900.0, 300.0),
-        (400.0, 100.0),
-        (100.0, 300.0),
+    // ラベル位置（各プレイヤー） — 中央寄りに配置
+    let label_positions: [(f32, f32); 4] = [
+        (400.0, 500.0),  // 自分（下）
+        (720.0, 300.0),  // 下家（右）— 中央寄り
+        (440.0, 230.0),  // 対面（上）— 中央寄り
+        (260.0, 300.0),  // 上家（左）— 中央寄り
     ];
+
+    let dtw: f32 = 32.0; // 牌の自然な幅
+    let dth: f32 = 44.0; // 牌の自然な高さ
+    // 自分用（回転なし）: グリッド間隔
+    let col_step: f32 = 36.0; // 列方向（牌幅+余白）
+    let row_step: f32 = 46.0; // 行方向（dth=44 + 余白2）
+    // 対面用（180°）: 列間を重ならないように
+    let top_row_step: f32 = 46.0; // 行方向（dth=44 + 余白2）
+    // 上家・下家用（90°回転）: 重ならないグリッド間隔
+    let rot_col_step: f32 = 36.0; // 牌短辺方向（回転後高さ=dtw=32 + 余白4）
+    let rot_row_step: f32 = 46.0; // 牌長辺方向（回転後幅=dth=44 + 余白2）
 
     let my_wind_idx = state.seat_wind.map(|w| w.to_index()).unwrap_or(0);
 
     for player_idx in 0..4 {
-        let (base_x, base_y) = positions[player_idx];
+        let (label_x, label_y) = label_positions[player_idx];
         let discards = &state.discards[player_idx];
         let display_wind = mahjong_core::tile::Wind::from_index(my_wind_idx + player_idx);
         let score = state.scores[player_idx];
@@ -238,23 +251,133 @@ fn draw_discards(state: &GameState, font: Option<&Font>, tile_textures: &TileTex
         draw_jp_text(
             font,
             &label,
-            base_x,
-            base_y - 5.0,
+            label_x,
+            label_y - 5.0,
             SMALL_FONT,
             Color::new(0.8, 0.8, 0.8, 1.0),
         );
 
+        // リーチ宣言牌を考慮した位置計算
+        // リーチ牌は90°追加回転するため、占有スペースが変わる。
+        // 各プレイヤーのベース回転に+90°して描画し、グリッド上のオフセットを調整する。
+        let mut col_offset: f32 = 0.0; // 列方向の累積オフセット
+        let mut current_row: usize = 0;
+
         for (i, discard) in discards.iter().enumerate() {
             let col = i % 6;
             let row = i / 6;
-            let x = base_x + col as f32 * 36.0;
-            let y = base_y + row as f32 * 30.0;
             let tint = if discard.is_tsumogiri {
                 Color::new(0.72, 0.72, 0.72, 1.0)
             } else {
                 WHITE
             };
-            draw_tile_sprite(tile_textures.for_tile(&discard.tile), x, y, 32.0, 44.0, tint);
+
+            // 行が変わったらオフセットをリセット
+            if row != current_row {
+                col_offset = 0.0;
+                current_row = row;
+            }
+
+            match player_idx {
+                0 => {
+                    // 自分: 左→右、行は下方向。通常は回転なし
+                    if discard.is_riichi {
+                        // リーチ牌: 90°回転（横倒し）
+                        // 横倒し牌の見た目: 幅=dth(44), 高さ=dtw(32)
+                        // 縦方向のセンタリング: (dth - dtw) / 2 = 6px 下にずらす
+                        let x = label_x + col_offset;
+                        let y = label_y + row as f32 * row_step + (dth - dtw) / 2.0;
+                        draw_tile_sprite_rotated(
+                            tile_textures.for_tile(&discard.tile),
+                            x, y, dtw, dth, tint,
+                            std::f32::consts::FRAC_PI_2,
+                        );
+                        col_offset += dth + 4.0; // 横倒し牌は幅=dth
+                    } else {
+                        let x = label_x + col_offset;
+                        let y = label_y + row as f32 * row_step;
+                        draw_tile_sprite(
+                            tile_textures.for_tile(&discard.tile),
+                            x, y, dtw, dth, tint,
+                        );
+                        col_offset += col_step;
+                    }
+                }
+                1 => {
+                    // 下家（右）: 6枚ずつ縦に、下→上に並べる。-90°回転
+                    // リーチ牌はさらに90°回転（合計-180°ではなく0°相当＝正立横倒し）
+                    if discard.is_riichi {
+                        // リーチ牌: 0°（-90°+90°）で横倒し
+                        // 通常の-90°牌の見た目: 幅=dth(44), 高さ=dtw(32)
+                        // リーチ牌は正立: 幅=dtw(32), 高さ=dth(44)
+                        // 横方向のセンタリング: (dth - dtw) / 2 = 6px
+                        let vx = label_x + row as f32 * rot_row_step + (dth - dtw) / 2.0;
+                        let vy = label_y + (5 - col) as f32 * rot_col_step - col_offset;
+                        draw_tile_sprite_rotated(
+                            tile_textures.for_tile(&discard.tile),
+                            vx, vy, dtw, dth, tint,
+                            0.0, // -90° + 90° = 0°
+                        );
+                        col_offset += dth - rot_col_step + 4.0; // 高さ差分を補正
+                    } else {
+                        let vx = label_x + row as f32 * rot_row_step;
+                        let vy = label_y + (5 - col) as f32 * rot_col_step - col_offset;
+                        draw_tile_sprite_rotated(
+                            tile_textures.for_tile(&discard.tile),
+                            vx, vy, dtw, dth, tint,
+                            -std::f32::consts::FRAC_PI_2,
+                        );
+                    }
+                }
+                2 => {
+                    // 対面（上）: 右→左に並べる。180°回転
+                    // リーチ牌はさらに90°回転（合計270°= -90°）
+                    if discard.is_riichi {
+                        // 横倒し牌の見た目: 幅=dth(44), 高さ=dtw(32)
+                        let x = label_x + (5 - col) as f32 * col_step - col_offset;
+                        let y = label_y - row as f32 * top_row_step - (dth - dtw) / 2.0;
+                        draw_tile_sprite_rotated(
+                            tile_textures.for_tile(&discard.tile),
+                            x, y, dtw, dth, tint,
+                            -std::f32::consts::FRAC_PI_2, // 180° + 90° = 270° = -90°
+                        );
+                        col_offset += dth - col_step + 4.0; // 幅差分を補正
+                    } else {
+                        let x = label_x + (5 - col) as f32 * col_step - col_offset;
+                        let y = label_y - row as f32 * top_row_step;
+                        draw_tile_sprite_rotated(
+                            tile_textures.for_tile(&discard.tile),
+                            x, y, dtw, dth, tint,
+                            std::f32::consts::PI,
+                        );
+                    }
+                }
+                3 => {
+                    // 上家（左）: 6枚ずつ縦に、上→下に並べる。90°回転
+                    // リーチ牌はさらに90°回転（合計180°）
+                    if discard.is_riichi {
+                        // リーチ牌: 180°（90°+90°）
+                        // 横方向のセンタリング: (dth - dtw) / 2
+                        let vx = label_x - row as f32 * rot_row_step - (dth - dtw) / 2.0;
+                        let vy = label_y + col as f32 * rot_col_step + col_offset;
+                        draw_tile_sprite_rotated(
+                            tile_textures.for_tile(&discard.tile),
+                            vx, vy, dtw, dth, tint,
+                            std::f32::consts::PI, // 90° + 90° = 180°
+                        );
+                        col_offset += dth - rot_col_step + 4.0; // 高さ差分を補正
+                    } else {
+                        let vx = label_x - row as f32 * rot_row_step;
+                        let vy = label_y + col as f32 * rot_col_step + col_offset;
+                        draw_tile_sprite_rotated(
+                            tile_textures.for_tile(&discard.tile),
+                            vx, vy, dtw, dth, tint,
+                            std::f32::consts::FRAC_PI_2,
+                        );
+                    }
+                }
+                _ => {}
+            }
         }
     }
 }
@@ -419,6 +542,202 @@ fn draw_tile_sprite(texture: &Texture2D, x: f32, y: f32, w: f32, h: f32, tint: C
             ..Default::default()
         },
     );
+}
+
+/// 回転付きで牌スプライトを描画する
+///
+/// (vx, vy) は回転後の「見た目上の左上」座標。
+/// テクスチャは常に自然なアスペクト比 (w, h) で描画し、
+/// 回転による描画座標のずれを内部で補正する。
+fn draw_tile_sprite_rotated(
+    texture: &Texture2D,
+    vx: f32,
+    vy: f32,
+    w: f32,
+    h: f32,
+    tint: Color,
+    rotation: f32,
+) {
+    // 90度回転時、バウンディングボックスの左上が (w, h) の矩形中心を基準にずれる。
+    // 回転後の見た目サイズ: 0°/180° → (w, h), ±90° → (h, w)
+    // draw座標 = visual座標 + 補正
+    let is_90 = (rotation.abs() - std::f32::consts::FRAC_PI_2).abs() < 0.01;
+    let (dx, dy) = if is_90 {
+        ((h - w) / 2.0, (w - h) / 2.0)
+    } else {
+        (0.0, 0.0)
+    };
+    let x = vx + dx;
+    let y = vy + dy;
+
+    draw_texture_ex(
+        texture,
+        x,
+        y,
+        tint,
+        DrawTextureParams {
+            dest_size: Some(vec2(w, h)),
+            rotation,
+            pivot: Some(vec2(x + w / 2.0, y + h / 2.0)),
+            ..Default::default()
+        },
+    );
+}
+
+/// 他プレイヤー（CPU）の手牌を描画する
+fn draw_other_player_hands(state: &GameState, tile_textures: &TileTextures) {
+    // 他プレイヤーの手牌サイズ（小さめ）
+    let tw: f32 = 28.0; // 牌の自然な幅
+    let th: f32 = 40.0; // 牌の自然な高さ
+    let meld_gap: f32 = 6.0;
+
+    // 90度回転後の見た目高さ = 自然な幅
+    let rotated_h = tw;
+
+    for other_idx in 0..3 {
+        let relative_idx = other_idx + 1; // 1=下家, 2=対面, 3=上家
+        let other = &state.other_players[other_idx];
+
+        match relative_idx {
+            1 => {
+                // 下家（右側）: 捨て牌の右側、下から上に並べる、90°左回転（-π/2）
+                // 下家の視点: 下=左、上=右。手牌が下、副露が上。
+                let base_x = 1120.0;
+                let base_y = 480.0;
+                let rotation = -std::f32::consts::FRAC_PI_2;
+
+                // 手牌を先に描画（下側から上方向へ）
+                let mut offset = 0.0;
+                if other.revealed {
+                    for tile in &other.hand {
+                        let vy = base_y - offset - rotated_h;
+                        draw_tile_sprite_rotated(
+                            tile_textures.for_tile(tile),
+                            base_x, vy, tw, th, WHITE, rotation,
+                        );
+                        offset += rotated_h + 1.0;
+                    }
+                } else {
+                    for _ in 0..other.concealed_count {
+                        let vy = base_y - offset - rotated_h;
+                        draw_tile_sprite_rotated(
+                            &tile_textures.back,
+                            base_x, vy, tw, th, WHITE, rotation,
+                        );
+                        offset += rotated_h + 1.0;
+                    }
+                }
+
+                // 副露を手牌の上側に描画
+                if !other.melds.is_empty() {
+                    offset += meld_gap;
+                }
+                for meld in &other.melds {
+                    for tile in &meld.tiles {
+                        let vy = base_y - offset - rotated_h;
+                        draw_tile_sprite_rotated(
+                            tile_textures.for_tile(tile),
+                            base_x, vy, tw, th, WHITE, rotation,
+                        );
+                        offset += rotated_h + 1.0;
+                    }
+                    offset += meld_gap;
+                }
+            }
+            2 => {
+                // 対面（上側）: 捨て牌の上側、右から左に並べる、180°回転
+                // 対面の視点: 右=画面左(-x)、左=画面右(+x)。
+                // 手牌が画面右（対面の左）、副露が画面左（対面の右）。
+                let base_x = 860.0;
+                let base_y = 18.0;
+                let rotation = std::f32::consts::PI;
+
+                // 手牌を先に描画（右端から左へ）
+                let mut offset = 0.0;
+                if other.revealed {
+                    for tile in other.hand.iter().rev() {
+                        let vx = base_x - offset - tw;
+                        draw_tile_sprite_rotated(
+                            tile_textures.for_tile(tile),
+                            vx, base_y, tw, th, WHITE, rotation,
+                        );
+                        offset += tw + 1.0;
+                    }
+                } else {
+                    for _ in 0..other.concealed_count {
+                        let vx = base_x - offset - tw;
+                        draw_tile_sprite_rotated(
+                            &tile_textures.back,
+                            vx, base_y, tw, th, WHITE, rotation,
+                        );
+                        offset += tw + 1.0;
+                    }
+                }
+
+                // 副露を手牌の左側（対面から見て右）に描画
+                if !other.melds.is_empty() {
+                    offset += meld_gap;
+                }
+                for meld in &other.melds {
+                    for tile in &meld.tiles {
+                        let vx = base_x - offset - tw;
+                        draw_tile_sprite_rotated(
+                            tile_textures.for_tile(tile),
+                            vx, base_y, tw, th, WHITE, rotation,
+                        );
+                        offset += tw + 1.0;
+                    }
+                    offset += meld_gap;
+                }
+            }
+            3 => {
+                // 上家（左側）: 捨て牌の左側、上から下に並べる、90°右回転（π/2）
+                // 上家の視点: 上=左、下=右。手牌が上（左）、副露が下（右）。
+                let base_x = 20.0;
+                let base_y = 120.0;
+                let rotation = std::f32::consts::FRAC_PI_2;
+
+                // 手牌を先に描画（上から下へ）
+                let mut offset = 0.0;
+                if other.revealed {
+                    for tile in &other.hand {
+                        let vy = base_y + offset;
+                        draw_tile_sprite_rotated(
+                            tile_textures.for_tile(tile),
+                            base_x, vy, tw, th, WHITE, rotation,
+                        );
+                        offset += rotated_h + 1.0;
+                    }
+                } else {
+                    for _ in 0..other.concealed_count {
+                        let vy = base_y + offset;
+                        draw_tile_sprite_rotated(
+                            &tile_textures.back,
+                            base_x, vy, tw, th, WHITE, rotation,
+                        );
+                        offset += rotated_h + 1.0;
+                    }
+                }
+
+                // 副露を手牌の下側（上家から見て右）に描画
+                if !other.melds.is_empty() {
+                    offset += meld_gap;
+                }
+                for meld in &other.melds {
+                    for tile in &meld.tiles {
+                        let vy = base_y + offset;
+                        draw_tile_sprite_rotated(
+                            tile_textures.for_tile(tile),
+                            base_x, vy, tw, th, WHITE, rotation,
+                        );
+                        offset += rotated_h + 1.0;
+                    }
+                    offset += meld_gap;
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 /// 和了ボタンを描画する（ロン・ツモ共通）

--- a/crates/mahjong-client/src/renderer.rs
+++ b/crates/mahjong-client/src/renderer.rs
@@ -4,9 +4,10 @@
 
 use macroquad::prelude::*;
 use mahjong_core::tile::Tile;
+use mahjong_server::cpu::client::CpuConfig;
 use mahjong_server::protocol::AvailableCall;
 
-use crate::game::{GamePhase, GameState};
+use crate::game::{GamePhase, GameState, SetupState};
 
 /// 牌を描画する色
 const TILE_BG: Color = Color::new(1.0, 1.0, 0.9, 1.0);
@@ -116,6 +117,9 @@ fn draw_jp_text(font: Option<&Font>, text: &str, x: f32, y: f32, font_size: u16,
 
 pub fn draw_game(state: &GameState, font: Option<&Font>, tile_textures: &TileTextures) {
     match state.phase {
+        GamePhase::Setup => {
+            draw_setup(state, font);
+        }
         GamePhase::WaitingForStart => {
             draw_jp_text(font, "ゲーム開始中...", 540.0, 400.0, 30, WHITE);
         }
@@ -999,4 +1003,133 @@ fn wind_to_str(wind: mahjong_core::tile::Wind) -> &'static str {
         mahjong_core::tile::Wind::West => "西",
         mahjong_core::tile::Wind::North => "北",
     }
+}
+
+// ========== 設定画面 ==========
+
+/// 設定画面のボタン領域
+struct SetupButton {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+}
+
+impl SetupButton {
+    fn contains(&self, mx: f32, my: f32) -> bool {
+        mx >= self.x && mx < self.x + self.w && my >= self.y && my < self.y + self.h
+    }
+}
+
+/// 設定画面を描画する
+fn draw_setup(state: &GameState, font: Option<&Font>) {
+    let setup = &state.setup_state;
+
+    // 背景パネル
+    draw_rectangle(190.0, 80.0, 900.0, 640.0, Color::new(0.0, 0.0, 0.0, 0.85));
+    draw_rectangle_lines(190.0, 80.0, 900.0, 640.0, 2.0, Color::new(0.5, 0.5, 0.5, 1.0));
+
+    // タイトル
+    draw_jp_text(font, "対局設定", 540.0, 130.0, 36, WHITE);
+
+    let cpu_names = ["下家 (CPU1)", "対面 (CPU2)", "上家 (CPU3)"];
+    let col_x = [250.0, 520.0, 790.0]; // 3列の左端X座標
+
+    for (cpu_idx, &name) in cpu_names.iter().enumerate() {
+        let cx = col_x[cpu_idx];
+        let base_y = 180.0;
+
+        // CPU名（ベースライン基準なので +24 で文字下端を揃える）
+        draw_jp_text(font, name, cx + 30.0, base_y + 24.0, 24, Color::new(1.0, 0.9, 0.3, 1.0));
+
+        // 強さ
+        draw_jp_text(font, "強さ:", cx, base_y + 70.0, FONT_SIZE, Color::new(0.8, 0.8, 0.8, 1.0));
+        for level_idx in 0..SetupState::level_count() {
+            let btn_y = base_y + 80.0 + level_idx as f32 * 42.0;
+            let selected = setup.cpu_levels[cpu_idx] == level_idx;
+            let bg = if selected {
+                Color::new(0.2, 0.5, 0.2, 1.0)
+            } else {
+                Color::new(0.25, 0.25, 0.25, 1.0)
+            };
+            draw_rectangle(cx, btn_y, 200.0, 34.0, bg);
+            draw_rectangle_lines(cx, btn_y, 200.0, 34.0, 1.0, Color::new(0.5, 0.5, 0.5, 1.0));
+            let label = SetupState::level_name(level_idx);
+            // ボタン(34px)内でフォント(20px)を垂直中央: btn_y + (34+20)/2 = btn_y + 24
+            draw_jp_text(font, label, cx + 10.0, btn_y + 24.0, FONT_SIZE, WHITE);
+        }
+
+        // 性格
+        draw_jp_text(font, "性格:", cx, base_y + 230.0, FONT_SIZE, Color::new(0.8, 0.8, 0.8, 1.0));
+        for pers_idx in 0..SetupState::personality_count() {
+            let btn_y = base_y + 240.0 + pers_idx as f32 * 42.0;
+            let selected = setup.cpu_personalities[cpu_idx] == pers_idx;
+            let bg = if selected {
+                Color::new(0.2, 0.3, 0.6, 1.0)
+            } else {
+                Color::new(0.25, 0.25, 0.25, 1.0)
+            };
+            draw_rectangle(cx, btn_y, 200.0, 34.0, bg);
+            draw_rectangle_lines(cx, btn_y, 200.0, 34.0, 1.0, Color::new(0.5, 0.5, 0.5, 1.0));
+            let label = SetupState::personality_name(pers_idx);
+            draw_jp_text(font, label, cx + 10.0, btn_y + 24.0, FONT_SIZE, WHITE);
+        }
+    }
+
+    // 対局開始ボタン
+    let start_btn = SetupButton { x: 490.0, y: 630.0, w: 300.0, h: 56.0 };
+    draw_rectangle(start_btn.x, start_btn.y, start_btn.w, start_btn.h, Color::new(0.6, 0.15, 0.15, 1.0));
+    draw_rectangle_lines(start_btn.x, start_btn.y, start_btn.w, start_btn.h, 2.0, Color::new(0.9, 0.3, 0.3, 1.0));
+    // ボタン(56px)内でフォント(28px)を垂直中央: btn_y + (56+28)/2 = btn_y + 38
+    draw_jp_text(font, "対局開始", start_btn.x + 80.0, start_btn.y + 38.0, 28, WHITE);
+}
+
+/// 設定画面の入力を処理する。対局開始が押された場合 Some(configs) を返す。
+pub fn handle_setup_input(state: &mut GameState, _font: Option<&Font>) -> Option<[CpuConfig; 3]> {
+    if !is_mouse_button_pressed(MouseButton::Left) {
+        return None;
+    }
+
+    let (mx, my) = mouse_position();
+    let setup = &mut state.setup_state;
+    let col_x = [250.0, 520.0, 790.0];
+    let base_y = 180.0;
+
+    for cpu_idx in 0..3 {
+        let cx = col_x[cpu_idx];
+
+        // 強さボタン
+        for level_idx in 0..SetupState::level_count() {
+            let btn = SetupButton {
+                x: cx, y: base_y + 80.0 + level_idx as f32 * 42.0,
+                w: 200.0, h: 34.0,
+            };
+            if btn.contains(mx, my) {
+                setup.cpu_levels[cpu_idx] = level_idx;
+                return None;
+            }
+        }
+
+        // 性格ボタン
+        for pers_idx in 0..SetupState::personality_count() {
+            let btn = SetupButton {
+                x: cx, y: base_y + 240.0 + pers_idx as f32 * 42.0,
+                w: 200.0, h: 34.0,
+            };
+            if btn.contains(mx, my) {
+                setup.cpu_personalities[cpu_idx] = pers_idx;
+                return None;
+            }
+        }
+    }
+
+    // 対局開始ボタン
+    let start_btn = SetupButton { x: 490.0, y: 630.0, w: 300.0, h: 56.0 };
+    if start_btn.contains(mx, my) {
+        let configs = setup.build_configs();
+        state.phase = GamePhase::WaitingForStart;
+        return Some(configs);
+    }
+
+    None
 }

--- a/crates/mahjong-core/src/hand_info/hand_analyzer.rs
+++ b/crates/mahjong-core/src/hand_info/hand_analyzer.rs
@@ -500,6 +500,251 @@ impl HandAnalyzer {
 pub fn has_won(hand: &HandAnalyzer) -> bool {
     hand.shanten == -1
 }
+
+/// 向聴数のみを高速に計算する（ブロック分解のVec割り当てなし）
+///
+/// `HandAnalyzer::new()` と同じ結果を返すが、向聴数の数値のみを返す。
+/// CPU打牌評価など大量に呼び出す箇所で使用する。
+pub fn shanten_number(hand: &Hand) -> i32 {
+    let sp = shanten_seven_pairs(hand);
+    let to = shanten_thirteen_orphans(hand);
+    let nm = shanten_normal(hand);
+    min(min(sp, to), nm)
+}
+
+fn shanten_seven_pairs(hand: &Hand) -> i32 {
+    if !hand.opened().is_empty() {
+        return UNAVAILABLE_SHANTEN;
+    }
+    let t = hand.summarize_tiles();
+    let mut pair: u32 = 0;
+    let mut kind: u32 = 0;
+    for i in 0..Tile::LEN as usize {
+        if t[i] > 0 {
+            kind += 1;
+            if t[i] >= 2 {
+                pair += 1;
+            }
+        }
+    }
+    (7 - pair + if kind < 7 { 7 - kind } else { 0 }) as i32 - 1
+}
+
+fn shanten_thirteen_orphans(hand: &Hand) -> i32 {
+    if !hand.opened().is_empty() {
+        return UNAVAILABLE_SHANTEN;
+    }
+    let to_tiles: [usize; 13] = [
+        Tile::M1 as usize, Tile::M9 as usize,
+        Tile::P1 as usize, Tile::P9 as usize,
+        Tile::S1 as usize, Tile::S9 as usize,
+        Tile::Z1 as usize, Tile::Z2 as usize, Tile::Z3 as usize,
+        Tile::Z4 as usize, Tile::Z5 as usize, Tile::Z6 as usize, Tile::Z7 as usize,
+    ];
+    let t = hand.summarize_tiles();
+    let mut pair: u32 = 0;
+    let mut kind: u32 = 0;
+    for &i in &to_tiles {
+        if t[i] > 0 {
+            kind += 1;
+            if t[i] >= 2 {
+                pair += 1;
+            }
+        }
+    }
+    (14 - kind - if pair > 0 { 1 } else { 0 }) as i32 - 1
+}
+
+fn shanten_normal(hand: &Hand) -> i32 {
+    let mut t = hand.summarize_tiles();
+    let mut best = UNAVAILABLE_SHANTEN;
+
+    // 独立ブロックを先に抽出（カウントのみ）
+    let indep_same3 = count_independent_same3_fast(&mut t);
+    let indep_seq3 = count_independent_seq3_fast(&mut t);
+    let _indep_single = remove_independent_singles(&mut t);
+
+    // 雀頭を抜き出す
+    for i in 0..Tile::LEN as usize {
+        if t[i] >= 2 {
+            t[i] -= 2;
+            shanten_recurse_fast(0, indep_same3, indep_seq3, 0, 0, 1, 0, &mut t, &mut best);
+            t[i] += 2;
+        }
+    }
+    // 雀頭なし
+    shanten_recurse_fast(0, indep_same3, indep_seq3, 0, 0, 0, 0, &mut t, &mut best);
+
+    best
+}
+
+/// 高速再帰: カウンタのみで面子・塔子を探索
+fn shanten_recurse_fast(
+    idx: usize,
+    indep_same3: usize,
+    indep_seq3: usize,
+    same3_count: usize,
+    seq3_count: usize,
+    head: usize,
+    block2_count: usize,
+    t: &mut TileSummarize,
+    best: &mut i32,
+) {
+    // 面子の探索
+    for i in idx..Tile::LEN as usize {
+        // 刻子
+        if t[i] >= 3 {
+            t[i] -= 3;
+            shanten_recurse_fast(i, indep_same3, indep_seq3, same3_count + 1, seq3_count, head, block2_count, t, best);
+            t[i] += 3;
+        }
+        // 順子
+        if i < 27 && i % 9 <= 6 && t[i] >= 1 && t[i + 1] >= 1 && t[i + 2] >= 1 {
+            t[i] -= 1;
+            t[i + 1] -= 1;
+            t[i + 2] -= 1;
+            shanten_recurse_fast(i, indep_same3, indep_seq3, same3_count, seq3_count + 1, head, block2_count, t, best);
+            t[i] += 1;
+            t[i + 1] += 1;
+            t[i + 2] += 1;
+        }
+    }
+
+    // 塔子・対子の探索
+    let block3 = indep_same3 + indep_seq3 + same3_count + seq3_count;
+    let mut b2 = block2_count;
+    shanten_recurse2_fast(idx, block3, head, &mut b2, t, best);
+}
+
+/// 塔子・対子の高速再帰
+fn shanten_recurse2_fast(
+    idx: usize,
+    block3: usize,
+    head: usize,
+    block2: &mut usize,
+    t: &mut TileSummarize,
+    best: &mut i32,
+) {
+    // まず現状で向聴数を計算
+    let b2_capped = (*block2).min(4usize.saturating_sub(block3));
+    let shanten = 8i32 - (block3 * 2 + b2_capped + head) as i32;
+    if shanten < *best {
+        *best = shanten;
+    }
+
+    // 枝刈り: これ以上 block2 を増やしても改善しない場合
+    if *block2 >= 4usize.saturating_sub(block3) {
+        return;
+    }
+
+    for i in idx..Tile::LEN as usize {
+        // 対子
+        if t[i] >= 2 {
+            t[i] -= 2;
+            *block2 += 1;
+            shanten_recurse2_fast(i + 1, block3, head, block2, t, best);
+            *block2 -= 1;
+            t[i] += 2;
+        }
+        // 塔子
+        if i < 27 && i % 9 <= 7 && t[i] >= 1 && t[i + 1] >= 1 {
+            t[i] -= 1;
+            t[i + 1] -= 1;
+            *block2 += 1;
+            shanten_recurse2_fast(i, block3, head, block2, t, best);
+            *block2 -= 1;
+            t[i] += 1;
+            t[i + 1] += 1;
+        }
+        // 嵌張
+        if i < 27 && i % 9 <= 6 && t[i] >= 1 && t[i + 1] == 0 && t[i + 2] >= 1 {
+            t[i] -= 1;
+            t[i + 2] -= 1;
+            *block2 += 1;
+            shanten_recurse2_fast(i, block3, head, block2, t, best);
+            *block2 -= 1;
+            t[i] += 1;
+            t[i + 2] += 1;
+        }
+    }
+}
+
+/// 独立した刻子を抽出（カウントのみ返す）
+fn count_independent_same3_fast(t: &mut TileSummarize) -> usize {
+    let mut count = 0;
+    for i in 0..Tile::LEN as usize {
+        if t[i] < 3 {
+            continue;
+        }
+        let is_isolated = if i >= 27 {
+            // 字牌: 常に独立
+            true
+        } else {
+            let pos = i % 9;
+            let base = i - pos;
+            let left2 = if pos >= 2 { t[base + pos - 2] == 0 } else { true };
+            let left1 = if pos >= 1 { t[base + pos - 1] == 0 } else { true };
+            let right1 = if pos <= 7 { t[base + pos + 1] == 0 } else { true };
+            let right2 = if pos <= 6 { t[base + pos + 2] == 0 } else { true };
+            left2 && left1 && right1 && right2
+        };
+        if is_isolated {
+            t[i] -= 3;
+            count += 1;
+        }
+    }
+    count
+}
+
+/// 独立した順子を抽出（カウントのみ返す）
+fn count_independent_seq3_fast(t: &mut TileSummarize) -> usize {
+    let mut count = 0;
+    // 一盃口を先に処理してから通常処理
+    for n in (1u32..=2).rev() {
+        for suit_start in (0..27).step_by(9) {
+            for k in 0..=6usize {
+                let l = suit_start + k;
+                if k >= 2 && t[l - 2] > 0 { continue; }
+                if k >= 1 && t[l - 1] > 0 { continue; }
+                if k <= 5 && t[l + 3] > 0 { continue; }
+                if k <= 4 && t[l + 4] > 0 { continue; }
+                if t[l] == n && t[l + 1] == n && t[l + 2] == n {
+                    t[l] -= n;
+                    t[l + 1] -= n;
+                    t[l + 2] -= n;
+                    count += n as usize;
+                }
+            }
+        }
+    }
+    count
+}
+
+/// 独立した単独牌を除去（カウントのみ返す）
+fn remove_independent_singles(t: &mut TileSummarize) -> usize {
+    let mut count = 0;
+    for i in 0..Tile::LEN as usize {
+        if t[i] != 1 {
+            continue;
+        }
+        let is_isolated = if i >= 27 {
+            true
+        } else {
+            let pos = i % 9;
+            let base = i - pos;
+            let left2 = if pos >= 2 { t[base + pos - 2] == 0 } else { true };
+            let left1 = if pos >= 1 { t[base + pos - 1] == 0 } else { true };
+            let right1 = if pos <= 7 { t[base + pos + 1] == 0 } else { true };
+            let right2 = if pos <= 6 { t[base + pos + 2] == 0 } else { true };
+            left2 && left1 && right1 && right2
+        };
+        if is_isolated {
+            t[i] -= 1;
+            count += 1;
+        }
+    }
+    count
+}
 /// 再帰的にシャンテン数が最小のものを探す
 fn count_normal_shanten_recursively(
     idx: TileType,
@@ -953,5 +1198,28 @@ mod tests {
         let test = Hand::from("123456789m11p 789s 1p");
         assert!(HandAnalyzer::new_by_form(&test, Form::SevenPairs).unwrap().shanten > 0);
         assert!(HandAnalyzer::new_by_form(&test, Form::ThirteenOrphans).unwrap().shanten > 0);
+    }
+
+    /// shanten_number() が HandAnalyzer::new() と同じ結果を返すことを検証
+    #[test]
+    fn shanten_number_matches_full_analyzer() {
+        let test_cases = vec![
+            "226699m99p228s66z 1z",   // 七対子テンパイ
+            "19m19p11s1234567z 5m",   // 国士テンパイ
+            "123m444p789s1112z 2z",   // 通常和了
+            "222333444666s6z 6z",     // 通常和了
+            "1112345678999m 5m",      // 通常和了
+            "1122m3344p5566s7z 7z",   // 七対子和了
+            "19m19p19s1234567z 1m",   // 国士和了
+            "123m456p789s1234z",       // 通常テンパイ（13枚）
+            "147m258p369s1234z",       // 遠い手
+            "333m456p1789s 333z 1s",  // 副露あり
+        ];
+        for s in &test_cases {
+            let hand = Hand::from(*s);
+            let full = HandAnalyzer::new(&hand).unwrap().shanten;
+            let fast = shanten_number(&hand);
+            assert_eq!(full, fast, "shanten mismatch for hand '{s}': full={full}, fast={fast}");
+        }
     }
 }

--- a/crates/mahjong-server/src/cpu/client.rs
+++ b/crates/mahjong-server/src/cpu/client.rs
@@ -5,6 +5,7 @@
 
 use mahjong_core::hand::Hand;
 use mahjong_core::hand_info::hand_analyzer::shanten_number;
+use mahjong_core::hand_info::opened::{OpenFrom, OpenTiles, OpenType};
 use mahjong_core::tile::Tile;
 
 use crate::protocol::{AvailableCall, ClientAction, ServerEvent};
@@ -462,6 +463,27 @@ impl CpuClient {
         None
     }
 
+    /// 既存の副露を OpenTiles に変換する
+    fn build_existing_opened(&self) -> Vec<OpenTiles> {
+        let mut opened = Vec::new();
+        let my_idx = super::state::CpuGameState::wind_to_index(self.state.my_seat_wind);
+        for meld in &self.state.player_melds[my_idx] {
+            if meld.tiles.len() >= 3 {
+                let ot = OpenTiles {
+                    tiles: [meld.tiles[0], meld.tiles[1], meld.tiles[2]],
+                    category: match meld.call_type {
+                        crate::protocol::CallType::Chi => OpenType::Chi,
+                        crate::protocol::CallType::Pon => OpenType::Pon,
+                        _ => OpenType::Kan,
+                    },
+                    from: OpenFrom::Unknown,
+                };
+                opened.push(ot);
+            }
+        }
+        opened
+    }
+
     /// ポンした場合に向聴数が下がるか
     fn call_reduces_shanten_pon(&self, called_tile: Tile) -> bool {
         // 現在の向聴数
@@ -485,7 +507,15 @@ impl CpuClient {
             return false;
         }
 
-        let new_hand = Hand::new(remaining, None);
+        // 既存の副露 + 今回のポンを含めた Hand を作成
+        let mut opened = self.build_existing_opened();
+        opened.push(OpenTiles {
+            tiles: [called_tile, called_tile, called_tile],
+            category: OpenType::Pon,
+            from: OpenFrom::Unknown,
+        });
+
+        let new_hand = Hand::new_with_opened(remaining, opened, None);
         shanten_number(&new_hand) < current_shanten
     }
 
@@ -496,16 +526,24 @@ impl CpuClient {
 
         // チー後の手牌（指定の2枚を除去）
         let mut remaining = self.state.my_hand.clone();
+        let mut chi_tiles_for_meld = Vec::new();
         for &tt in &hand_tiles {
             if let Some(pos) = remaining.iter().position(|t| t.get() == tt) {
-                remaining.remove(pos);
+                chi_tiles_for_meld.push(remaining.remove(pos));
             } else {
                 return false;
             }
         }
 
-        let _ = called_tile; // チーで取得する牌は副露に入るので手牌からは除外済み
-        let new_hand = Hand::new(remaining, None);
+        // 既存の副露 + 今回のチーを含めた Hand を作成
+        let mut opened = self.build_existing_opened();
+        opened.push(OpenTiles {
+            tiles: [called_tile, chi_tiles_for_meld[0], chi_tiles_for_meld[1]],
+            category: OpenType::Chi,
+            from: OpenFrom::Previous,
+        });
+
+        let new_hand = Hand::new_with_opened(remaining, opened, None);
         shanten_number(&new_hand) < current_shanten
     }
 }

--- a/crates/mahjong-server/src/cpu/client.rs
+++ b/crates/mahjong-server/src/cpu/client.rs
@@ -4,7 +4,7 @@
 //! プレイヤーと全く同じプロトコルでサーバとやり取りする。
 
 use mahjong_core::hand::Hand;
-use mahjong_core::hand_info::hand_analyzer::HandAnalyzer;
+use mahjong_core::hand_info::hand_analyzer::shanten_number;
 use mahjong_core::tile::Tile;
 
 use crate::protocol::{AvailableCall, ClientAction, ServerEvent};
@@ -280,10 +280,7 @@ impl CpuClient {
 
             // 捨てた後にテンパイ（shanten == 0）を維持するか
             let hand = Hand::new(remaining, None);
-            let shanten = match HandAnalyzer::new(&hand) {
-                Ok(a) => a.shanten,
-                Err(_) => continue,
-            };
+            let shanten = shanten_number(&hand);
 
             if shanten == 0 {
                 // 安全度で比較
@@ -331,10 +328,8 @@ impl CpuClient {
                         .copied()
                         .collect();
                     let hand = Hand::new(remaining, None);
-                    if let Ok(a) = HandAnalyzer::new(&hand) {
-                        if a.shanten > 0 {
-                            continue; // テンパイが崩れるのでカンしない
-                        }
+                    if shanten_number(&hand) > 0 {
+                        continue; // テンパイが崩れるのでカンしない
                     }
                 }
                 return Some(ClientAction::Kan {
@@ -356,10 +351,7 @@ impl CpuClient {
             all_tiles.push(drawn);
         }
         let hand = Hand::new(all_tiles, None);
-        let shanten = match HandAnalyzer::new(&hand) {
-            Ok(a) => a.shanten,
-            Err(_) => 99,
-        };
+        let shanten = shanten_number(&hand);
 
         // テンパイなら基本的に攻撃
         if shanten <= 0 {
@@ -474,10 +466,7 @@ impl CpuClient {
     fn call_reduces_shanten_pon(&self, called_tile: Tile) -> bool {
         // 現在の向聴数
         let current_hand = Hand::new(self.state.my_hand.clone(), None);
-        let current_shanten = match HandAnalyzer::new(&current_hand) {
-            Ok(a) => a.shanten,
-            Err(_) => return false,
-        };
+        let current_shanten = shanten_number(&current_hand);
 
         // ポン後の手牌（同じ種類の2枚を除去）
         let tt = called_tile.get();
@@ -497,19 +486,13 @@ impl CpuClient {
         }
 
         let new_hand = Hand::new(remaining, None);
-        match HandAnalyzer::new(&new_hand) {
-            Ok(a) => a.shanten < current_shanten,
-            Err(_) => false,
-        }
+        shanten_number(&new_hand) < current_shanten
     }
 
     /// チーした場合に向聴数が下がるか
     fn call_reduces_shanten_chi(&self, called_tile: Tile, hand_tiles: [u32; 2]) -> bool {
         let current_hand = Hand::new(self.state.my_hand.clone(), None);
-        let current_shanten = match HandAnalyzer::new(&current_hand) {
-            Ok(a) => a.shanten,
-            Err(_) => return false,
-        };
+        let current_shanten = shanten_number(&current_hand);
 
         // チー後の手牌（指定の2枚を除去）
         let mut remaining = self.state.my_hand.clone();
@@ -523,10 +506,7 @@ impl CpuClient {
 
         let _ = called_tile; // チーで取得する牌は副露に入るので手牌からは除外済み
         let new_hand = Hand::new(remaining, None);
-        match HandAnalyzer::new(&new_hand) {
-            Ok(a) => a.shanten < current_shanten,
-            Err(_) => false,
-        }
+        shanten_number(&new_hand) < current_shanten
     }
 }
 

--- a/crates/mahjong-server/src/cpu/client.rs
+++ b/crates/mahjong-server/src/cpu/client.rs
@@ -1,0 +1,663 @@
+//! CPUクライアント
+//!
+//! ServerEvent を受信して ClientAction を返す。
+//! プレイヤーと全く同じプロトコルでサーバとやり取りする。
+
+use mahjong_core::hand::Hand;
+use mahjong_core::hand_info::hand_analyzer::HandAnalyzer;
+use mahjong_core::tile::Tile;
+
+use crate::protocol::{AvailableCall, ClientAction, ServerEvent};
+
+use super::evaluator;
+use super::state::CpuGameState;
+
+/// CPUの強さレベル
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CpuLevel {
+    /// 初心者: 向聴数のみ考慮、防御なし、ミスあり
+    Weak,
+    /// 中級者: 有効牌数考慮、基本防御
+    Normal,
+    /// 上級者: 打点考慮、筋/壁/現物の高度な防御
+    Strong,
+}
+
+impl CpuLevel {
+    /// 有効牌数を考慮するか
+    pub fn uses_acceptance_count(&self) -> bool {
+        matches!(self, CpuLevel::Normal | CpuLevel::Strong)
+    }
+
+    /// 打点推定を使うか
+    pub fn uses_value_estimation(&self) -> bool {
+        matches!(self, CpuLevel::Strong)
+    }
+
+    /// 防御戦略を使うか
+    pub fn uses_defense(&self) -> bool {
+        matches!(self, CpuLevel::Normal | CpuLevel::Strong)
+    }
+
+    /// ミスをするか（最善手以外を選ぶ可能性）
+    pub fn should_make_mistake(&self) -> bool {
+        matches!(self, CpuLevel::Weak)
+    }
+}
+
+/// CPUの性格（攻撃スタイル）
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CpuPersonality {
+    /// バランス型
+    Balanced,
+    /// 速攻型（タンヤオ・ピンフ等の早い和了り重視）
+    Speedy,
+    /// 高打点型（面前リーチ・役牌・ドラ重視）
+    HighValue,
+    /// 守備型（安全打優先、放銃回避重視）
+    Defensive,
+}
+
+/// 性格ごとのパラメータ
+#[derive(Debug, Clone)]
+pub struct PersonalityParams {
+    /// 鳴き積極度（0.0=鳴かない, 1.0=積極的に鳴く）
+    pub call_aggressiveness: f64,
+    /// 打点重み（高いほど打点を重視）
+    pub value_weight: f64,
+    /// 速度重み（高いほど早い和了りを重視）
+    pub speed_weight: f64,
+    /// 撤退閾値（高いほど早く撤退する）
+    pub retreat_threshold: f64,
+    /// リーチ積極度（0.0=リーチしない, 1.0=積極的にリーチ）
+    pub riichi_aggressiveness: f64,
+}
+
+/// CPU設定（性格と強さの組み合わせ）
+#[derive(Debug, Clone)]
+pub struct CpuConfig {
+    /// 強さレベル
+    pub level: CpuLevel,
+    /// 性格
+    pub personality: CpuPersonality,
+    /// 性格パラメータ
+    pub params: PersonalityParams,
+}
+
+impl CpuConfig {
+    /// 指定した強さと性格で設定を作成する
+    pub fn new(level: CpuLevel, personality: CpuPersonality) -> Self {
+        let params = PersonalityParams::from_personality(personality);
+        CpuConfig {
+            level,
+            personality,
+            params,
+        }
+    }
+}
+
+/// CPUクライアント: ServerEvent を処理して ClientAction を返す
+pub struct CpuClient {
+    /// CPU設定
+    pub config: CpuConfig,
+    /// ゲーム状態（イベントから構築）
+    pub state: CpuGameState,
+}
+
+impl CpuClient {
+    /// 新しいCPUクライアントを作成する
+    pub fn new(config: CpuConfig) -> Self {
+        CpuClient {
+            config,
+            state: CpuGameState::new(),
+        }
+    }
+
+    /// ServerEvent を処理し、必要なら ClientAction を返す
+    ///
+    /// CPUはこのメソッドだけでサーバとやり取りする。
+    /// 人間プレイヤーが画面を見て操作するのと同様に、
+    /// イベントから情報を得て判断する。
+    pub fn handle_event(&mut self, event: &ServerEvent) -> Option<ClientAction> {
+        // 1. イベントに応じて内部状態を更新
+        self.state.update(event);
+
+        // 2. アクションが必要なイベントなら判断して返す
+        match event {
+            ServerEvent::TileDrawn { .. } => Some(self.decide_on_draw()),
+            ServerEvent::CallAvailable { .. } => Some(self.decide_call()),
+            ServerEvent::HandUpdated { .. } => {
+                if self.state.need_discard_after_call {
+                    self.state.need_discard_after_call = false;
+                    Some(self.decide_discard_after_call())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    /// ツモ後の判断（ツモ和了/リーチ/カン/打牌）
+    fn decide_on_draw(&self) -> ClientAction {
+        // ツモ和了可能なら常に和了する
+        if self.state.can_tsumo {
+            return ClientAction::Tsumo;
+        }
+
+        // リーチ中はツモ切りのみ
+        if self.state.is_riichi {
+            return ClientAction::Discard { tile: None };
+        }
+
+        // リーチ可能か検討
+        if self.state.can_riichi {
+            if self.should_riichi() {
+                let tile = self.select_riichi_tile();
+                return ClientAction::Riichi { tile };
+            }
+        }
+
+        // 暗カン検討
+        if let Some(kan_action) = self.consider_ankan() {
+            return kan_action;
+        }
+
+        // 打牌選択
+        self.decide_discard()
+    }
+
+    /// 打牌を選択する
+    fn decide_discard(&self) -> ClientAction {
+        let candidates = evaluator::evaluate_discards(&self.state, &self.config);
+
+        let attacking = self.should_attack();
+        if let Some(tile) = evaluator::select_best_discard(&candidates, &self.config, attacking) {
+            // ツモ牌と同じならツモ切り
+            if self.state.my_drawn == Some(tile) {
+                ClientAction::Discard { tile: None }
+            } else {
+                ClientAction::Discard { tile: Some(tile) }
+            }
+        } else {
+            // フォールバック: ツモ切り
+            ClientAction::Discard { tile: None }
+        }
+    }
+
+    /// 鳴き後の打牌を選択する
+    fn decide_discard_after_call(&self) -> ClientAction {
+        // 鳴き後はツモ牌がないので、手牌から選ぶ
+        let candidates = evaluator::evaluate_discards(&self.state, &self.config);
+        let attacking = self.should_attack();
+
+        if let Some(tile) = evaluator::select_best_discard(&candidates, &self.config, attacking) {
+            ClientAction::Discard { tile: Some(tile) }
+        } else if let Some(&tile) = self.state.my_hand.last() {
+            ClientAction::Discard { tile: Some(tile) }
+        } else {
+            ClientAction::Discard { tile: None }
+        }
+    }
+
+    /// 鳴き判断（ロン/ポン/チー/パス）
+    fn decide_call(&self) -> ClientAction {
+        let calls = &self.state.pending_calls;
+
+        // ロン可能なら常に和了する
+        if calls.iter().any(|c| matches!(c, AvailableCall::Ron)) {
+            return ClientAction::Ron;
+        }
+
+        // ポン判断
+        if calls.iter().any(|c| matches!(c, AvailableCall::Pon)) {
+            if self.should_pon() {
+                return ClientAction::Pon;
+            }
+        }
+
+        // 大明カン判断
+        if calls.iter().any(|c| matches!(c, AvailableCall::Daiminkan)) {
+            // 基本的にはパス（ドラ増加リスクがある）
+            // Strongレベルかつ高打点型のみ検討
+            if self.config.level == CpuLevel::Strong
+                && self.config.personality == CpuPersonality::HighValue
+            {
+                // 簡易判断: パスしておく（将来拡張可能）
+            }
+        }
+
+        // チー判断
+        for call in calls {
+            if let AvailableCall::Chi { options } = call {
+                if let Some(tiles) = self.select_chi_option(options) {
+                    return ClientAction::Chi { tiles };
+                }
+            }
+        }
+
+        ClientAction::Pass
+    }
+
+    /// リーチすべきか判断する
+    fn should_riichi(&self) -> bool {
+        let params = &self.config.params;
+
+        // リーチ積極度に基づく基本判断
+        // 簡易的に: 積極度 0.5 以上ならリーチ
+        // ただしリーチ者が既にいる場合は慎重に
+        let riichi_count = self.state.player_riichi.iter().filter(|&&r| r).count();
+
+        if riichi_count >= 2 && params.riichi_aggressiveness < 0.8 {
+            return false;
+        }
+
+        if riichi_count >= 1 && params.riichi_aggressiveness < 0.4 {
+            return false;
+        }
+
+        // 残り山が少ない場合はリーチしない
+        if self.state.remaining_tiles < 10 && params.riichi_aggressiveness < 0.9 {
+            return false;
+        }
+
+        params.riichi_aggressiveness >= 0.4
+    }
+
+    /// リーチ宣言牌を選ぶ
+    fn select_riichi_tile(&self) -> Option<Tile> {
+        // テンパイを維持する牌を選ぶ
+        let mut all_tiles = self.state.my_hand.clone();
+        if let Some(drawn) = self.state.my_drawn {
+            all_tiles.push(drawn);
+        }
+
+        let mut best: Option<(Tile, f64)> = None;
+
+        for (i, &tile) in all_tiles.iter().enumerate() {
+            let mut remaining: Vec<Tile> = all_tiles.clone();
+            remaining.remove(i);
+
+            // 捨てた後にテンパイ（shanten == 0）を維持するか
+            let hand = Hand::new(remaining, None);
+            let shanten = match HandAnalyzer::new(&hand) {
+                Ok(a) => a.shanten,
+                Err(_) => continue,
+            };
+
+            if shanten == 0 {
+                // 安全度で比較
+                let safety = super::defense::evaluate_safety(tile, &self.state);
+                if best.is_none() || safety > best.unwrap().1 {
+                    best = Some((tile, safety));
+                }
+            }
+        }
+
+        best.map(|(tile, _)| {
+            // ツモ牌ならNone（ツモ切りリーチ）
+            if self.state.my_drawn == Some(tile) {
+                None
+            } else {
+                Some(tile)
+            }
+        })
+        .unwrap_or(None)
+        // Note: この返り値はOption<Tile>で、Noneの場合ツモ切りリーチ
+    }
+
+    /// 暗カンを検討する
+    fn consider_ankan(&self) -> Option<ClientAction> {
+        let mut all_tiles = self.state.my_hand.clone();
+        if let Some(drawn) = self.state.my_drawn {
+            all_tiles.push(drawn);
+        }
+
+        // 4枚揃っている牌種を探す
+        let mut counts = [0u8; 34];
+        for tile in &all_tiles {
+            counts[tile.get() as usize] += 1;
+        }
+
+        for (tile_type, &count) in counts.iter().enumerate() {
+            if count == 4 {
+                // 暗カンしてもテンパイが崩れないか確認
+                // （簡易的に: Strong以外は常にカン、Strongは向聴数を確認）
+                if self.config.level == CpuLevel::Strong {
+                    // 暗カン後の手牌で向聴数を確認（簡易チェック）
+                    let remaining: Vec<Tile> = all_tiles
+                        .iter()
+                        .filter(|t| t.get() != tile_type as u32)
+                        .copied()
+                        .collect();
+                    let hand = Hand::new(remaining, None);
+                    if let Ok(a) = HandAnalyzer::new(&hand) {
+                        if a.shanten > 0 {
+                            continue; // テンパイが崩れるのでカンしない
+                        }
+                    }
+                }
+                return Some(ClientAction::Kan {
+                    tile_index: tile_type,
+                });
+            }
+        }
+
+        None
+    }
+
+    /// 攻撃続行か撤退かを判断する
+    fn should_attack(&self) -> bool {
+        let params = &self.config.params;
+
+        // 自分の向聴数を計算
+        let mut all_tiles = self.state.my_hand.clone();
+        if let Some(drawn) = self.state.my_drawn {
+            all_tiles.push(drawn);
+        }
+        let hand = Hand::new(all_tiles, None);
+        let shanten = match HandAnalyzer::new(&hand) {
+            Ok(a) => a.shanten,
+            Err(_) => 99,
+        };
+
+        // テンパイなら基本的に攻撃
+        if shanten <= 0 {
+            return true;
+        }
+
+        // リーチ者の数
+        let riichi_count = self.state.player_riichi.iter().filter(|&&r| r).count();
+
+        // 防御を使わないレベルなら常に攻撃
+        if !self.config.level.uses_defense() {
+            return true;
+        }
+
+        // 撤退判断
+        // 2人以上リーチ → 撤退寄り
+        if riichi_count >= 2 && shanten >= 2 {
+            return params.retreat_threshold < 0.3;
+        }
+
+        // 1人リーチ + 自分が2向聴以上 → 性格次第
+        if riichi_count >= 1 && shanten >= 2 {
+            return params.retreat_threshold < 0.5;
+        }
+
+        // 残り山が少ない + 向聴数が高い → 撤退
+        if self.state.remaining_tiles < 15 && shanten >= 2 {
+            return params.retreat_threshold < 0.4;
+        }
+
+        true
+    }
+
+    /// ポンすべきか判断する
+    fn should_pon(&self) -> bool {
+        let params = &self.config.params;
+        let called_tile = match self.state.pending_call_tile {
+            Some(t) => t,
+            None => return false,
+        };
+
+        // Weakレベル: 向聴数が下がるなら常に鳴く
+        if self.config.level == CpuLevel::Weak {
+            return self.call_reduces_shanten_pon(called_tile);
+        }
+
+        // 鳴き積極度が低ければパス
+        if params.call_aggressiveness < 0.3 {
+            return false;
+        }
+
+        // 向聴数が下がるか
+        if !self.call_reduces_shanten_pon(called_tile) {
+            return false;
+        }
+
+        // 鳴いた後に役がありそうか（簡易チェック）
+        let tt = called_tile.get();
+
+        // 役牌のポンは積極的に
+        if is_yakuhai(tt, self.state.my_seat_wind, self.state.prevailing_wind) {
+            return true;
+        }
+
+        // タンヤオ志向: 中張牌のポンは積極的
+        if self.config.personality == CpuPersonality::Speedy && is_tanyao_tile(tt) {
+            return params.call_aggressiveness >= 0.5;
+        }
+
+        // 高打点志向: 門前維持を重視するのでポンは控えめ
+        if self.config.personality == CpuPersonality::HighValue {
+            return false;
+        }
+
+        params.call_aggressiveness >= 0.5
+    }
+
+    /// チーの選択肢から最適なものを選ぶ（鳴くべきでなければNone）
+    fn select_chi_option(&self, options: &[[u32; 2]]) -> Option<[u32; 2]> {
+        let params = &self.config.params;
+
+        // 高打点志向は基本的にチーしない
+        if self.config.personality == CpuPersonality::HighValue {
+            return None;
+        }
+
+        // 鳴き積極度が低ければパス
+        if params.call_aggressiveness < 0.4 {
+            return None;
+        }
+
+        let called_tile = self.state.pending_call_tile?;
+
+        // 各選択肢で向聴数が下がるか確認
+        for &opt in options {
+            if self.call_reduces_shanten_chi(called_tile, opt) {
+                // Speedy型は積極的にチー
+                if self.config.personality == CpuPersonality::Speedy {
+                    return Some(opt);
+                }
+                // 他の型は鳴き積極度で判断
+                if params.call_aggressiveness >= 0.5 {
+                    return Some(opt);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// ポンした場合に向聴数が下がるか
+    fn call_reduces_shanten_pon(&self, called_tile: Tile) -> bool {
+        // 現在の向聴数
+        let current_hand = Hand::new(self.state.my_hand.clone(), None);
+        let current_shanten = match HandAnalyzer::new(&current_hand) {
+            Ok(a) => a.shanten,
+            Err(_) => return false,
+        };
+
+        // ポン後の手牌（同じ種類の2枚を除去）
+        let tt = called_tile.get();
+        let mut remaining = self.state.my_hand.clone();
+        let mut removed = 0;
+        remaining.retain(|t| {
+            if t.get() == tt && removed < 2 {
+                removed += 1;
+                false
+            } else {
+                true
+            }
+        });
+
+        if removed < 2 {
+            return false;
+        }
+
+        let new_hand = Hand::new(remaining, None);
+        match HandAnalyzer::new(&new_hand) {
+            Ok(a) => a.shanten < current_shanten,
+            Err(_) => false,
+        }
+    }
+
+    /// チーした場合に向聴数が下がるか
+    fn call_reduces_shanten_chi(&self, called_tile: Tile, hand_tiles: [u32; 2]) -> bool {
+        let current_hand = Hand::new(self.state.my_hand.clone(), None);
+        let current_shanten = match HandAnalyzer::new(&current_hand) {
+            Ok(a) => a.shanten,
+            Err(_) => return false,
+        };
+
+        // チー後の手牌（指定の2枚を除去）
+        let mut remaining = self.state.my_hand.clone();
+        for &tt in &hand_tiles {
+            if let Some(pos) = remaining.iter().position(|t| t.get() == tt) {
+                remaining.remove(pos);
+            } else {
+                return false;
+            }
+        }
+
+        let _ = called_tile; // チーで取得する牌は副露に入るので手牌からは除外済み
+        let new_hand = Hand::new(remaining, None);
+        match HandAnalyzer::new(&new_hand) {
+            Ok(a) => a.shanten < current_shanten,
+            Err(_) => false,
+        }
+    }
+}
+
+/// 役牌かどうか判定
+fn is_yakuhai(tile_type: u32, seat_wind: mahjong_core::tile::Wind, prevailing_wind: mahjong_core::tile::Wind) -> bool {
+    use mahjong_core::tile::Tile as T;
+    // 三元牌
+    if tile_type == T::Z5 || tile_type == T::Z6 || tile_type == T::Z7 {
+        return true;
+    }
+    // 場風
+    let pw = match prevailing_wind {
+        mahjong_core::tile::Wind::East => T::Z1,
+        mahjong_core::tile::Wind::South => T::Z2,
+        mahjong_core::tile::Wind::West => T::Z3,
+        mahjong_core::tile::Wind::North => T::Z4,
+    };
+    if tile_type == pw {
+        return true;
+    }
+    // 自風
+    let sw = match seat_wind {
+        mahjong_core::tile::Wind::East => T::Z1,
+        mahjong_core::tile::Wind::South => T::Z2,
+        mahjong_core::tile::Wind::West => T::Z3,
+        mahjong_core::tile::Wind::North => T::Z4,
+    };
+    tile_type == sw
+}
+
+/// タンヤオ有効牌（中張牌: 2-8）か
+fn is_tanyao_tile(tile_type: u32) -> bool {
+    if tile_type >= 27 {
+        return false;
+    }
+    let num = tile_type % 9;
+    num >= 1 && num <= 7
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mahjong_core::tile::Wind;
+
+    #[test]
+    fn test_cpu_config_creation() {
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        assert_eq!(config.level, CpuLevel::Normal);
+        assert_eq!(config.personality, CpuPersonality::Balanced);
+    }
+
+    #[test]
+    fn test_level_capabilities() {
+        assert!(!CpuLevel::Weak.uses_acceptance_count());
+        assert!(CpuLevel::Normal.uses_acceptance_count());
+        assert!(CpuLevel::Strong.uses_acceptance_count());
+
+        assert!(!CpuLevel::Weak.uses_value_estimation());
+        assert!(!CpuLevel::Normal.uses_value_estimation());
+        assert!(CpuLevel::Strong.uses_value_estimation());
+
+        assert!(CpuLevel::Weak.should_make_mistake());
+        assert!(!CpuLevel::Normal.should_make_mistake());
+    }
+
+    #[test]
+    fn test_is_yakuhai() {
+        assert!(is_yakuhai(Tile::Z5, Wind::East, Wind::East)); // 白
+        assert!(is_yakuhai(Tile::Z6, Wind::East, Wind::East)); // 發
+        assert!(is_yakuhai(Tile::Z7, Wind::East, Wind::East)); // 中
+        assert!(is_yakuhai(Tile::Z1, Wind::East, Wind::East)); // 東（場風+自風）
+        assert!(!is_yakuhai(Tile::Z2, Wind::East, Wind::East)); // 南（場風でも自風でもない）
+    }
+
+    #[test]
+    fn test_tsumo_action() {
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let mut client = CpuClient::new(config);
+
+        // ゲーム開始
+        client.handle_event(&ServerEvent::GameStarted {
+            seat_wind: Wind::East,
+            hand: vec![
+                Tile::new(Tile::M1), Tile::new(Tile::M2), Tile::new(Tile::M3),
+                Tile::new(Tile::P4), Tile::new(Tile::P5), Tile::new(Tile::P6),
+                Tile::new(Tile::S7), Tile::new(Tile::S8), Tile::new(Tile::S9),
+                Tile::new(Tile::Z1), Tile::new(Tile::Z1), Tile::new(Tile::Z1),
+                Tile::new(Tile::Z2),
+            ],
+            scores: [25000; 4],
+            prevailing_wind: Wind::East,
+            dora_indicators: vec![],
+            round_number: 0,
+            honba: 0,
+            riichi_sticks: 0,
+        });
+
+        // ツモ和了可能なイベント
+        let action = client.handle_event(&ServerEvent::TileDrawn {
+            tile: Tile::new(Tile::Z2),
+            remaining_tiles: 50,
+            can_tsumo: true,
+            can_riichi: false,
+            is_furiten: false,
+        });
+
+        assert!(matches!(action, Some(ClientAction::Tsumo)));
+    }
+
+    #[test]
+    fn test_ron_action() {
+        let config = CpuConfig::new(CpuLevel::Weak, CpuPersonality::Balanced);
+        let mut client = CpuClient::new(config);
+
+        client.handle_event(&ServerEvent::GameStarted {
+            seat_wind: Wind::South,
+            hand: vec![],
+            scores: [25000; 4],
+            prevailing_wind: Wind::East,
+            dora_indicators: vec![],
+            round_number: 0,
+            honba: 0,
+            riichi_sticks: 0,
+        });
+
+        let action = client.handle_event(&ServerEvent::CallAvailable {
+            tile: Tile::new(Tile::M1),
+            discarder: Wind::East,
+            calls: vec![AvailableCall::Ron],
+        });
+
+        assert!(matches!(action, Some(ClientAction::Ron)));
+    }
+}

--- a/crates/mahjong-server/src/cpu/defense.rs
+++ b/crates/mahjong-server/src/cpu/defense.rs
@@ -1,0 +1,279 @@
+//! 守備ロジック
+//!
+//! 牌の安全度を評価する。現物・筋・壁・字牌・端牌の判定。
+
+use mahjong_core::tile::{Tile, TileType};
+
+use super::state::CpuGameState;
+
+/// 牌の安全度を評価する（0.0=最危険, 1.0=最安全）
+///
+/// リーチ者や危険なプレイヤー全員に対する安全度を総合的に評価する。
+pub fn evaluate_safety(tile: Tile, state: &CpuGameState) -> f64 {
+    let my_idx = match state.my_seat_wind {
+        mahjong_core::tile::Wind::East => 0,
+        mahjong_core::tile::Wind::South => 1,
+        mahjong_core::tile::Wind::West => 2,
+        mahjong_core::tile::Wind::North => 3,
+    };
+
+    let mut min_safety = 1.0f64;
+
+    for i in 0..4 {
+        if i == my_idx {
+            continue;
+        }
+
+        // リーチしているプレイヤーに対してのみ安全度を計算
+        // （リーチしていないプレイヤーに対しては安全とみなす）
+        if !state.player_riichi[i] {
+            continue;
+        }
+
+        let safety = evaluate_safety_against_player(tile, &state.all_discards[i], state);
+        min_safety = min_safety.min(safety);
+    }
+
+    min_safety
+}
+
+/// 特定のプレイヤーに対する牌の安全度を評価する
+fn evaluate_safety_against_player(
+    tile: Tile,
+    opponent_discards: &[Tile],
+    state: &CpuGameState,
+) -> f64 {
+    let tt = tile.get();
+
+    // 1. 現物: 相手の捨て牌に同じ牌がある → 完全安全
+    if opponent_discards.iter().any(|d| d.get() == tt) {
+        return 1.0;
+    }
+
+    // 2. 字牌の安全度
+    if tt >= 27 {
+        let visible = state.visible_tile_counts()[tt as usize];
+        return match visible {
+            4 => 1.0,   // 全部見えている（ありえないが念のため）
+            3 => 0.95,  // 残り1枚 → ほぼ安全
+            2 => 0.6,   // 残り2枚
+            1 => 0.4,   // 残り3枚
+            _ => 0.3,   // 1枚も見えていない
+        };
+    }
+
+    // 3. 筋（suji）判定
+    if is_suji(tt, opponent_discards) {
+        return 0.75;
+    }
+
+    // 4. 壁（kabe）判定
+    let visible_counts = state.visible_tile_counts();
+    if is_kabe(tt, &visible_counts) {
+        return 0.7;
+    }
+
+    // 5. 端牌 vs 中張牌
+    let num = tt % 9;
+    match num {
+        0 | 8 => 0.4,       // 1, 9
+        1 | 7 => 0.3,       // 2, 8
+        2 | 6 => 0.2,       // 3, 7
+        _ => 0.15,           // 4, 5, 6
+    }
+}
+
+/// 筋（suji）で安全かどうか判定する
+///
+/// 例: 相手が4mを捨てている → 1m, 7m は筋で比較的安全
+///     相手が5mを捨てている → 2m, 8m は筋
+///     相手が6mを捨てている → 3m, 9m は筋
+fn is_suji(tile_type: TileType, opponent_discards: &[Tile]) -> bool {
+    if tile_type >= 27 {
+        return false; // 字牌に筋はない
+    }
+
+    let suit_start = (tile_type / 9) * 9;
+    let num = tile_type - suit_start; // 0-8
+
+    // 筋のペア: (1,4), (2,5), (3,6), (4,7), (5,8), (6,9)
+    // numは0-indexed: (0,3), (1,4), (2,5), (3,6), (4,7), (5,8)
+    let suji_partner = match num {
+        0 => Some(suit_start + 3), // 1 → 4
+        1 => Some(suit_start + 4), // 2 → 5
+        2 => Some(suit_start + 5), // 3 → 6
+        3 => {
+            // 4 → 1 or 7
+            if opponent_discards.iter().any(|d| d.get() == suit_start + 0)
+                || opponent_discards.iter().any(|d| d.get() == suit_start + 6)
+            {
+                return true;
+            }
+            return false;
+        }
+        4 => {
+            // 5 → 2 or 8
+            if opponent_discards.iter().any(|d| d.get() == suit_start + 1)
+                || opponent_discards.iter().any(|d| d.get() == suit_start + 7)
+            {
+                return true;
+            }
+            return false;
+        }
+        5 => {
+            // 6 → 3 or 9
+            if opponent_discards.iter().any(|d| d.get() == suit_start + 2)
+                || opponent_discards.iter().any(|d| d.get() == suit_start + 8)
+            {
+                return true;
+            }
+            return false;
+        }
+        6 => Some(suit_start + 3), // 7 → 4
+        7 => Some(suit_start + 4), // 8 → 5
+        8 => Some(suit_start + 5), // 9 → 6
+        _ => None,
+    };
+
+    if let Some(partner) = suji_partner {
+        opponent_discards.iter().any(|d| d.get() == partner)
+    } else {
+        false
+    }
+}
+
+/// 壁（kabe）で安全かどうか判定する
+///
+/// ある牌種が場に全て見えている（残り0枚）場合、
+/// その牌を含む順子が成立しないため、隣接牌の危険度が下がる。
+fn is_kabe(tile_type: TileType, visible_counts: &[u8; 34]) -> bool {
+    if tile_type >= 27 {
+        return false; // 字牌に壁はない
+    }
+
+    let suit_start = (tile_type / 9) * 9;
+    let num = tile_type - suit_start; // 0-8
+
+    // この牌を含みうる順子の構成牌を確認
+    // 例: 5m(num=4) → 345m, 456m, 567m の構成牌 3,4,6,7 のいずれかが壁なら安全寄り
+    let mut blocked_patterns = 0;
+    let total_patterns;
+
+    match num {
+        0 => {
+            // 1: 123 のみ。2か3が壁なら安全
+            total_patterns = 1;
+            if visible_counts[(suit_start + 1) as usize] >= 4
+                || visible_counts[(suit_start + 2) as usize] >= 4
+            {
+                blocked_patterns = 1;
+            }
+        }
+        1 => {
+            // 2: 123, 234。
+            total_patterns = 2;
+            if visible_counts[(suit_start + 0) as usize] >= 4
+                || visible_counts[(suit_start + 2) as usize] >= 4
+            {
+                blocked_patterns += 1;
+            }
+            if visible_counts[(suit_start + 2) as usize] >= 4
+                || visible_counts[(suit_start + 3) as usize] >= 4
+            {
+                blocked_patterns += 1;
+            }
+        }
+        7 => {
+            // 8: 789, 678
+            total_patterns = 2;
+            if visible_counts[(suit_start + 8) as usize] >= 4
+                || visible_counts[(suit_start + 6) as usize] >= 4
+            {
+                blocked_patterns += 1;
+            }
+            if visible_counts[(suit_start + 6) as usize] >= 4
+                || visible_counts[(suit_start + 5) as usize] >= 4
+            {
+                blocked_patterns += 1;
+            }
+        }
+        8 => {
+            // 9: 789 のみ。7か8が壁なら安全
+            total_patterns = 1;
+            if visible_counts[(suit_start + 6) as usize] >= 4
+                || visible_counts[(suit_start + 7) as usize] >= 4
+            {
+                blocked_patterns = 1;
+            }
+        }
+        _ => {
+            // 3-7: 3パターン
+            total_patterns = 3;
+            // 前方の順子
+            if num >= 2
+                && (visible_counts[(suit_start + num - 2) as usize] >= 4
+                    || visible_counts[(suit_start + num - 1) as usize] >= 4)
+            {
+                blocked_patterns += 1;
+            }
+            // 中央の順子
+            if num >= 1
+                && num <= 7
+                && (visible_counts[(suit_start + num - 1) as usize] >= 4
+                    || visible_counts[(suit_start + num + 1) as usize] >= 4)
+            {
+                blocked_patterns += 1;
+            }
+            // 後方の順子
+            if num <= 6
+                && (visible_counts[(suit_start + num + 1) as usize] >= 4
+                    || visible_counts[(suit_start + num + 2) as usize] >= 4)
+            {
+                blocked_patterns += 1;
+            }
+        }
+    }
+
+    // 全パターンが壁でブロックされていれば安全
+    blocked_patterns > 0 && blocked_patterns >= total_patterns
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mahjong_core::tile::Tile;
+
+    #[test]
+    fn test_genbutsu() {
+        let discards = vec![Tile::new(Tile::M5)];
+        let state = CpuGameState::new();
+        let safety = evaluate_safety_against_player(Tile::new(Tile::M5), &discards, &state);
+        assert_eq!(safety, 1.0);
+    }
+
+    #[test]
+    fn test_suji_basic() {
+        // 4mが捨てられている → 1m は筋で安全
+        let discards = vec![Tile::new(Tile::M4)];
+        assert!(is_suji(Tile::M1, &discards));
+        assert!(is_suji(Tile::M7, &discards));
+        assert!(!is_suji(Tile::M5, &discards));
+    }
+
+    #[test]
+    fn test_suji_middle() {
+        // 5mが捨てられている → 2m, 8m は筋
+        let discards = vec![Tile::new(Tile::M5)];
+        assert!(is_suji(Tile::M2, &discards));
+        assert!(is_suji(Tile::M8, &discards));
+    }
+
+    #[test]
+    fn test_honor_tile_safety() {
+        let state = CpuGameState::new();
+        let discards: Vec<Tile> = Vec::new();
+        // 字牌で見えていない → 低い安全度
+        let safety = evaluate_safety_against_player(Tile::new(Tile::Z1), &discards, &state);
+        assert!(safety < 0.5);
+    }
+}

--- a/crates/mahjong-server/src/cpu/evaluator.rs
+++ b/crates/mahjong-server/src/cpu/evaluator.rs
@@ -4,7 +4,7 @@
 //! 入力は CpuGameState のみ（サーバ内部にはアクセスしない）。
 
 use mahjong_core::hand::Hand;
-use mahjong_core::hand_info::hand_analyzer::HandAnalyzer;
+use mahjong_core::hand_info::hand_analyzer::shanten_number;
 use mahjong_core::tile::{dora_indicator_to_dora, Tile, TileType, Wind};
 
 use super::client::CpuConfig;
@@ -54,16 +54,13 @@ pub fn evaluate_discards(state: &CpuGameState, config: &CpuConfig) -> Vec<Discar
         let mut remaining: Vec<Tile> = all_tiles.clone();
         remaining.remove(i);
 
-        // HandAnalyzer で向聴数を計算（13枚の手牌として）
+        // 向聴数を高速計算（Vec割り当てなし）
         let hand = Hand::new(remaining.clone(), None);
-        let shanten = match HandAnalyzer::new(&hand) {
-            Ok(a) => a.shanten,
-            Err(_) => 99, // エラー時は最悪値
-        };
+        let shanten = shanten_number(&hand);
 
-        // 有効牌数（受入数）を計算
+        // 有効牌数（受入数）を計算（既知の向聴数を渡して重複計算を回避）
         let acceptance_count = if config.level.uses_acceptance_count() {
-            count_acceptance(&remaining, &visible_counts)
+            count_acceptance(&remaining, &visible_counts, shanten)
         } else {
             0
         };
@@ -96,14 +93,9 @@ pub fn evaluate_discards(state: &CpuGameState, config: &CpuConfig) -> Vec<Discar
 
 /// 有効牌（受入牌）の残り枚数をカウントする
 ///
-/// 13枚の手牌に対して、各牌種を加えた時に向聴数が下がるものをカウント
-fn count_acceptance(hand_tiles: &[Tile], visible_counts: &[u8; 34]) -> u32 {
-    let hand = Hand::new(hand_tiles.to_vec(), None);
-    let current_shanten = match HandAnalyzer::new(&hand) {
-        Ok(a) => a.shanten,
-        Err(_) => return 0,
-    };
-
+/// 13枚の手牌に対して、各牌種を加えた時に向聴数が下がるものをカウント。
+/// `current_shanten` は呼び出し元で既に計算済みの向聴数。
+fn count_acceptance(hand_tiles: &[Tile], visible_counts: &[u8; 34], current_shanten: i32) -> u32 {
     let mut total = 0u32;
     for tile_type in 0..34u32 {
         // 場に4枚全て見えていたら受入不可
@@ -112,12 +104,9 @@ fn count_acceptance(hand_tiles: &[Tile], visible_counts: &[u8; 34]) -> u32 {
             continue;
         }
 
-        // この牌を加えて向聴数が下がるか
+        // この牌を加えて向聴数が下がるか（高速計算）
         let test_hand = Hand::new(hand_tiles.to_vec(), Some(Tile::new(tile_type)));
-        let new_shanten = match HandAnalyzer::new(&test_hand) {
-            Ok(a) => a.shanten,
-            Err(_) => continue,
-        };
+        let new_shanten = shanten_number(&test_hand);
 
         if new_shanten < current_shanten {
             total += remaining as u32;

--- a/crates/mahjong-server/src/cpu/evaluator.rs
+++ b/crates/mahjong-server/src/cpu/evaluator.rs
@@ -1,0 +1,283 @@
+//! 手牌評価
+//!
+//! 各牌を捨てた場合の向聴数・有効牌数・推定打点を計算する。
+//! 入力は CpuGameState のみ（サーバ内部にはアクセスしない）。
+
+use mahjong_core::hand::Hand;
+use mahjong_core::hand_info::hand_analyzer::HandAnalyzer;
+use mahjong_core::tile::{dora_indicator_to_dora, Tile, TileType, Wind};
+
+use super::client::CpuConfig;
+use super::defense;
+use super::state::CpuGameState;
+
+/// 牌1枚を捨てた場合の評価
+#[derive(Debug, Clone)]
+pub struct DiscardCandidate {
+    /// 捨てる牌
+    pub tile: Tile,
+    /// 捨てた後の向聴数
+    pub shanten: i32,
+    /// 有効牌の残り枚数（受入数）
+    pub acceptance_count: u32,
+    /// 推定打点スコア（高いほど良い）
+    pub estimated_value: f64,
+    /// 安全度（0.0=最危険, 1.0=最安全）
+    pub safety: f64,
+}
+
+/// 手牌の全候補牌について評価を行う
+///
+/// hand: 手牌（13枚）+ ツモ牌 の全牌リスト（14枚）
+/// opened: 副露情報を含む Hand（HandAnalyzer に渡す用）
+pub fn evaluate_discards(state: &CpuGameState, config: &CpuConfig) -> Vec<DiscardCandidate> {
+    let mut all_tiles = state.my_hand.clone();
+    if let Some(drawn) = state.my_drawn {
+        all_tiles.push(drawn);
+    }
+
+    if all_tiles.is_empty() {
+        return Vec::new();
+    }
+
+    let visible_counts = state.visible_tile_counts();
+    let mut candidates = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for (i, &tile) in all_tiles.iter().enumerate() {
+        // 同じ牌種は重複評価しない
+        if !seen.insert(tile.get()) {
+            continue;
+        }
+
+        // この牌を捨てた場合の残り手牌を構築
+        let mut remaining: Vec<Tile> = all_tiles.clone();
+        remaining.remove(i);
+
+        // HandAnalyzer で向聴数を計算（13枚の手牌として）
+        let hand = Hand::new(remaining.clone(), None);
+        let shanten = match HandAnalyzer::new(&hand) {
+            Ok(a) => a.shanten,
+            Err(_) => 99, // エラー時は最悪値
+        };
+
+        // 有効牌数（受入数）を計算
+        let acceptance_count = if config.level.uses_acceptance_count() {
+            count_acceptance(&remaining, &visible_counts)
+        } else {
+            0
+        };
+
+        // 推定打点
+        let estimated_value = if config.level.uses_value_estimation() {
+            estimate_hand_value(&remaining, state)
+        } else {
+            0.0
+        };
+
+        // 安全度
+        let safety = if config.level.uses_defense() {
+            defense::evaluate_safety(tile, state)
+        } else {
+            0.5 // 防御を考慮しない場合は中立値
+        };
+
+        candidates.push(DiscardCandidate {
+            tile,
+            shanten,
+            acceptance_count,
+            estimated_value,
+            safety,
+        });
+    }
+
+    candidates
+}
+
+/// 有効牌（受入牌）の残り枚数をカウントする
+///
+/// 13枚の手牌に対して、各牌種を加えた時に向聴数が下がるものをカウント
+fn count_acceptance(hand_tiles: &[Tile], visible_counts: &[u8; 34]) -> u32 {
+    let hand = Hand::new(hand_tiles.to_vec(), None);
+    let current_shanten = match HandAnalyzer::new(&hand) {
+        Ok(a) => a.shanten,
+        Err(_) => return 0,
+    };
+
+    let mut total = 0u32;
+    for tile_type in 0..34u32 {
+        // 場に4枚全て見えていたら受入不可
+        let remaining = 4u8.saturating_sub(visible_counts[tile_type as usize]);
+        if remaining == 0 {
+            continue;
+        }
+
+        // この牌を加えて向聴数が下がるか
+        let test_hand = Hand::new(hand_tiles.to_vec(), Some(Tile::new(tile_type)));
+        let new_shanten = match HandAnalyzer::new(&test_hand) {
+            Ok(a) => a.shanten,
+            Err(_) => continue,
+        };
+
+        if new_shanten < current_shanten {
+            total += remaining as u32;
+        }
+    }
+
+    total
+}
+
+/// 手牌の推定打点を簡易計算する
+fn estimate_hand_value(hand_tiles: &[Tile], state: &CpuGameState) -> f64 {
+    let mut value = 0.0;
+
+    // ドラ枚数
+    let dora_count = count_dora_in_hand(hand_tiles, &state.dora_indicators);
+    value += dora_count as f64 * 2.0;
+
+    // 赤ドラ
+    let red_count = hand_tiles.iter().filter(|t| t.is_red_dora()).count();
+    value += red_count as f64 * 2.0;
+
+    // 役牌（自風・場風・三元牌）の刻子候補
+    let yakuhai_types = get_yakuhai_types(state.my_seat_wind, state.prevailing_wind);
+    for &yh in &yakuhai_types {
+        let count = hand_tiles.iter().filter(|t| t.get() == yh).count();
+        if count >= 2 {
+            value += count as f64 * 1.5;
+        }
+    }
+
+    // タンヤオ可能性（中張牌のみ）
+    let all_tanyao = hand_tiles.iter().all(|t| is_chunchanpai(t.get()));
+    if all_tanyao {
+        value += 1.5;
+    }
+
+    value
+}
+
+/// 手牌中のドラ枚数をカウント
+fn count_dora_in_hand(hand_tiles: &[Tile], dora_indicators: &[Tile]) -> u32 {
+    let mut count = 0u32;
+    for indicator in dora_indicators {
+        let dora_type = dora_indicator_to_dora(indicator.get());
+        count += hand_tiles.iter().filter(|t| t.get() == dora_type).count() as u32;
+    }
+    count
+}
+
+/// 役牌となる牌種のリストを返す
+fn get_yakuhai_types(seat_wind: Wind, prevailing_wind: Wind) -> Vec<TileType> {
+    use mahjong_core::tile::Tile as T;
+    let mut types = vec![T::Z5, T::Z6, T::Z7]; // 白發中
+
+    // 場風
+    let pw = match prevailing_wind {
+        Wind::East => T::Z1,
+        Wind::South => T::Z2,
+        Wind::West => T::Z3,
+        Wind::North => T::Z4,
+    };
+    types.push(pw);
+
+    // 自風
+    let sw = match seat_wind {
+        Wind::East => T::Z1,
+        Wind::South => T::Z2,
+        Wind::West => T::Z3,
+        Wind::North => T::Z4,
+    };
+    if !types.contains(&sw) {
+        types.push(sw);
+    }
+
+    types
+}
+
+/// 中張牌（2-8）かどうか
+fn is_chunchanpai(tile_type: TileType) -> bool {
+    if tile_type >= 27 {
+        return false; // 字牌
+    }
+    let num = tile_type % 9;
+    num >= 1 && num <= 7 // 2-8 (0-indexed: 1-7)
+}
+
+/// 打牌候補から最良の1枚を選ぶ
+pub fn select_best_discard(candidates: &[DiscardCandidate], config: &CpuConfig, attacking: bool) -> Option<Tile> {
+    if candidates.is_empty() {
+        return None;
+    }
+
+    let params = &config.params;
+    let mut scored: Vec<(usize, f64)> = candidates
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            let mut score = 0.0;
+
+            // 向聴数が低いほど良い（負の方向にスコアリング）
+            score -= c.shanten as f64 * 100.0;
+
+            // 有効牌数が多いほど良い
+            score += c.acceptance_count as f64 * params.speed_weight;
+
+            // 推定打点
+            score += c.estimated_value * params.value_weight;
+
+            // 守備中の場合は安全度を重視
+            if !attacking {
+                score += c.safety * params.retreat_threshold * 50.0;
+            }
+
+            (i, score)
+        })
+        .collect();
+
+    // スコア降順でソート
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Weakレベルの場合、確率でランダム選択
+    if config.level.should_make_mistake() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        // 簡易的な疑似ランダム（std のみ使用）
+        let mut hasher = DefaultHasher::new();
+        candidates.len().hash(&mut hasher);
+        if let Some(drawn) = candidates.first() {
+            drawn.tile.get().hash(&mut hasher);
+        }
+        let hash = hasher.finish();
+        // 約30%の確率で2番目以降を選ぶ
+        if hash % 100 < 30 && scored.len() > 1 {
+            let idx = 1 + (hash as usize % (scored.len() - 1).max(1));
+            let idx = idx.min(scored.len() - 1);
+            return Some(candidates[scored[idx].0].tile);
+        }
+    }
+
+    Some(candidates[scored[0].0].tile)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mahjong_core::tile::Tile;
+
+    #[test]
+    fn test_is_chunchanpai() {
+        assert!(!is_chunchanpai(Tile::M1)); // 1m = 端牌
+        assert!(is_chunchanpai(Tile::M2));  // 2m = 中張牌
+        assert!(is_chunchanpai(Tile::M8));  // 8m = 中張牌
+        assert!(!is_chunchanpai(Tile::M9)); // 9m = 端牌
+        assert!(!is_chunchanpai(Tile::Z1)); // 東 = 字牌
+    }
+
+    #[test]
+    fn test_count_dora_in_hand() {
+        let hand = vec![Tile::new(Tile::M2), Tile::new(Tile::M2), Tile::new(Tile::M3)];
+        let indicators = vec![Tile::new(Tile::M1)]; // ドラ表示牌1m → ドラは2m
+        assert_eq!(count_dora_in_hand(&hand, &indicators), 2);
+    }
+}

--- a/crates/mahjong-server/src/cpu/mod.rs
+++ b/crates/mahjong-server/src/cpu/mod.rs
@@ -1,0 +1,10 @@
+//! CPU AI プレイヤーモジュール
+//!
+//! CPUはプレイヤーと同じプロトコル（ServerEvent / ClientAction）で
+//! サーバとやり取りする。サーバ内部に直接アクセスしない。
+
+pub mod client;
+pub mod defense;
+pub mod evaluator;
+pub mod personalities;
+pub mod state;

--- a/crates/mahjong-server/src/cpu/personalities.rs
+++ b/crates/mahjong-server/src/cpu/personalities.rs
@@ -1,0 +1,94 @@
+//! プリセット性格定義
+//!
+//! 各性格タイプに対応するパラメータのプリセットを定義する。
+
+use super::client::{CpuConfig, CpuLevel, CpuPersonality, PersonalityParams};
+
+impl PersonalityParams {
+    /// 性格からパラメータを生成する
+    pub fn from_personality(personality: CpuPersonality) -> Self {
+        match personality {
+            CpuPersonality::Balanced => PersonalityParams {
+                call_aggressiveness: 0.5,
+                value_weight: 0.5,
+                speed_weight: 0.5,
+                retreat_threshold: 0.5,
+                riichi_aggressiveness: 0.6,
+            },
+            CpuPersonality::Speedy => PersonalityParams {
+                call_aggressiveness: 0.8,
+                value_weight: 0.2,
+                speed_weight: 0.9,
+                retreat_threshold: 0.3,
+                riichi_aggressiveness: 0.4,
+            },
+            CpuPersonality::HighValue => PersonalityParams {
+                call_aggressiveness: 0.2,
+                value_weight: 0.9,
+                speed_weight: 0.3,
+                retreat_threshold: 0.4,
+                riichi_aggressiveness: 0.9,
+            },
+            CpuPersonality::Defensive => PersonalityParams {
+                call_aggressiveness: 0.3,
+                value_weight: 0.3,
+                speed_weight: 0.4,
+                retreat_threshold: 0.7,
+                riichi_aggressiveness: 0.5,
+            },
+        }
+    }
+}
+
+/// プリセットCPU設定を取得する
+pub fn preset_configs() -> Vec<CpuConfig> {
+    vec![
+        // 弱いバランス型
+        CpuConfig::new(CpuLevel::Weak, CpuPersonality::Balanced),
+        // 普通の速攻型
+        CpuConfig::new(CpuLevel::Normal, CpuPersonality::Speedy),
+        // 強い高打点型
+        CpuConfig::new(CpuLevel::Strong, CpuPersonality::HighValue),
+        // 強い守備型
+        CpuConfig::new(CpuLevel::Strong, CpuPersonality::Defensive),
+    ]
+}
+
+/// デフォルトの3人CPUプレイヤー設定を返す
+///
+/// 人間プレイヤー以外の3人分の設定。
+/// バランスの取れた混合構成。
+pub fn default_cpu_configs() -> [CpuConfig; 3] {
+    [
+        CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced),
+        CpuConfig::new(CpuLevel::Normal, CpuPersonality::Speedy),
+        CpuConfig::new(CpuLevel::Normal, CpuPersonality::HighValue),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_personality_params() {
+        let balanced = PersonalityParams::from_personality(CpuPersonality::Balanced);
+        assert_eq!(balanced.call_aggressiveness, 0.5);
+
+        let speedy = PersonalityParams::from_personality(CpuPersonality::Speedy);
+        assert!(speedy.call_aggressiveness > balanced.call_aggressiveness);
+        assert!(speedy.speed_weight > balanced.speed_weight);
+    }
+
+    #[test]
+    fn test_preset_configs() {
+        let presets = preset_configs();
+        assert_eq!(presets.len(), 4);
+    }
+
+    #[test]
+    fn test_default_cpu_configs() {
+        let configs = default_cpu_configs();
+        assert_eq!(configs.len(), 3);
+    }
+}

--- a/crates/mahjong-server/src/cpu/state.rs
+++ b/crates/mahjong-server/src/cpu/state.rs
@@ -95,7 +95,7 @@ impl CpuGameState {
     }
 
     /// 風からプレイヤーインデックス（0=東, 1=南, 2=西, 3=北）を取得する
-    fn wind_to_index(wind: Wind) -> usize {
+    pub fn wind_to_index(wind: Wind) -> usize {
         match wind {
             Wind::East => 0,
             Wind::South => 1,

--- a/crates/mahjong-server/src/cpu/state.rs
+++ b/crates/mahjong-server/src/cpu/state.rs
@@ -1,0 +1,436 @@
+//! CPUが保持するゲーム状態
+//!
+//! ServerEvent のストリームだけから構築される、プレイヤー視点のゲーム状態。
+//! プレイヤーが画面から読み取れる情報と同等の情報のみを保持する。
+
+use mahjong_core::tile::{Tile, Wind};
+
+use crate::protocol::{AvailableCall, CallType, ServerEvent};
+
+/// 副露情報（PlayerCalledイベントから構築）
+#[derive(Debug, Clone)]
+pub struct MeldInfo {
+    /// 鳴きの種類
+    pub call_type: CallType,
+    /// 公開された牌
+    pub tiles: Vec<Tile>,
+}
+
+/// CPUが保持するゲーム状態（全て ServerEvent から構築）
+#[derive(Debug, Clone)]
+pub struct CpuGameState {
+    // --- 自分の情報 ---
+    /// 自分の手牌
+    pub my_hand: Vec<Tile>,
+    /// ツモった牌
+    pub my_drawn: Option<Tile>,
+    /// 自分の座席の風
+    pub my_seat_wind: Wind,
+    /// 自分がリーチしているか
+    pub is_riichi: bool,
+
+    // --- TileDrawn イベントで受け取るフラグ ---
+    /// ツモ和了可能か
+    pub can_tsumo: bool,
+    /// リーチ宣言可能か
+    pub can_riichi: bool,
+    /// フリテン状態か
+    pub is_furiten: bool,
+
+    // --- 公開情報（全員分）---
+    /// 各プレイヤーの得点
+    pub scores: [i32; 4],
+    /// 各プレイヤーの捨て牌（風のインデックス順: 東=0, 南=1, 西=2, 北=3）
+    pub all_discards: [Vec<Tile>; 4],
+    /// 各プレイヤーのリーチ状態
+    pub player_riichi: [bool; 4],
+    /// 各プレイヤーの副露情報
+    pub player_melds: [Vec<MeldInfo>; 4],
+    /// ドラ表示牌
+    pub dora_indicators: Vec<Tile>,
+    /// 場風
+    pub prevailing_wind: Wind,
+    /// 山の残り枚数
+    pub remaining_tiles: usize,
+    /// 本場数
+    pub honba: usize,
+    /// 供託リーチ棒
+    pub riichi_sticks: usize,
+
+    // --- 鳴き関連 ---
+    /// 現在利用可能な鳴きアクション
+    pub pending_calls: Vec<AvailableCall>,
+    /// 鳴き対象の牌
+    pub pending_call_tile: Option<Tile>,
+
+    // --- 鳴き後打牌フラグ ---
+    /// 鳴き後に打牌が必要か
+    pub need_discard_after_call: bool,
+}
+
+impl CpuGameState {
+    /// 空の初期状態を作成する
+    pub fn new() -> Self {
+        CpuGameState {
+            my_hand: Vec::new(),
+            my_drawn: None,
+            my_seat_wind: Wind::East,
+            is_riichi: false,
+            can_tsumo: false,
+            can_riichi: false,
+            is_furiten: false,
+            scores: [0; 4],
+            all_discards: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+            player_riichi: [false; 4],
+            player_melds: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+            dora_indicators: Vec::new(),
+            prevailing_wind: Wind::East,
+            remaining_tiles: 0,
+            honba: 0,
+            riichi_sticks: 0,
+            pending_calls: Vec::new(),
+            pending_call_tile: None,
+            need_discard_after_call: false,
+        }
+    }
+
+    /// 風からプレイヤーインデックス（0=東, 1=南, 2=西, 3=北）を取得する
+    fn wind_to_index(wind: Wind) -> usize {
+        match wind {
+            Wind::East => 0,
+            Wind::South => 1,
+            Wind::West => 2,
+            Wind::North => 3,
+        }
+    }
+
+    /// ServerEvent を処理してゲーム状態を更新する
+    pub fn update(&mut self, event: &ServerEvent) {
+        match event {
+            ServerEvent::GameStarted {
+                seat_wind,
+                hand,
+                scores,
+                prevailing_wind,
+                dora_indicators,
+                honba,
+                riichi_sticks,
+                ..
+            } => {
+                // 新しい局の開始: 状態をリセット
+                self.my_hand = hand.clone();
+                self.my_drawn = None;
+                self.my_seat_wind = *seat_wind;
+                self.is_riichi = false;
+                self.can_tsumo = false;
+                self.can_riichi = false;
+                self.is_furiten = false;
+                self.scores = *scores;
+                self.all_discards = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+                self.player_riichi = [false; 4];
+                self.player_melds = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+                self.dora_indicators = dora_indicators.clone();
+                self.prevailing_wind = *prevailing_wind;
+                self.remaining_tiles = 70; // 136 - 14(王牌) - 13*4(配牌) = 70
+                self.honba = *honba;
+                self.riichi_sticks = *riichi_sticks;
+                self.pending_calls.clear();
+                self.pending_call_tile = None;
+                self.need_discard_after_call = false;
+            }
+
+            ServerEvent::TileDrawn {
+                tile,
+                remaining_tiles,
+                can_tsumo,
+                can_riichi,
+                is_furiten,
+            } => {
+                self.my_drawn = Some(*tile);
+                self.remaining_tiles = *remaining_tiles;
+                self.can_tsumo = *can_tsumo;
+                self.can_riichi = *can_riichi;
+                self.is_furiten = *is_furiten;
+                self.need_discard_after_call = false;
+            }
+
+            ServerEvent::OtherPlayerDrew {
+                remaining_tiles, ..
+            } => {
+                self.remaining_tiles = *remaining_tiles;
+            }
+
+            ServerEvent::TileDiscarded {
+                player,
+                tile,
+                is_tsumogiri,
+            } => {
+                let idx = Self::wind_to_index(*player);
+                self.all_discards[idx].push(*tile);
+
+                // 自分が捨てた場合、手牌を正しく更新する
+                if *player == self.my_seat_wind {
+                    if *is_tsumogiri {
+                        // ツモ切り: ツモ牌を捨てるだけ
+                        self.my_drawn = None;
+                    } else {
+                        // 手出し: 手牌から捨てた牌を除去し、ツモ牌を手牌に加える
+                        if let Some(pos) = self.my_hand.iter().position(|t| *t == *tile) {
+                            self.my_hand.remove(pos);
+                        }
+                        if let Some(drawn) = self.my_drawn {
+                            self.my_hand.push(drawn);
+                            self.my_hand.sort();
+                        }
+                        self.my_drawn = None;
+                    }
+                }
+            }
+
+            ServerEvent::CallAvailable {
+                tile, calls, ..
+            } => {
+                self.pending_calls = calls.clone();
+                self.pending_call_tile = Some(*tile);
+            }
+
+            ServerEvent::PlayerCalled {
+                player,
+                call_type,
+                tiles,
+                called_tile,
+                ..
+            } => {
+                let idx = Self::wind_to_index(*player);
+                self.player_melds[idx].push(MeldInfo {
+                    call_type: call_type.clone(),
+                    tiles: tiles.clone(),
+                });
+
+                // 捨て牌から鳴かれた牌を除去する必要はない
+                // （サーバが is_called フラグを管理するので、CPUは捨て牌リストをそのまま保持）
+
+                // 鳴かれた牌が自分の捨て牌にあった場合の処理は不要
+                // （捨て牌はそのまま保持 — 現物判定に使うため）
+
+                self.pending_calls.clear();
+                self.pending_call_tile = None;
+
+                // 自分が鳴いた場合、called_tile の情報を保持
+                // （HandUpdated で手牌が更新される）
+                let _ = called_tile; // 明示的に使わないことを示す
+            }
+
+            ServerEvent::PlayerRiichi {
+                player,
+                scores,
+                riichi_sticks,
+            } => {
+                let idx = Self::wind_to_index(*player);
+                self.player_riichi[idx] = true;
+                self.scores = *scores;
+                self.riichi_sticks = *riichi_sticks;
+                if *player == self.my_seat_wind {
+                    self.is_riichi = true;
+                }
+            }
+
+            ServerEvent::DoraIndicatorsUpdated { dora_indicators } => {
+                self.dora_indicators = dora_indicators.clone();
+            }
+
+            ServerEvent::HandUpdated { hand } => {
+                self.my_hand = hand.clone();
+                self.my_drawn = None;
+                // 鳴き後は打牌が必要
+                self.need_discard_after_call = true;
+            }
+
+            ServerEvent::RoundWon { scores, .. } => {
+                self.scores = *scores;
+            }
+
+            ServerEvent::RoundDraw { scores, .. } => {
+                self.scores = *scores;
+            }
+        }
+    }
+
+    /// 場に見えている牌の枚数を種類ごとにカウントする
+    /// （自分の手牌 + 全員の捨て牌 + 全員の副露）
+    pub fn visible_tile_counts(&self) -> [u8; 34] {
+        let mut counts = [0u8; 34];
+
+        // 自分の手牌
+        for tile in &self.my_hand {
+            counts[tile.get() as usize] += 1;
+        }
+        if let Some(drawn) = self.my_drawn {
+            counts[drawn.get() as usize] += 1;
+        }
+
+        // 全員の捨て牌
+        for discards in &self.all_discards {
+            for tile in discards {
+                counts[tile.get() as usize] += 1;
+            }
+        }
+
+        // 全員の副露
+        for melds in &self.player_melds {
+            for meld in melds {
+                for tile in &meld.tiles {
+                    counts[tile.get() as usize] += 1;
+                }
+            }
+        }
+
+        // ドラ表示牌
+        for tile in &self.dora_indicators {
+            counts[tile.get() as usize] += 1;
+        }
+
+        counts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::ServerEvent;
+    use mahjong_core::tile::{Tile, Wind};
+
+    #[test]
+    fn test_game_started_initializes_state() {
+        let mut state = CpuGameState::new();
+        let hand = vec![
+            Tile::new(Tile::M1),
+            Tile::new(Tile::M2),
+            Tile::new(Tile::M3),
+        ];
+
+        state.update(&ServerEvent::GameStarted {
+            seat_wind: Wind::South,
+            hand: hand.clone(),
+            scores: [25000; 4],
+            prevailing_wind: Wind::East,
+            dora_indicators: vec![Tile::new(Tile::M5)],
+            round_number: 0,
+            honba: 0,
+            riichi_sticks: 0,
+        });
+
+        assert_eq!(state.my_seat_wind, Wind::South);
+        assert_eq!(state.my_hand, hand);
+        assert_eq!(state.scores, [25000; 4]);
+        assert_eq!(state.prevailing_wind, Wind::East);
+        assert_eq!(state.dora_indicators.len(), 1);
+    }
+
+    #[test]
+    fn test_tile_drawn_updates_state() {
+        let mut state = CpuGameState::new();
+        state.update(&ServerEvent::TileDrawn {
+            tile: Tile::new(Tile::P5),
+            remaining_tiles: 50,
+            can_tsumo: false,
+            can_riichi: true,
+            is_furiten: false,
+        });
+
+        assert_eq!(state.my_drawn, Some(Tile::new(Tile::P5)));
+        assert_eq!(state.remaining_tiles, 50);
+        assert!(!state.can_tsumo);
+        assert!(state.can_riichi);
+    }
+
+    #[test]
+    fn test_tile_discarded_updates_discards() {
+        let mut state = CpuGameState::new();
+        state.my_seat_wind = Wind::East;
+
+        state.update(&ServerEvent::TileDiscarded {
+            player: Wind::South,
+            tile: Tile::new(Tile::Z1),
+            is_tsumogiri: false,
+        });
+
+        assert_eq!(state.all_discards[1].len(), 1);
+        assert_eq!(state.all_discards[1][0], Tile::new(Tile::Z1));
+    }
+
+    #[test]
+    fn test_player_riichi_updates_state() {
+        let mut state = CpuGameState::new();
+        state.my_seat_wind = Wind::East;
+
+        state.update(&ServerEvent::PlayerRiichi {
+            player: Wind::East,
+            scores: [24000, 25000, 25000, 25000],
+            riichi_sticks: 1,
+        });
+
+        assert!(state.is_riichi);
+        assert!(state.player_riichi[0]);
+        assert_eq!(state.scores[0], 24000);
+        assert_eq!(state.riichi_sticks, 1);
+    }
+
+    #[test]
+    fn test_visible_tile_counts() {
+        let mut state = CpuGameState::new();
+        state.my_hand = vec![Tile::new(Tile::M1), Tile::new(Tile::M1)];
+        state.all_discards[0] = vec![Tile::new(Tile::M1)];
+
+        let counts = state.visible_tile_counts();
+        assert_eq!(counts[Tile::M1 as usize], 3);
+    }
+
+    #[test]
+    fn test_self_discard_hand_updates_my_hand() {
+        let mut state = CpuGameState::new();
+        state.my_seat_wind = Wind::East;
+        state.my_hand = vec![
+            Tile::new(Tile::M1),
+            Tile::new(Tile::M2),
+            Tile::new(Tile::M3),
+        ];
+        state.my_drawn = Some(Tile::new(Tile::P5));
+
+        // 手出し: M1を捨てる → 手牌からM1が消え、P5が手牌に入る
+        state.update(&ServerEvent::TileDiscarded {
+            player: Wind::East,
+            tile: Tile::new(Tile::M1),
+            is_tsumogiri: false,
+        });
+
+        assert!(state.my_drawn.is_none());
+        assert_eq!(state.my_hand.len(), 3);
+        assert!(!state.my_hand.contains(&Tile::new(Tile::M1)));
+        assert!(state.my_hand.contains(&Tile::new(Tile::P5)));
+    }
+
+    #[test]
+    fn test_self_tsumogiri_keeps_my_hand() {
+        let mut state = CpuGameState::new();
+        state.my_seat_wind = Wind::East;
+        state.my_hand = vec![
+            Tile::new(Tile::M1),
+            Tile::new(Tile::M2),
+            Tile::new(Tile::M3),
+        ];
+        state.my_drawn = Some(Tile::new(Tile::P5));
+
+        // ツモ切り: P5を捨てる → 手牌はそのまま
+        state.update(&ServerEvent::TileDiscarded {
+            player: Wind::East,
+            tile: Tile::new(Tile::P5),
+            is_tsumogiri: true,
+        });
+
+        assert!(state.my_drawn.is_none());
+        assert_eq!(state.my_hand.len(), 3);
+        assert!(state.my_hand.contains(&Tile::new(Tile::M1)));
+        assert!(!state.my_hand.contains(&Tile::new(Tile::P5)));
+    }
+}

--- a/crates/mahjong-server/src/lib.rs
+++ b/crates/mahjong-server/src/lib.rs
@@ -6,3 +6,4 @@ pub mod turn;
 pub mod action;
 pub mod scoring;
 pub mod protocol;
+pub mod cpu;

--- a/crates/mahjong-server/src/protocol.rs
+++ b/crates/mahjong-server/src/protocol.rs
@@ -36,6 +36,26 @@ pub enum CallType {
     Kakan,
 }
 
+/// 局終了時のプレイヤー手牌情報
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlayerHandInfo {
+    /// プレイヤーの風
+    pub wind: Wind,
+    /// 手牌（閉じた部分）
+    pub hand: Vec<Tile>,
+    /// 副露（鳴き）一覧
+    pub melds: Vec<MeldTiles>,
+}
+
+/// 副露の牌情報
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeldTiles {
+    /// 鳴きの種類
+    pub call_type: CallType,
+    /// 副露で公開された牌
+    pub tiles: Vec<Tile>,
+}
+
 /// 利用可能な鳴きアクション（CallAvailableイベント内で使用）
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum AvailableCall {
@@ -172,6 +192,8 @@ pub enum ServerEvent {
         uradora_indicators: Vec<Tile>,
         /// 和了前に場に出ていた供託リーチ棒の本数
         riichi_sticks: usize,
+        /// 全プレイヤーの手牌情報
+        player_hands: Vec<PlayerHandInfo>,
     },
 
     /// 局終了（流局）
@@ -184,6 +206,8 @@ pub enum ServerEvent {
         tenpai: Vec<Wind>,
         /// 現在の供託リーチ棒の本数
         riichi_sticks: usize,
+        /// 全プレイヤーの手牌情報
+        player_hands: Vec<PlayerHandInfo>,
     },
 }
 

--- a/crates/mahjong-server/src/round.rs
+++ b/crates/mahjong-server/src/round.rs
@@ -3,11 +3,11 @@
 //! 1局分のゲーム進行を管理する。
 //! ツモ → 打牌 → 鳴き判定 → 次の手番 のターンフローを制御する。
 
-use mahjong_core::hand_info::hand_analyzer::HandAnalyzer;
+use mahjong_core::hand_info::hand_analyzer::{self, HandAnalyzer};
 use mahjong_core::tile::{Tile, TileType, Wind};
 
 use crate::player::Player;
-use crate::protocol::{AvailableCall, CallType, DrawReason, ServerEvent};
+use crate::protocol::{AvailableCall, CallType, DrawReason, MeldTiles, PlayerHandInfo, ServerEvent};
 use crate::scoring;
 use crate::wall::Wall;
 
@@ -176,6 +176,34 @@ impl Round {
     }
 
     /// 各プレイヤーの点数を返す
+    /// 全プレイヤーの手牌情報を構築する
+    fn build_player_hands(&self) -> Vec<PlayerHandInfo> {
+        self.players
+            .iter()
+            .map(|p| {
+                let melds: Vec<MeldTiles> = p.hand.opened().iter().map(|open| {
+                    let mut tiles: Vec<Tile> = open.tiles.to_vec();
+                    let call_type = match open.category {
+                        mahjong_core::hand_info::opened::OpenType::Chi => CallType::Chi,
+                        mahjong_core::hand_info::opened::OpenType::Pon => CallType::Pon,
+                        mahjong_core::hand_info::opened::OpenType::Kan => CallType::Ankan,
+                    };
+                    // カンの場合は4枚にする
+                    if open.category == mahjong_core::hand_info::opened::OpenType::Kan {
+                        tiles.push(tiles[0]);
+                    }
+                    MeldTiles { call_type, tiles }
+                }).collect();
+
+                PlayerHandInfo {
+                    wind: p.seat_wind,
+                    hand: p.hand.tiles().to_vec(),
+                    melds,
+                }
+            })
+            .collect()
+    }
+
     pub fn get_scores(&self) -> [i32; 4] {
         [
             self.players[0].score,
@@ -192,6 +220,7 @@ impl Round {
     }
 
     /// デバッグ用に自分のツモ時の判定状態を出力する
+    #[cfg(debug_assertions)]
     fn log_draw_diagnostics(&self, player_idx: usize, source: &str, can_tsumo: bool, can_riichi: bool) {
         if player_idx != 0 {
             return;
@@ -298,6 +327,7 @@ impl Round {
 
         // リーチ可能チェック
         let can_riichi = self.can_player_riichi(self.current_player);
+        #[cfg(debug_assertions)]
         self.log_draw_diagnostics(self.current_player, "draw", can_tsumo, can_riichi);
 
         // フリテン判定
@@ -710,6 +740,7 @@ impl Round {
             .map(|(name, han)| (name.to_string(), *han))
             .collect();
         let rank_name = scoring::rank_to_string(&score_result.rank).to_string();
+        let player_hands = self.build_player_hands();
 
         for i in 0..4 {
             self.events.push((
@@ -726,6 +757,7 @@ impl Round {
                     rank_name: rank_name.clone(),
                     uradora_indicators: uradora_indicators.clone(),
                     riichi_sticks,
+                    player_hands: player_hands.clone(),
                 },
             ));
         }
@@ -1067,6 +1099,7 @@ impl Round {
         let remaining = self.wall.remaining();
         let can_tsumo = self.can_tsumo();
         let can_riichi = self.can_player_riichi(player_idx);
+        #[cfg(debug_assertions)]
         self.log_draw_diagnostics(player_idx, "kan_draw", can_tsumo, can_riichi);
 
         let is_furiten = self.players[player_idx].is_furiten();
@@ -1121,10 +1154,7 @@ impl Round {
             }
         }
 
-        match HandAnalyzer::new(&hand) {
-            Ok(analyzer) => analyzer.shanten == 0,
-            Err(_) => false,
-        }
+        hand_analyzer::shanten_number(&hand) == 0
     }
 
     /// プレイヤーがリーチ宣言可能か判定する
@@ -1382,6 +1412,7 @@ impl Round {
             .map(|(name, han)| (name.to_string(), *han))
             .collect();
         let rank_name = scoring::rank_to_string(&score_result.rank).to_string();
+        let player_hands = self.build_player_hands();
 
         // 全プレイヤーに和了イベントを送信
         for i in 0..4 {
@@ -1399,6 +1430,7 @@ impl Round {
                     rank_name: rank_name.clone(),
                     uradora_indicators: uradora_indicators.clone(),
                     riichi_sticks,
+                    player_hands: player_hands.clone(),
                 },
             ));
         }
@@ -1531,6 +1563,7 @@ impl Round {
             .collect();
 
         let dealer_tenpai = tenpai_players.contains(&self.dealer);
+        let player_hands = self.build_player_hands();
 
         self.phase = TurnPhase::RoundOver;
         self.result = Some(RoundResult::ExhaustiveDraw { dealer_tenpai });
@@ -1543,6 +1576,7 @@ impl Round {
                     reason: DrawReason::Exhaustive,
                     tenpai: tenpai_winds.clone(),
                     riichi_sticks: self.riichi_sticks,
+                    player_hands: player_hands.clone(),
                 },
             ));
         }
@@ -1597,6 +1631,7 @@ impl Round {
     /// 特殊流局を宣言する
     fn declare_special_draw(&mut self, reason: DrawReason) {
         let scores = self.get_scores();
+        let player_hands = self.build_player_hands();
         self.phase = TurnPhase::RoundOver;
         self.result = Some(RoundResult::SpecialDraw);
 
@@ -1608,6 +1643,7 @@ impl Round {
                     reason: reason.clone(),
                     tenpai: Vec::new(),
                     riichi_sticks: self.riichi_sticks,
+                    player_hands: player_hands.clone(),
                 },
             ));
         }

--- a/crates/mahjong-server/src/scoring.rs
+++ b/crates/mahjong-server/src/scoring.rs
@@ -5,7 +5,7 @@
 //! 点数移動を適用する。
 
 use mahjong_core::hand::Hand;
-use mahjong_core::hand_info::hand_analyzer::HandAnalyzer;
+use mahjong_core::hand_info::hand_analyzer::{self, HandAnalyzer};
 use mahjong_core::hand_info::status::Status;
 use mahjong_core::scoring::score::{
     calculate_base_points, calculate_score, determine_rank, round_up_to_100, ScoreRank, ScoreResult,
@@ -169,12 +169,7 @@ pub fn get_waiting_tiles(player: &Player) -> Vec<TileType> {
         let mut hand = player.hand.clone();
         hand.set_drawn(Some(Tile::new(tile_type)));
 
-        let analyzer = match HandAnalyzer::new(&hand) {
-            Ok(a) => a,
-            Err(_) => continue,
-        };
-
-        if analyzer.shanten == -1 {
+        if hand_analyzer::shanten_number(&hand) == -1 {
             waiting.push(tile_type);
         }
     }
@@ -338,10 +333,7 @@ pub fn add_dora_to_score(
 
 /// プレイヤーがテンパイしているか判定する（13枚の手牌で）
 pub fn is_tenpai(player: &Player) -> bool {
-    match HandAnalyzer::new(&player.hand) {
-        Ok(analyzer) => analyzer.shanten == 0,
-        Err(_) => false,
-    }
+    hand_analyzer::shanten_number(&player.hand) == 0
 }
 
 /// ロン和了の点数移動を計算する


### PR DESCRIPTION
## Summary
- Implement CPU (AI) players using the same `ServerEvent`/`ClientAction` protocol as human players
- CPU players have configurable **personality** (Balanced, Speedy, HighValue, Defensive) and **strength** (Weak, Normal, Strong)
- Display CPU hands per seat with correct rotation (revealed on win/tenpai, face-down with open melds otherwise)
- Rotate all players' discards to match their seat orientation
- Display riichi declaration tile sideways (90° rotated)
- Add fast `shanten_number()` for ~15x performance improvement in CPU evaluation

## Details

### CPU AI Architecture (`mahjong-server/src/cpu/`)
- **`state.rs`**: `CpuGameState` built entirely from `ServerEvent` stream — same info as human players
- **`client.rs`**: `CpuClient` with `handle_event(ServerEvent) -> Option<ClientAction>` interface
- **`evaluator.rs`**: Hand evaluation using shanten, acceptance count, and estimated value
- **`defense.rs`**: Safety evaluation with genbutsu, suji, and kabe strategies
- **`personalities.rs`**: Tuned parameters per personality type

### Visual Enhancements (`mahjong-client/`)
- CPU hand tiles rendered with correct rotation per seat (left 90°CW, top 180°, right 90°CCW)
- All players' discards rotated to face their seat direction
- Riichi declaration tiles displayed sideways
- Discard row spacing adjusted to eliminate overlap
- Open melds positioned on the right side from each player's perspective

### Performance Optimization
- New `shanten_number()` computes shanten without Vec allocation
- Replaced `HandAnalyzer::new()` with `shanten_number()` in CPU evaluation, riichi checks, and tenpai detection
- Server test suite: 15.66s → 1.06s (~15x faster)

## Test plan
- [x] All 267 tests pass
- [x] `shanten_number()` result matches `HandAnalyzer::new()` verified by dedicated test
- [ ] Manual play testing: CPU players make strategic decisions (not just tsumogiri)
- [ ] Verify CPU hand display on win/tenpai and face-down during play
- [ ] Verify rotated discards and riichi sideways tiles for all seats

Closes #57, #63, #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)