### PR TITLE
Unify shanten calculation logic and introduce ShantenNumber type

### DIFF
--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -676,7 +676,7 @@ impl GameState {
         }
 
         match HandAnalyzer::new(&hand) {
-            Ok(analyzer) => analyzer.shanten.is_tenpai(),
+            Ok(analyzer) => analyzer.shanten.is_ready(),
             Err(_) => false,
         }
     }
@@ -746,7 +746,7 @@ impl GameState {
             Ok(a) => a,
             Err(_) => return false,
         };
-        if !analyzer.shanten.is_tenpai() {
+        if !analyzer.shanten.is_ready() {
             return false;
         }
 

--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -676,7 +676,7 @@ impl GameState {
         }
 
         match HandAnalyzer::new(&hand) {
-            Ok(analyzer) => analyzer.shanten == 0,
+            Ok(analyzer) => analyzer.shanten.is_tenpai(),
             Err(_) => false,
         }
     }
@@ -746,7 +746,7 @@ impl GameState {
             Ok(a) => a,
             Err(_) => return false,
         };
-        if analyzer.shanten != 0 {
+        if !analyzer.shanten.is_tenpai() {
             return false;
         }
 
@@ -756,7 +756,7 @@ impl GameState {
             let mut test_hand = hand.clone();
             test_hand.set_drawn(Some(Tile::new(tile_type)));
             if let Ok(a) = HandAnalyzer::new(&test_hand) {
-                if a.shanten == -1 {
+                if a.shanten.has_won() {
                     waiting.push(tile_type);
                 }
             }

--- a/crates/mahjong-core/src/hand_info/hand_analyzer.rs
+++ b/crates/mahjong-core/src/hand_info/hand_analyzer.rs
@@ -942,24 +942,23 @@ mod tests {
         assert!(HandAnalyzer::new_by_form(&test, Form::ThirteenOrphans).unwrap().shanten > 0);
     }
 
-    /// shanten_number() が HandAnalyzer::new() と同じ結果を返すことを検証
+    /// 様々なパターンの手牌でシャンテン数が正しいことを検証する回帰テスト
     #[rstest::rstest]
-    #[case::seven_pairs_tenpai("226699m99p228s66z 1z")]
-    #[case::thirteen_orphans_tenpai("19m19p11s1234567z 5m")]
-    #[case::normal_win_triplets("123m444p789s1112z 2z")]
-    #[case::normal_win_flush("222333444666s6z 6z")]
-    #[case::normal_win_nine_gates("1112345678999m 5m")]
-    #[case::seven_pairs_win("1122m3344p5566s7z 7z")]
-    #[case::thirteen_orphans_win("19m19p19s1234567z 1m")]
-    #[case::normal_tenpai_13_tiles("123m456p789s1234z")]
-    #[case::far_from_ready("147m258p369s1234z")]
-    #[case::with_open_melds("333m456p1789s 333z 1s")]
-    #[case::leftover_tatsu_at_lower_index("23444p22334567s")]
-    #[case::leftover_tatsu_at_lower_index_with_drawn("23444p22334567s 1z")]
-    fn shanten_number_matches_full_analyzer(#[case] hand_str: &str) {
+    #[case::seven_pairs_tenpai("226699m99p228s66z 1z", 0)]
+    #[case::thirteen_orphans_tenpai("19m19p11s1234567z 5m", 0)]
+    #[case::normal_win_triplets("123m444p789s1112z 2z", -1)]
+    #[case::normal_win_flush("222333444666s6z 6z", -1)]
+    #[case::normal_win_nine_gates("1112345678999m 5m", -1)]
+    #[case::seven_pairs_win("1122m3344p5566s7z 7z", -1)]
+    #[case::thirteen_orphans_win("19m19p19s1234567z 1m", -1)]
+    #[case::normal_13_tiles_with_isolated_honors("123m456p789s1234z", 2)]
+    #[case::far_from_ready("147m258p369s1234z", 6)]
+    #[case::with_open_melds("333m456p1789s 333z 1s", -1)]
+    #[case::leftover_tatsu_at_lower_index("23444p22334567s", 0)]
+    #[case::leftover_tatsu_at_lower_index_with_drawn("23444p22334567s 1z", 0)]
+    fn shanten_regression(#[case] hand_str: &str, #[case] expected: i32) {
         let hand = Hand::from(hand_str);
-        let full = HandAnalyzer::new(&hand).unwrap().shanten;
-        let fast = shanten_number(&hand);
-        assert_eq!(full, fast, "shanten mismatch for hand '{hand_str}': full={full}, fast={fast}");
+        let shanten = HandAnalyzer::new(&hand).unwrap().shanten;
+        assert_eq!(shanten, expected, "hand '{hand_str}': expected {expected}, got {shanten}");
     }
 }

--- a/crates/mahjong-core/src/hand_info/hand_analyzer.rs
+++ b/crates/mahjong-core/src/hand_info/hand_analyzer.rs
@@ -1,4 +1,3 @@
-use anyhow::anyhow;
 use anyhow::Result;
 
 use std::cmp::*;
@@ -229,273 +228,26 @@ impl HandAnalyzer {
 
     /// 通常の役への向聴数を計算する
     fn calc_normal_form(hand: &Hand) -> Result<HandAnalyzer> {
-        let mut t = hand.summarize_tiles();
-        let mut shanten: i32 = UNAVAILABLE_SHANTEN;
-        // 計算用
-        let mut same3: Vec<Same3> = Vec::new();
-        let mut sequential3: Vec<Sequential3> = Vec::new();
-        let mut same2: Vec<Same2> = Vec::new();
-        let mut sequential2: Vec<Sequential2> = Vec::new();
-        // 結果保存用
-        let mut same3_result: Vec<Same3> = Vec::new();
-        let mut sequential3_result: Vec<Sequential3> = Vec::new();
-        let mut same2_result: Vec<Same2> = Vec::new();
-        let mut sequential2_result: Vec<Sequential2> = Vec::new();
-        let mut single_result: Vec<TileType> = Vec::new();
-        // 先に独立した牌を抜き出しておく
-        let mut independent_same3 = HandAnalyzer::count_independent_same_3(&mut t)?;
-        let mut independent_sequential3 = HandAnalyzer::count_independent_sequential_3(&mut t)?;
-        let mut independent_single = HandAnalyzer::count_independent_single(&mut t)?;
-
-        // 雀頭を抜き出す
-        for i in Tile::M1..=Tile::Z7 {
-            if t[i as usize] >= 2 {
-                same2.push(Same2::new(i, i)?);
-                t[i as usize] -= 2;
-                shanten = count_normal_shanten_recursively(
-                    0,
-                    &independent_same3,
-                    &independent_sequential3,
-                    &mut same3,
-                    &mut sequential3,
-                    &mut same2,
-                    &mut sequential2,
-                    &mut t,
-                    &mut shanten,
-                    &mut same3_result,
-                    &mut sequential3_result,
-                    &mut same2_result,
-                    &mut sequential2_result,
-                    &mut single_result,
-                )?;
-                t[i as usize] += 2;
-                same2.pop();
-            }
-        }
-
-        // 雀頭がない場合
-        shanten = count_normal_shanten_recursively(
-            0,
-            &independent_same3,
-            &independent_sequential3,
-            &mut same3,
-            &mut sequential3,
-            &mut same2,
-            &mut sequential2,
-            &mut t,
-            &mut shanten,
-            &mut same3_result,
-            &mut sequential3_result,
-            &mut same2_result,
-            &mut sequential2_result,
-            &mut single_result,
-        )?;
-
-        // 最後に結合
-        same3_result.append(&mut independent_same3);
-        sequential3_result.append(&mut independent_sequential3);
-        single_result.append(&mut independent_single);
-
+        let (shanten, tracking) = calc_normal_shanten::<FullTracking>(hand)?;
+        let FullTracking {
+            same3,
+            sequential3,
+            same2,
+            sequential2,
+            single,
+        } = tracking;
         Ok(HandAnalyzer {
             shanten,
             form: Form::Normal,
-            same3: same3_result,
-            sequential3: sequential3_result,
-            same2: same2_result,
-            sequential2: sequential2_result,
-            single: single_result,
+            same3,
+            sequential3,
+            same2,
+            sequential2,
+            single,
         })
     }
-    /// 独立した（順子になり得ない）刻子の数を返す
-    fn count_independent_same_3(summarized_hand: &mut TileSummarize) -> Result<Vec<Same3>> {
-        let mut result: Vec<Same3> = Vec::new();
-        for i in Tile::M1..=Tile::Z7 {
-            match i {
-                Tile::M1 | Tile::P1 | Tile::S1 => {
-                    if summarized_hand[i as usize] >= 3
-                        && summarized_hand[i as usize + 1] == 0
-                        && summarized_hand[i as usize + 2] == 0
-                    {
-                        summarized_hand[i as usize] -= 3;
-                        result.push(Same3::new(i, i, i)?);
-                    }
-                }
-                Tile::M2 | Tile::P2 | Tile::S2 => {
-                    if summarized_hand[i as usize - 1] == 0
-                        && summarized_hand[i as usize] >= 3
-                        && summarized_hand[i as usize + 1] == 0
-                        && summarized_hand[i as usize + 2] == 0
-                    {
-                        summarized_hand[i as usize] -= 3;
-                        result.push(Same3::new(i, i, i)?);
-                    }
-                }
-                Tile::M3..=Tile::M7 | Tile::P3..=Tile::P7 | Tile::S3..=Tile::S7 => {
-                    if summarized_hand[i as usize - 2] == 0
-                        && summarized_hand[i as usize - 1] == 0
-                        && summarized_hand[i as usize] >= 3
-                        && summarized_hand[i as usize + 1] == 0
-                        && summarized_hand[i as usize + 2] == 0
-                    {
-                        summarized_hand[i as usize] -= 3;
-                        result.push(Same3::new(i, i, i)?);
-                    }
-                }
-                Tile::M8 | Tile::P8 | Tile::S8 => {
-                    if summarized_hand[i as usize - 2] == 0
-                        && summarized_hand[i as usize - 1] == 0
-                        && summarized_hand[i as usize] >= 3
-                        && summarized_hand[i as usize + 1] == 0
-                    {
-                        summarized_hand[i as usize] -= 3;
-                        result.push(Same3::new(i, i, i)?);
-                    }
-                }
-                Tile::M9 | Tile::P9 | Tile::S9 => {
-                    if summarized_hand[i as usize - 2] == 0
-                        && summarized_hand[i as usize - 1] == 0
-                        && summarized_hand[i as usize] >= 3
-                    {
-                        summarized_hand[i as usize] -= 3;
-                        result.push(Same3::new(i, i, i)?);
-                    }
-                }
-                Tile::Z1..=Tile::Z7 => {
-                    if summarized_hand[i as usize] >= 3 {
-                        summarized_hand[i as usize] -= 3;
-                        result.push(Same3::new(i, i, i)?);
-                    }
-                }
-                _ => {
-                    return Err(anyhow!("Unknown tile index found!"));
-                }
-            }
-        }
-        Ok(result)
-    }
-
-    /// 独立した（他の順子と複合し得ない）順子の数を返す
-    /// i.e. xx567xxのような順子
-    fn count_independent_sequential_3(
-        summarized_hand: &mut TileSummarize,
-    ) -> Result<Vec<Sequential3>> {
-        let mut result: Vec<Sequential3> = Vec::new();
-        // 先に一盃口の処理をしてから通常の処理
-        for i in (1..=2).rev() {
-            // 一萬、一筒、一索のインデックス位置
-            for j in (Tile::M1..=Tile::S9).step_by(9) {
-                // 一*～七*のインデックス位置
-                for k in 0..=6 {
-                    let l: usize = (j + k) as usize;
-                    //三*以上のとき-2の牌が存在したらチェックしない
-                    // i.e. チェック下限はxx345
-                    if k >= 2 && summarized_hand[l - 2] > 0 {
-                        continue;
-                    }
-                    //二*以上のとき-1の牌が存在したらチェックしない
-                    // i.e. チェック下限はx234
-                    if k >= 1 && summarized_hand[l - 1] > 0 {
-                        continue;
-                    }
-                    //六*以下で+3の牌が存在したらチェックしない
-                    // i.e. チェック上限は678x
-                    if k <= 5 && summarized_hand[l + 3] > 0 {
-                        continue;
-                    }
-                    //五*以下で+4の牌が存在したらチェックしない
-                    // i.e. チェック上限は567xx
-                    if k <= 4 && summarized_hand[l + 4] > 0 {
-                        continue;
-                    }
-                    if summarized_hand[l] == i
-                        && summarized_hand[l + 1] == i
-                        && summarized_hand[l + 2] == i
-                    {
-                        summarized_hand[l] -= i;
-                        summarized_hand[l + 1] -= i;
-                        summarized_hand[l + 2] -= i;
-                        for _ in 0..i {
-                            result.push(Sequential3::new(
-                                l as TileType,
-                                (l + 1) as TileType,
-                                (l + 2) as TileType,
-                            )?);
-                        }
-                    }
-                }
-            }
-        }
-        Ok(result)
-    }
-
-    /// 独立した（他の順子や刻子などと複合し得ない）牌の数を返す
-    fn count_independent_single(summarized_hand: &mut TileSummarize) -> Result<Vec<TileType>> {
-        let mut result: Vec<TileType> = Vec::new();
-        for i in Tile::M1..=Tile::Z7 {
-            match i {
-                Tile::M1 | Tile::P1 | Tile::S1 => {
-                    if summarized_hand[i as usize] == 1
-                        && summarized_hand[i as usize + 1] == 0
-                        && summarized_hand[i as usize + 2] == 0
-                    {
-                        summarized_hand[i as usize] -= 1;
-                        result.push(i);
-                    }
-                }
-                Tile::M2 | Tile::P2 | Tile::S2 => {
-                    if summarized_hand[i as usize - 1] == 0
-                        && summarized_hand[i as usize] == 1
-                        && summarized_hand[i as usize + 1] == 0
-                        && summarized_hand[i as usize + 2] == 0
-                    {
-                        summarized_hand[i as usize] -= 1;
-                        result.push(i);
-                    }
-                }
-                Tile::M3..=Tile::M7 | Tile::P3..=Tile::P7 | Tile::S3..=Tile::S7 => {
-                    if summarized_hand[i as usize - 2] == 0
-                        && summarized_hand[i as usize - 1] == 0
-                        && summarized_hand[i as usize] == 1
-                        && summarized_hand[i as usize + 1] == 0
-                        && summarized_hand[i as usize + 2] == 0
-                    {
-                        summarized_hand[i as usize] -= 1;
-                        result.push(i);
-                    }
-                }
-                Tile::M8 | Tile::P8 | Tile::S8 => {
-                    if summarized_hand[i as usize - 2] == 0
-                        && summarized_hand[i as usize - 1] == 0
-                        && summarized_hand[i as usize] == 1
-                        && summarized_hand[i as usize + 1] == 0
-                    {
-                        summarized_hand[i as usize] -= 1;
-                        result.push(i);
-                    }
-                }
-                Tile::M9 | Tile::P9 | Tile::S9 => {
-                    if summarized_hand[i as usize - 2] == 0
-                        && summarized_hand[i as usize - 1] == 0
-                        && summarized_hand[i as usize] == 1
-                    {
-                        summarized_hand[i as usize] -= 1;
-                        result.push(i);
-                    }
-                }
-                Tile::Z1..=Tile::Z7 => {
-                    if summarized_hand[i as usize] == 1 {
-                        summarized_hand[i as usize] -= 1;
-                        result.push(i);
-                    }
-                }
-                _ => {
-                    return Err(anyhow!("Unknown tile index found!"));
-                }
-            }
-        }
-        Ok(result)
-    }
 }
+
 /// 和了しているか否か
 pub fn has_won(hand: &HandAnalyzer) -> bool {
     hand.shanten == -1
@@ -508,7 +260,9 @@ pub fn has_won(hand: &HandAnalyzer) -> bool {
 pub fn shanten_number(hand: &Hand) -> i32 {
     let sp = shanten_seven_pairs(hand);
     let to = shanten_thirteen_orphans(hand);
-    let nm = shanten_normal(hand);
+    let nm = calc_normal_shanten::<CountOnly>(hand)
+        .map(|(s, _)| s)
+        .unwrap_or(UNAVAILABLE_SHANTEN);
     min(min(sp, to), nm)
 }
 
@@ -555,47 +309,263 @@ fn shanten_thirteen_orphans(hand: &Hand) -> i32 {
     (14 - kind - if pair > 0 { 1 } else { 0 }) as i32 - 1
 }
 
-fn shanten_normal(hand: &Hand) -> i32 {
+// ============================================================================
+// 共通シャンテン数計算エンジン
+//
+// ShantenAccumulator トレイトにより、ブロック分解を Vec で追跡する FullTracking と
+// カウンタのみで追跡する CountOnly の2つのモードを、同一の再帰ロジックで実行する。
+// Rust のモノモーフィゼーションにより CountOnly ではゼロコストで最適化される。
+// ============================================================================
+
+/// 前処理で抽出された独立ブロックの情報
+trait PreprocessResult {
+    fn same3_count(&self) -> usize;
+    fn seq3_count(&self) -> usize;
+}
+
+/// シャンテン数計算中のブロック蓄積を抽象化するトレイト
+trait ShantenAccumulator: Sized {
+    type Preprocess: PreprocessResult;
+
+    /// 前処理: 独立した刻子・順子・孤立牌を抽出する
+    fn preprocess(t: &mut TileSummarize) -> Result<Self::Preprocess>;
+
+    /// 新しい空の追跡状態を作成する
+    fn new_tracking() -> Self;
+
+    fn push_same3(&mut self, tile: usize);
+    fn pop_same3(&mut self);
+    fn same3_count(&self) -> usize;
+
+    fn push_seq3(&mut self, tile: usize);
+    fn pop_seq3(&mut self);
+    fn seq3_count(&self) -> usize;
+
+    fn push_same2(&mut self, tile: usize);
+    fn pop_same2(&mut self);
+    fn same2_count(&self) -> usize;
+
+    fn push_seq2(&mut self, tile1: usize, tile2: usize);
+    fn pop_seq2(&mut self);
+    fn seq2_count(&self) -> usize;
+
+    /// 新しい最良結果が見つかったときに呼ばれる。現在の状態をスナップショットする。
+    fn snapshot_best(&self, pre: &Self::Preprocess, t: &TileSummarize, head: usize) -> Self;
+
+    /// 最終結果に独立ブロックをマージする
+    fn finalize(self, pre: Self::Preprocess) -> Self;
+}
+
+// --- CountOnly: カウンタのみ（高速版） ---
+
+struct CountOnlyPreprocess {
+    same3: usize,
+    seq3: usize,
+}
+
+impl PreprocessResult for CountOnlyPreprocess {
+    #[inline(always)]
+    fn same3_count(&self) -> usize { self.same3 }
+    #[inline(always)]
+    fn seq3_count(&self) -> usize { self.seq3 }
+}
+
+struct CountOnly {
+    same3: usize,
+    seq3: usize,
+    same2: usize,
+    seq2: usize,
+}
+
+impl ShantenAccumulator for CountOnly {
+    type Preprocess = CountOnlyPreprocess;
+
+    fn preprocess(t: &mut TileSummarize) -> Result<CountOnlyPreprocess> {
+        let same3 = extract_independent_same3(t);
+        let seq3 = extract_independent_seq3(t);
+        let _ = remove_independent_singles(t);
+        Ok(CountOnlyPreprocess { same3, seq3 })
+    }
+
+    #[inline(always)]
+    fn new_tracking() -> Self {
+        CountOnly { same3: 0, seq3: 0, same2: 0, seq2: 0 }
+    }
+
+    #[inline(always)]
+    fn push_same3(&mut self, _tile: usize) { self.same3 += 1; }
+    #[inline(always)]
+    fn pop_same3(&mut self) { self.same3 -= 1; }
+    #[inline(always)]
+    fn same3_count(&self) -> usize { self.same3 }
+
+    #[inline(always)]
+    fn push_seq3(&mut self, _tile: usize) { self.seq3 += 1; }
+    #[inline(always)]
+    fn pop_seq3(&mut self) { self.seq3 -= 1; }
+    #[inline(always)]
+    fn seq3_count(&self) -> usize { self.seq3 }
+
+    #[inline(always)]
+    fn push_same2(&mut self, _tile: usize) { self.same2 += 1; }
+    #[inline(always)]
+    fn pop_same2(&mut self) { self.same2 -= 1; }
+    #[inline(always)]
+    fn same2_count(&self) -> usize { self.same2 }
+
+    #[inline(always)]
+    fn push_seq2(&mut self, _tile1: usize, _tile2: usize) { self.seq2 += 1; }
+    #[inline(always)]
+    fn pop_seq2(&mut self) { self.seq2 -= 1; }
+    #[inline(always)]
+    fn seq2_count(&self) -> usize { self.seq2 }
+
+    #[inline(always)]
+    fn snapshot_best(&self, _pre: &CountOnlyPreprocess, _t: &TileSummarize, _head: usize) -> Self {
+        // カウンタのみなのでスナップショット不要
+        CountOnly { same3: 0, seq3: 0, same2: 0, seq2: 0 }
+    }
+
+    #[inline(always)]
+    fn finalize(self, _pre: CountOnlyPreprocess) -> Self { self }
+}
+
+// --- FullTracking: Vec 追跡（役判定・符計算用） ---
+
+struct FullTrackingPreprocess {
+    same3: Vec<Same3>,
+    seq3: Vec<Sequential3>,
+    singles: Vec<TileType>,
+}
+
+impl PreprocessResult for FullTrackingPreprocess {
+    fn same3_count(&self) -> usize { self.same3.len() }
+    fn seq3_count(&self) -> usize { self.seq3.len() }
+}
+
+struct FullTracking {
+    same3: Vec<Same3>,
+    sequential3: Vec<Sequential3>,
+    same2: Vec<Same2>,
+    sequential2: Vec<Sequential2>,
+    single: Vec<TileType>,
+}
+
+impl ShantenAccumulator for FullTracking {
+    type Preprocess = FullTrackingPreprocess;
+
+    fn preprocess(t: &mut TileSummarize) -> Result<FullTrackingPreprocess> {
+        let same3 = extract_independent_same3_full(t)?;
+        let seq3 = extract_independent_seq3_full(t)?;
+        let singles = extract_independent_singles_full(t)?;
+        Ok(FullTrackingPreprocess { same3, seq3, singles })
+    }
+
+    fn new_tracking() -> Self {
+        FullTracking {
+            same3: Vec::new(),
+            sequential3: Vec::new(),
+            same2: Vec::new(),
+            sequential2: Vec::new(),
+            single: Vec::new(),
+        }
+    }
+
+    fn push_same3(&mut self, tile: usize) {
+        self.same3.push(Same3::new(tile as TileType, tile as TileType, tile as TileType).unwrap());
+    }
+    fn pop_same3(&mut self) { self.same3.pop(); }
+    fn same3_count(&self) -> usize { self.same3.len() }
+
+    fn push_seq3(&mut self, tile: usize) {
+        self.sequential3.push(Sequential3::new(
+            tile as TileType, (tile + 1) as TileType, (tile + 2) as TileType,
+        ).unwrap());
+    }
+    fn pop_seq3(&mut self) { self.sequential3.pop(); }
+    fn seq3_count(&self) -> usize { self.sequential3.len() }
+
+    fn push_same2(&mut self, tile: usize) {
+        self.same2.push(Same2::new(tile as TileType, tile as TileType).unwrap());
+    }
+    fn pop_same2(&mut self) { self.same2.pop(); }
+    fn same2_count(&self) -> usize { self.same2.len() }
+
+    fn push_seq2(&mut self, tile1: usize, tile2: usize) {
+        self.sequential2.push(Sequential2::new(tile1 as TileType, tile2 as TileType).unwrap());
+    }
+    fn pop_seq2(&mut self) { self.sequential2.pop(); }
+    fn seq2_count(&self) -> usize { self.sequential2.len() }
+
+    fn snapshot_best(&self, _pre: &FullTrackingPreprocess, t: &TileSummarize, _head: usize) -> Self {
+        let mut single = Vec::new();
+        for i in 0..Tile::LEN as usize {
+            for _ in 0..t[i] {
+                single.push(i as TileType);
+            }
+        }
+        FullTracking {
+            same3: self.same3.clone(),
+            sequential3: self.sequential3.clone(),
+            same2: self.same2.clone(),
+            sequential2: self.sequential2.clone(),
+            single,
+        }
+    }
+
+    fn finalize(mut self, mut pre: FullTrackingPreprocess) -> Self {
+        self.same3.append(&mut pre.same3);
+        self.sequential3.append(&mut pre.seq3);
+        self.single.append(&mut pre.singles);
+        self
+    }
+}
+
+// --- 共通再帰ロジック ---
+
+/// 通常形のシャンテン数を計算する共通エントリポイント
+fn calc_normal_shanten<A: ShantenAccumulator>(hand: &Hand) -> Result<(i32, A)> {
     let mut t = hand.summarize_tiles();
     let mut best = UNAVAILABLE_SHANTEN;
 
-    // 独立ブロックを先に抽出（カウントのみ）
-    let indep_same3 = count_independent_same3_fast(&mut t);
-    let indep_seq3 = count_independent_seq3_fast(&mut t);
-    let _indep_single = remove_independent_singles(&mut t);
+    let pre = A::preprocess(&mut t)?;
+    let mut acc = A::new_tracking();
+    let mut best_acc = A::new_tracking();
 
     // 雀頭を抜き出す
     for i in 0..Tile::LEN as usize {
         if t[i] >= 2 {
             t[i] -= 2;
-            shanten_recurse_fast(0, indep_same3, indep_seq3, 0, 0, 1, 0, &mut t, &mut best);
+            acc.push_same2(i);
+            find_mentsu(0, &pre, &mut acc, 1, &mut t, &mut best, &mut best_acc);
+            acc.pop_same2();
             t[i] += 2;
         }
     }
     // 雀頭なし
-    shanten_recurse_fast(0, indep_same3, indep_seq3, 0, 0, 0, 0, &mut t, &mut best);
+    find_mentsu(0, &pre, &mut acc, 0, &mut t, &mut best, &mut best_acc);
 
-    best
+    let result = best_acc.finalize(pre);
+    Ok((best, result))
 }
 
-/// 高速再帰: カウンタのみで面子・塔子を探索
-fn shanten_recurse_fast(
+/// フェーズ1: 面子（刻子・順子）を再帰的に抽出する
+fn find_mentsu<A: ShantenAccumulator>(
     idx: usize,
-    indep_same3: usize,
-    indep_seq3: usize,
-    same3_count: usize,
-    seq3_count: usize,
+    pre: &A::Preprocess,
+    acc: &mut A,
     head: usize,
-    block2_count: usize,
     t: &mut TileSummarize,
     best: &mut i32,
+    best_acc: &mut A,
 ) {
-    // 面子の探索
     for i in idx..Tile::LEN as usize {
         // 刻子
         if t[i] >= 3 {
             t[i] -= 3;
-            shanten_recurse_fast(i, indep_same3, indep_seq3, same3_count + 1, seq3_count, head, block2_count, t, best);
+            acc.push_same3(i);
+            find_mentsu(i, pre, acc, head, t, best, best_acc);
+            acc.pop_same3();
             t[i] += 3;
         }
         // 順子
@@ -603,39 +573,45 @@ fn shanten_recurse_fast(
             t[i] -= 1;
             t[i + 1] -= 1;
             t[i + 2] -= 1;
-            shanten_recurse_fast(i, indep_same3, indep_seq3, same3_count, seq3_count + 1, head, block2_count, t, best);
+            acc.push_seq3(i);
+            find_mentsu(i, pre, acc, head, t, best, best_acc);
+            acc.pop_seq3();
             t[i] += 1;
             t[i + 1] += 1;
             t[i + 2] += 1;
         }
     }
 
-    // 塔子・対子の探索
-    // 面子抽出後の残り牌は元のインデックスより前に存在し得るため、
-    // 常に先頭から探索する必要がある（例: 234p+234s+567s 抽出後に 23s が残る場合）
-    let block3 = indep_same3 + indep_seq3 + same3_count + seq3_count;
-    let mut b2 = block2_count;
-    shanten_recurse2_fast(0, block3, head, &mut b2, t, best);
+    // 面子を全て抽出し終えたら、塔子・対子の探索に移行する。
+    // 面子抽出後の残り牌は元のインデックスより前に存在し得るため、常に先頭から探索する。
+    let block3 = pre.same3_count() + pre.seq3_count() + acc.same3_count() + acc.seq3_count();
+    find_tatsu(0, block3, head, pre, acc, t, best, best_acc);
 }
 
-/// 塔子・対子の高速再帰
-fn shanten_recurse2_fast(
+/// フェーズ2: 塔子（対子・両面/辺張・嵌張）を再帰的に抽出する
+fn find_tatsu<A: ShantenAccumulator>(
     idx: usize,
     block3: usize,
     head: usize,
-    block2: &mut usize,
+    pre: &A::Preprocess,
+    acc: &mut A,
     t: &mut TileSummarize,
     best: &mut i32,
+    best_acc: &mut A,
 ) {
-    // まず現状で向聴数を計算
-    let b2_capped = (*block2).min(4usize.saturating_sub(block3));
-    let shanten = 8i32 - (block3 * 2 + b2_capped + head) as i32;
+    // 現在の分解で向聴数を計算
+    let block2_raw = acc.same2_count() + acc.seq2_count();
+    // 雀頭として使っている same2 は block2 に含めない
+    let block2_net = block2_raw.saturating_sub(head);
+    let block2_capped = block2_net.min(4usize.saturating_sub(block3));
+    let shanten = 8i32 - (block3 * 2 + block2_capped + head) as i32;
     if shanten < *best {
         *best = shanten;
+        *best_acc = acc.snapshot_best(pre, t, head);
     }
 
     // 枝刈り: これ以上 block2 を増やしても改善しない場合
-    if *block2 >= 4usize.saturating_sub(block3) {
+    if block2_net >= 4usize.saturating_sub(block3) {
         return;
     }
 
@@ -643,54 +619,57 @@ fn shanten_recurse2_fast(
         // 対子
         if t[i] >= 2 {
             t[i] -= 2;
-            *block2 += 1;
-            shanten_recurse2_fast(i + 1, block3, head, block2, t, best);
-            *block2 -= 1;
+            acc.push_same2(i);
+            find_tatsu(i + 1, block3, head, pre, acc, t, best, best_acc);
+            acc.pop_same2();
             t[i] += 2;
         }
-        // 塔子
+        // 塔子（隣接する2枚）
         if i < 27 && i % 9 <= 7 && t[i] >= 1 && t[i + 1] >= 1 {
             t[i] -= 1;
             t[i + 1] -= 1;
-            *block2 += 1;
-            shanten_recurse2_fast(i, block3, head, block2, t, best);
-            *block2 -= 1;
+            acc.push_seq2(i, i + 1);
+            find_tatsu(i, block3, head, pre, acc, t, best, best_acc);
+            acc.pop_seq2();
             t[i] += 1;
             t[i + 1] += 1;
         }
-        // 嵌張
+        // 嵌張（間が空いた2枚）
         if i < 27 && i % 9 <= 6 && t[i] >= 1 && t[i + 1] == 0 && t[i + 2] >= 1 {
             t[i] -= 1;
             t[i + 2] -= 1;
-            *block2 += 1;
-            shanten_recurse2_fast(i, block3, head, block2, t, best);
-            *block2 -= 1;
+            acc.push_seq2(i, i + 2);
+            find_tatsu(i, block3, head, pre, acc, t, best, best_acc);
+            acc.pop_seq2();
             t[i] += 1;
             t[i + 2] += 1;
         }
     }
 }
 
-/// 独立した刻子を抽出（カウントのみ返す）
-fn count_independent_same3_fast(t: &mut TileSummarize) -> usize {
+// ============================================================================
+// 前処理: 独立ブロック抽出
+// ============================================================================
+
+/// 数牌において、隣接2マス以内に他の牌がないかを判定する
+fn is_isolated(t: &TileSummarize, i: usize) -> bool {
+    if i >= 27 {
+        return true; // 字牌は常に独立
+    }
+    let pos = i % 9;
+    let base = i - pos;
+    let left2  = pos < 2 || t[base + pos - 2] == 0;
+    let left1  = pos < 1 || t[base + pos - 1] == 0;
+    let right1 = pos > 7 || t[base + pos + 1] == 0;
+    let right2 = pos > 6 || t[base + pos + 2] == 0;
+    left2 && left1 && right1 && right2
+}
+
+/// 独立した刻子を抽出する（カウントのみ返す）
+fn extract_independent_same3(t: &mut TileSummarize) -> usize {
     let mut count = 0;
     for i in 0..Tile::LEN as usize {
-        if t[i] < 3 {
-            continue;
-        }
-        let is_isolated = if i >= 27 {
-            // 字牌: 常に独立
-            true
-        } else {
-            let pos = i % 9;
-            let base = i - pos;
-            let left2 = if pos >= 2 { t[base + pos - 2] == 0 } else { true };
-            let left1 = if pos >= 1 { t[base + pos - 1] == 0 } else { true };
-            let right1 = if pos <= 7 { t[base + pos + 1] == 0 } else { true };
-            let right2 = if pos <= 6 { t[base + pos + 2] == 0 } else { true };
-            left2 && left1 && right1 && right2
-        };
-        if is_isolated {
+        if t[i] >= 3 && is_isolated(t, i) {
             t[i] -= 3;
             count += 1;
         }
@@ -698,10 +677,27 @@ fn count_independent_same3_fast(t: &mut TileSummarize) -> usize {
     count
 }
 
-/// 独立した順子を抽出（カウントのみ返す）
-fn count_independent_seq3_fast(t: &mut TileSummarize) -> usize {
-    let mut count = 0;
-    // 一盃口を先に処理してから通常処理
+/// 独立した刻子を抽出する（Vec で返す）
+fn extract_independent_same3_full(t: &mut TileSummarize) -> Result<Vec<Same3>> {
+    let mut result = Vec::new();
+    for i in 0..Tile::LEN as usize {
+        if t[i] >= 3 && is_isolated(t, i) {
+            t[i] -= 3;
+            let tile = i as TileType;
+            result.push(Same3::new(tile, tile, tile)?);
+        }
+    }
+    Ok(result)
+}
+
+/// 独立した順子を抽出する（共通ロジック）
+///
+/// 一盃口を先に処理してから通常処理する。
+/// `on_found` は見つかった順子の先頭インデックスと個数（1 or 2）を受け取る。
+fn extract_independent_seq3_impl(
+    t: &mut TileSummarize,
+    mut on_found: impl FnMut(usize, u32),
+) {
     for n in (1u32..=2).rev() {
         for suit_start in (0..27).step_by(9) {
             for k in 0..=6usize {
@@ -714,317 +710,61 @@ fn count_independent_seq3_fast(t: &mut TileSummarize) -> usize {
                     t[l] -= n;
                     t[l + 1] -= n;
                     t[l + 2] -= n;
-                    count += n as usize;
+                    on_found(l, n);
                 }
             }
         }
     }
+}
+
+/// 独立した順子を抽出する（カウントのみ返す）
+fn extract_independent_seq3(t: &mut TileSummarize) -> usize {
+    let mut count = 0usize;
+    extract_independent_seq3_impl(t, |_l, n| {
+        count += n as usize;
+    });
     count
 }
 
-/// 独立した単独牌を除去（カウントのみ返す）
+/// 独立した順子を抽出する（Vec で返す）
+fn extract_independent_seq3_full(t: &mut TileSummarize) -> Result<Vec<Sequential3>> {
+    let mut result = Vec::new();
+    let mut err: Option<anyhow::Error> = None;
+    extract_independent_seq3_impl(t, |l, n| {
+        if err.is_some() { return; }
+        for _ in 0..n {
+            match Sequential3::new(l as TileType, (l + 1) as TileType, (l + 2) as TileType) {
+                Ok(s) => result.push(s),
+                Err(e) => { err = Some(e); return; }
+            }
+        }
+    });
+    if let Some(e) = err { return Err(e); }
+    Ok(result)
+}
+
+/// 独立した孤立牌を除去する（カウントのみ返す）
 fn remove_independent_singles(t: &mut TileSummarize) -> usize {
     let mut count = 0;
     for i in 0..Tile::LEN as usize {
-        if t[i] != 1 {
-            continue;
-        }
-        let is_isolated = if i >= 27 {
-            true
-        } else {
-            let pos = i % 9;
-            let base = i - pos;
-            let left2 = if pos >= 2 { t[base + pos - 2] == 0 } else { true };
-            let left1 = if pos >= 1 { t[base + pos - 1] == 0 } else { true };
-            let right1 = if pos <= 7 { t[base + pos + 1] == 0 } else { true };
-            let right2 = if pos <= 6 { t[base + pos + 2] == 0 } else { true };
-            left2 && left1 && right1 && right2
-        };
-        if is_isolated {
+        if t[i] == 1 && is_isolated(t, i) {
             t[i] -= 1;
             count += 1;
         }
     }
     count
 }
-/// 再帰的にシャンテン数が最小のものを探す
-fn count_normal_shanten_recursively(
-    idx: TileType,
-    independent_same3: &Vec<Same3>,
-    independent_sequential3: &Vec<Sequential3>,
-    same3: &mut Vec<Same3>,
-    sequential3: &mut Vec<Sequential3>,
-    same2: &mut Vec<Same2>,
-    sequential2: &mut Vec<Sequential2>,
-    summarized_hand: &mut TileSummarize,
 
-    shanten_min: &mut i32,
-    same3_result: &mut Vec<Same3>,
-    sequential3_result: &mut Vec<Sequential3>,
-    same2_result: &mut Vec<Same2>,
-    sequential2_result: &mut Vec<Sequential2>,
-    single_result: &mut Vec<TileType>,
-) -> Result<i32> {
-    count_same_or_sequential_3(
-        idx,
-        independent_same3,
-        independent_sequential3,
-        same3,
-        sequential3,
-        same2,
-        sequential2,
-        summarized_hand,
-        shanten_min,
-        same3_result,
-        sequential3_result,
-        same2_result,
-        sequential2_result,
-        single_result,
-    )?;
-    count_same_or_sequential_2(
-        idx,
-        independent_same3,
-        independent_sequential3,
-        same3,
-        sequential3,
-        same2,
-        sequential2,
-        summarized_hand,
-        shanten_min,
-        same3_result,
-        sequential3_result,
-        same2_result,
-        sequential2_result,
-        single_result,
-    )?;
-    let shanten = calc_normal_shanten(
-        independent_same3,
-        independent_sequential3,
-        same3,
-        sequential3,
-        same2,
-        sequential2,
-    );
-    if shanten < *shanten_min {
-        *shanten_min = shanten;
-        *same3_result = same3.clone();
-        *sequential3_result = sequential3.clone();
-        *same2_result = same2.clone();
-        *sequential2_result = sequential2.clone();
-        single_result.clear();
-        for i in Tile::M1..=Tile::Z7 {
-            for _ in 0..summarized_hand[i as usize] as u32 {
-                single_result.push(i);
-            }
+/// 独立した孤立牌を除去する（Vec で返す）
+fn extract_independent_singles_full(t: &mut TileSummarize) -> Result<Vec<TileType>> {
+    let mut result = Vec::new();
+    for i in 0..Tile::LEN as usize {
+        if t[i] == 1 && is_isolated(t, i) {
+            t[i] -= 1;
+            result.push(i as TileType);
         }
     }
-    Ok(*shanten_min)
-}
-
-/// 面子（刻子および順子）をカウントして引数に与えられた各変数に格納する
-fn count_same_or_sequential_3(
-    idx: TileType,
-    independent_same3: &Vec<Same3>,
-    independent_sequential3: &Vec<Sequential3>,
-    same3: &mut Vec<Same3>,
-    sequential3: &mut Vec<Sequential3>,
-    same2: &mut Vec<Same2>,
-    sequential2: &mut Vec<Sequential2>,
-    summarized_hand: &mut TileSummarize,
-    shanten_min: &mut i32,
-    same3_result: &mut Vec<Same3>,
-    sequential3_result: &mut Vec<Sequential3>,
-    same2_result: &mut Vec<Same2>,
-    sequential2_result: &mut Vec<Sequential2>,
-    single_result: &mut Vec<TileType>,
-) -> Result<()> {
-    for i in idx..=Tile::Z7 {
-        // 刻子カウント
-        if summarized_hand[i as usize] >= 3 {
-            //block3 += 1;
-            same3.push(Same3::new(i, i, i)?);
-            summarized_hand[i as usize] -= 3;
-            *shanten_min = count_normal_shanten_recursively(
-                i,
-                independent_same3,
-                independent_sequential3,
-                same3,
-                sequential3,
-                same2,
-                sequential2,
-                summarized_hand,
-                shanten_min,
-                same3_result,
-                sequential3_result,
-                same2_result,
-                sequential2_result,
-                single_result,
-            )?;
-            summarized_hand[i as usize] += 3;
-            same3.pop();
-        }
-
-        //順子カウント
-        if ((i >= Tile::M1 && i <= Tile::M7)
-            || (i >= Tile::P1 && i <= Tile::P7)
-            || (i >= Tile::S1 && i <= Tile::S7))
-            && summarized_hand[i as usize] >= 1
-            && summarized_hand[i as usize + 1] >= 1
-            && summarized_hand[i as usize + 2] >= 1
-        {
-            //block3 += 1;
-            sequential3.push(Sequential3::new(i, i + 1, i + 2)?);
-            summarized_hand[i as usize] -= 1;
-            summarized_hand[i as usize + 1] -= 1;
-            summarized_hand[i as usize + 2] -= 1;
-            *shanten_min = count_normal_shanten_recursively(
-                i,
-                independent_same3,
-                independent_sequential3,
-                same3,
-                sequential3,
-                same2,
-                sequential2,
-                summarized_hand,
-                shanten_min,
-                same3_result,
-                sequential3_result,
-                same2_result,
-                sequential2_result,
-                single_result,
-            )?;
-            summarized_hand[i as usize] += 1;
-            summarized_hand[i as usize + 1] += 1;
-            summarized_hand[i as usize + 2] += 1;
-            sequential3.pop();
-        }
-    }
-    Ok(())
-}
-
-/// 対子・塔子・嵌張をカウントして引数に与えられた各変数に格納する
-fn count_same_or_sequential_2(
-    idx: TileType,
-    independent_same3: &Vec<Same3>,
-    independent_sequential3: &Vec<Sequential3>,
-    same3: &mut Vec<Same3>,
-    sequential3: &mut Vec<Sequential3>,
-    same2: &mut Vec<Same2>,
-    sequential2: &mut Vec<Sequential2>,
-    summarized_hand: &mut TileSummarize,
-    shanten_min: &mut i32,
-    same3_result: &mut Vec<Same3>,
-    sequential3_result: &mut Vec<Sequential3>,
-    same2_result: &mut Vec<Same2>,
-    sequential2_result: &mut Vec<Sequential2>,
-    single_result: &mut Vec<TileType>,
-) -> Result<()> {
-    for i in idx..=Tile::Z7 {
-        // 対子
-        if summarized_hand[i as usize] == 2 {
-            same2.push(Same2::new(i, i)?);
-            summarized_hand[i as usize] -= 2;
-            *shanten_min = count_normal_shanten_recursively(
-                idx,
-                independent_same3,
-                independent_sequential3,
-                same3,
-                sequential3,
-                same2,
-                sequential2,
-                summarized_hand,
-                shanten_min,
-                same3_result,
-                sequential3_result,
-                same2_result,
-                sequential2_result,
-                single_result,
-            )?;
-            summarized_hand[i as usize] += 2;
-            same2.pop();
-        }
-        // 塔子（隣接する2枚: 例 8m9m）— *8 まで含める
-        let is_sequential_range = (i >= Tile::M1 && i <= Tile::M8)
-            || (i >= Tile::P1 && i <= Tile::P8)
-            || (i >= Tile::S1 && i <= Tile::S8);
-        if is_sequential_range
-            && summarized_hand[i as usize] >= 1
-            && summarized_hand[i as usize + 1] >= 1
-        {
-            sequential2.push(Sequential2::new(i, i + 1)?);
-            summarized_hand[i as usize] -= 1;
-            summarized_hand[i as usize + 1] -= 1;
-            *shanten_min = count_normal_shanten_recursively(
-                idx,
-                independent_same3,
-                independent_sequential3,
-                same3,
-                sequential3,
-                same2,
-                sequential2,
-                summarized_hand,
-                shanten_min,
-                same3_result,
-                sequential3_result,
-                same2_result,
-                sequential2_result,
-                single_result,
-            )?;
-            summarized_hand[i as usize] += 1;
-            summarized_hand[i as usize + 1] += 1;
-            sequential2.pop();
-        }
-        // 嵌張（間が空いた2枚: 例 7m9m）— *7 まで
-        let is_kanchan_range = (i >= Tile::M1 && i <= Tile::M7)
-            || (i >= Tile::P1 && i <= Tile::P7)
-            || (i >= Tile::S1 && i <= Tile::S7);
-        if is_kanchan_range
-            && summarized_hand[i as usize] >= 1
-            && summarized_hand[i as usize + 1] == 0
-            && summarized_hand[i as usize + 2] >= 1
-        {
-            sequential2.push(Sequential2::new(i, i + 2)?);
-            summarized_hand[i as usize] -= 1;
-            summarized_hand[i as usize + 2] -= 1;
-            *shanten_min = count_normal_shanten_recursively(
-                idx,
-                independent_same3,
-                independent_sequential3,
-                same3,
-                sequential3,
-                same2,
-                sequential2,
-                summarized_hand,
-                shanten_min,
-                same3_result,
-                sequential3_result,
-                same2_result,
-                sequential2_result,
-                single_result,
-            )?;
-            summarized_hand[i as usize] += 1;
-            summarized_hand[i as usize + 2] += 1;
-            sequential2.pop();
-        }
-    }
-    Ok(())
-    //return (same2, sequential2);
-}
-
-fn calc_normal_shanten(
-    independent_same3: &Vec<Same3>,
-    independent_sequential3: &Vec<Sequential3>,
-    same3: &Vec<Same3>,
-    sequential3: &Vec<Sequential3>,
-    same2: &Vec<Same2>,
-    sequential2: &Vec<Sequential2>,
-) -> i32 {
-    let block3 =
-        independent_same3.len() + independent_sequential3.len() + same3.len() + sequential3.len();
-    let head = usize::from(!same2.is_empty());
-    let mut block2 = sequential2.len() + same2.len().saturating_sub(head);
-    block2 = block2.min(4usize.saturating_sub(block3));
-    return 8 - (block3 * 2 + block2 + head) as i32;
+    Ok(result)
 }
 
 /// ユニットテスト

--- a/crates/mahjong-core/src/hand_info/hand_analyzer.rs
+++ b/crates/mahjong-core/src/hand_info/hand_analyzer.rs
@@ -1,13 +1,61 @@
 use anyhow::Result;
 
 use std::cmp::*;
+use std::fmt;
 
 use crate::hand::Hand;
 use crate::hand_info::block::*;
 use crate::tile::*;
 use crate::winning_hand::name::Form;
 
-const UNAVAILABLE_SHANTEN: i32 = i32::MAX;
+/// 向聴数を表すニュータイプ
+///
+/// テンパイが`0`、和了が`-1`。意味のあるメソッドを通じて状態を判定できる。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ShantenNumber(i32);
+
+impl ShantenNumber {
+    /// 該当なし（副露時の七対子・国士無双など）を表す定数
+    const UNAVAILABLE: ShantenNumber = ShantenNumber(i32::MAX);
+
+    /// 和了しているか（shanten == -1）
+    pub fn has_won(&self) -> bool {
+        self.0 == -1
+    }
+
+    /// テンパイしているか（shanten == 0）
+    pub fn is_tenpai(&self) -> bool {
+        self.0 == 0
+    }
+
+    /// テンパイ以上か（shanten <= 0）
+    pub fn is_tenpai_or_won(&self) -> bool {
+        self.0 <= 0
+    }
+
+    /// 生の`i32`値を返す
+    pub fn as_i32(&self) -> i32 {
+        self.0
+    }
+}
+
+impl PartialEq<i32> for ShantenNumber {
+    fn eq(&self, other: &i32) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialOrd<i32> for ShantenNumber {
+    fn partial_cmp(&self, other: &i32) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
+impl fmt::Display for ShantenNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 /// 与えられた手牌について、向聴数が最小になる時の面子・対子等の組み合わせを計算して格納する
 ///
@@ -15,8 +63,8 @@ const UNAVAILABLE_SHANTEN: i32 = i32::MAX;
 /// 国士無双の場合は（今のところ）向聴数のみが格納される。
 #[derive(Debug, Eq)]
 pub struct HandAnalyzer {
-    /// 向聴数：あと牌を何枚交換すれば聴牌できるかの最小数。聴牌状態が`0`、和了が`-1`。
-    pub shanten: i32,
+    /// 向聴数：あと牌を何枚交換すれば聴牌できるかの最小数。テンパイが`0`、和了が`-1`。
+    pub shanten: ShantenNumber,
     /// どの和了形か
     pub form: Form,
     /// 刻子（同じ牌が3枚）が入るVec
@@ -51,7 +99,7 @@ impl PartialEq for HandAnalyzer {
 impl HandAnalyzer {
     fn unavailable(form: Form) -> HandAnalyzer {
         HandAnalyzer {
-            shanten: UNAVAILABLE_SHANTEN,
+            shanten: ShantenNumber::UNAVAILABLE,
             form,
             same3: Vec::new(),
             sequential3: Vec::new(),
@@ -73,10 +121,7 @@ impl HandAnalyzer {
     /// let nm_test_str = "222333444666s6z 6z";
     /// let nm_test = Hand::from(nm_test_str);
     /// let analyzer = HandAnalyzer::new(&nm_test).unwrap();
-    /// assert_eq!(
-    ///   analyzer.shanten,
-    ///   -1
-    /// );
+    /// assert!(analyzer.shanten.has_won());
     /// assert_eq!(
     ///   analyzer.form,
     ///   Form::Normal
@@ -86,9 +131,9 @@ impl HandAnalyzer {
         let sp = HandAnalyzer::new_by_form(hand, Form::SevenPairs)?;
         let to = HandAnalyzer::new_by_form(hand, Form::ThirteenOrphans)?;
         let normal = HandAnalyzer::new_by_form(hand, Form::Normal)?;
-        // 高点法: 和了している場合（shanten == -1）、通常形を優先する。
+        // 高点法: 和了している場合、通常形を優先する。
         // 二盃口（3翻）は七対子（2翻）より高得点であるため、通常形で和了できるならそちらを採用する。
-        if normal.shanten == -1 {
+        if normal.shanten.has_won() {
             Ok(normal)
         } else {
             Ok(min(min(sp, to), normal))
@@ -106,26 +151,17 @@ impl HandAnalyzer {
     /// // 国士無双で和了る
     /// let to_test_str = "19m19p19s1234567z 1m";
     /// let to_test = Hand::from(to_test_str);
-    /// assert_eq!(
-    ///   HandAnalyzer::new_by_form(&to_test, Form::ThirteenOrphans).unwrap().shanten,
-    ///   -1
-    /// );
+    /// assert!(HandAnalyzer::new_by_form(&to_test, Form::ThirteenOrphans).unwrap().shanten.has_won());
     ///
     /// // 七対子で和了る
     /// let sp_test_str = "1122m3344p5566s7z 7z";
     /// let sp_test = Hand::from(sp_test_str);
-    /// assert_eq!(
-    ///   HandAnalyzer::new_by_form(&sp_test, Form::SevenPairs).unwrap().shanten,
-    ///   -1
-    /// );
+    /// assert!(HandAnalyzer::new_by_form(&sp_test, Form::SevenPairs).unwrap().shanten.has_won());
     ///
     /// // 通常型で和了る
     /// let nm_test_str = "1112345678999m 5m";
     /// let nm_test = Hand::from(nm_test_str);
-    /// assert_eq!(
-    ///   HandAnalyzer::new_by_form(&nm_test, Form::Normal).unwrap().shanten,
-    ///   -1
-    /// );
+    /// assert!(HandAnalyzer::new_by_form(&nm_test, Form::Normal).unwrap().shanten.has_won());
     /// ```
     pub fn new_by_form(hand: &Hand, form: Form) -> Result<HandAnalyzer> {
         Ok(match form {
@@ -145,8 +181,7 @@ impl HandAnalyzer {
         }
 
         let mut t = hand.summarize_tiles();
-        let (shanten, pair_count) = calc_seven_pairs_shanten(&t);
-        let _ = pair_count; // ブロック分解では直接使わない
+        let (shanten_raw, _pair_count) = calc_seven_pairs_shanten(&t);
 
         let mut same2: Vec<Same2> = Vec::new();
         for i in 0..Tile::LEN {
@@ -162,7 +197,7 @@ impl HandAnalyzer {
             }
         }
         Ok(HandAnalyzer {
-            shanten,
+            shanten: ShantenNumber(shanten_raw),
             form: Form::SevenPairs,
             same3: Vec::new(),
             sequential3: Vec::new(),
@@ -181,9 +216,9 @@ impl HandAnalyzer {
         }
 
         let t = hand.summarize_tiles();
-        let shanten = calc_thirteen_orphans_shanten(&t);
+        let shanten_raw = calc_thirteen_orphans_shanten(&t);
         Ok(HandAnalyzer {
-            shanten,
+            shanten: ShantenNumber(shanten_raw),
             form: Form::ThirteenOrphans,
             same3: Vec::new(),
             sequential3: Vec::new(),
@@ -195,7 +230,7 @@ impl HandAnalyzer {
 
     /// 通常の役への向聴数を計算・ブロック分解する
     fn analyze_normal_form(hand: &Hand) -> Result<HandAnalyzer> {
-        let (shanten, tracking) = calc_normal_shanten::<FullTracking>(hand)?;
+        let (shanten_raw, tracking) = calc_normal_shanten::<FullTracking>(hand)?;
         let FullTracking {
             same3,
             sequential3,
@@ -204,7 +239,7 @@ impl HandAnalyzer {
             single,
         } = tracking;
         Ok(HandAnalyzer {
-            shanten,
+            shanten: ShantenNumber(shanten_raw),
             form: Form::Normal,
             same3,
             sequential3,
@@ -215,26 +250,19 @@ impl HandAnalyzer {
     }
 }
 
-impl HandAnalyzer {
-    /// 和了しているか否か
-    pub fn has_won(&self) -> bool {
-        self.shanten == -1
-    }
-}
-
 /// 向聴数のみを高速に計算する（ブロック分解・Vec格納なし）
 ///
 /// `HandAnalyzer::new()` と同じ結果を返すが、向聴数の数値のみを返す。
 /// CPU打牌評価など大量に呼び出す箇所で使用する。
-pub fn calc_shanten_number(hand: &Hand) -> i32 {
+pub fn calc_shanten_number(hand: &Hand) -> ShantenNumber {
     let t = hand.summarize_tiles();
     let is_closed = hand.opened().is_empty();
-    let sp = if is_closed { calc_seven_pairs_shanten(&t).0 } else { UNAVAILABLE_SHANTEN };
-    let to = if is_closed { calc_thirteen_orphans_shanten(&t) } else { UNAVAILABLE_SHANTEN };
+    let sp = if is_closed { calc_seven_pairs_shanten(&t).0 } else { i32::MAX };
+    let to = if is_closed { calc_thirteen_orphans_shanten(&t) } else { i32::MAX };
     let nm = calc_normal_shanten::<CountOnly>(hand)
         .map(|(s, _)| s)
-        .unwrap_or(UNAVAILABLE_SHANTEN);
-    min(min(sp, to), nm)
+        .unwrap_or(i32::MAX);
+    ShantenNumber(min(min(sp, to), nm))
 }
 
 /// 七対子のシャンテン数を計算する共通ロジック
@@ -577,7 +605,7 @@ impl ShantenAccumulator for FullTracking {
 /// 通常形のシャンテン数を計算する共通エントリポイント
 fn calc_normal_shanten<A: ShantenAccumulator>(hand: &Hand) -> Result<(i32, A)> {
     let mut t = hand.summarize_tiles();
-    let mut best = UNAVAILABLE_SHANTEN;
+    let mut best = i32::MAX;
 
     let pre = A::preprocess(&mut t)?;
     let mut acc = A::new_tracking();
@@ -840,11 +868,11 @@ mod tests {
     fn zero_shanten_to_seven_pairs() {
         let test_str = "226699m99p228s66z 1z";
         let test = Hand::from(test_str);
-        assert_eq!(
+        assert!(
             HandAnalyzer::new_by_form(&test, Form::SevenPairs)
                 .unwrap()
-                .shanten,
-            0
+                .shanten
+                .is_tenpai()
         );
     }
     #[test]
@@ -852,11 +880,11 @@ mod tests {
     fn zero_shanten_to_seven_pairs_2() {
         let test_str = "226699m99p222s66z 1z";
         let test = Hand::from(test_str);
-        assert_eq!(
+        assert!(
             HandAnalyzer::new_by_form(&test, Form::SevenPairs)
                 .unwrap()
-                .shanten,
-            0
+                .shanten
+                .is_tenpai()
         );
     }
     #[test]
@@ -864,11 +892,11 @@ mod tests {
     fn zero_shanten_to_orphans() {
         let test_str = "19m19p11s1234567z 5m";
         let test = Hand::from(test_str);
-        assert_eq!(
+        assert!(
             HandAnalyzer::new_by_form(&test, Form::ThirteenOrphans)
                 .unwrap()
-                .shanten,
-            0
+                .shanten
+                .is_tenpai()
         );
     }
 
@@ -881,7 +909,7 @@ mod tests {
             HandAnalyzer::new_by_form(&test, Form::SevenPairs)
                 .unwrap()
                 .shanten,
-            1
+            ShantenNumber(1)
         );
     }
 
@@ -890,11 +918,11 @@ mod tests {
     fn win_by_ready_hand() {
         let test_str = "123m444p789s1112z 2z";
         let test = Hand::from(test_str);
-        assert_eq!(
+        assert!(
             HandAnalyzer::new_by_form(&test, Form::Normal)
                 .unwrap()
-                .shanten,
-            -1
+                .shanten
+                .has_won()
         );
     }
 
@@ -903,11 +931,11 @@ mod tests {
     fn win_by_honor_tiles_players_wind() {
         let test_str = "333m456p1789s 333z 1s";
         let test = Hand::from(test_str);
-        assert_eq!(
+        assert!(
             HandAnalyzer::new_by_form(&test, Form::Normal)
                 .unwrap()
-                .shanten,
-            -1
+                .shanten
+                .has_won()
         );
     }
 
@@ -916,11 +944,11 @@ mod tests {
     fn win_by_honor_tiles_prevailing_wind() {
         let test_str = "234567m6789s 111z 6s";
         let test = Hand::from(test_str);
-        assert_eq!(
+        assert!(
             HandAnalyzer::new_by_form(&test, Form::Normal)
                 .unwrap()
-                .shanten,
-            -1
+                .shanten
+                .has_won()
         );
     }
     #[test]
@@ -928,11 +956,11 @@ mod tests {
     fn win_by_honor_tiles_dragons() {
         let test_str = "5m123456p888s 777z 5m";
         let test = Hand::from(test_str);
-        assert_eq!(
+        assert!(
             HandAnalyzer::new_by_form(&test, Form::Normal)
                 .unwrap()
-                .shanten,
-            -1
+                .shanten
+                .has_won()
         );
     }
     #[test]
@@ -940,11 +968,11 @@ mod tests {
     fn win_by_all_simples() {
         let test_str = "234m8s 567m 333p 456s 8s";
         let test = Hand::from(test_str);
-        assert_eq!(
+        assert!(
             HandAnalyzer::new_by_form(&test, Form::Normal)
                 .unwrap()
-                .shanten,
-            -1
+                .shanten
+                .has_won()
         );
     }
 
@@ -953,11 +981,11 @@ mod tests {
     fn win_by_no_points() {
         let test_str = "123567m234p6799s 5s";
         let test = Hand::from(test_str);
-        assert_eq!(
+        assert!(
             HandAnalyzer::new_by_form(&test, Form::Normal)
                 .unwrap()
-                .shanten,
-            -1
+                .shanten
+                .has_won()
         );
     }
 
@@ -966,7 +994,7 @@ mod tests {
     fn tenpai_with_89_wait() {
         let test_str = "55m123567p56789s 9m";
         let test = Hand::from(test_str);
-        assert_eq!(HandAnalyzer::new(&test).unwrap().shanten, 0);
+        assert!(HandAnalyzer::new(&test).unwrap().shanten.is_tenpai());
     }
 
     #[test]
@@ -974,7 +1002,7 @@ mod tests {
     fn tenpai_with_89s_toitsu() {
         let test_str = "11m234p567p234s89s 1z";
         let test = Hand::from(test_str);
-        assert_eq!(HandAnalyzer::new(&test).unwrap().shanten, 0);
+        assert!(HandAnalyzer::new(&test).unwrap().shanten.is_tenpai());
     }
 
     #[test]
@@ -982,36 +1010,36 @@ mod tests {
     fn tenpai_with_89m_toitsu() {
         let test_str = "89m11p234p567s234s 2z";
         let test = Hand::from(test_str);
-        assert_eq!(HandAnalyzer::new(&test).unwrap().shanten, 0);
+        assert!(HandAnalyzer::new(&test).unwrap().shanten.is_tenpai());
     }
 
     #[test]
     /// 4面子1塔子は和了ではなく聴牌
     fn four_melds_and_one_taatsu_is_tenpai_not_win() {
         let test = Hand::from("234678m56p567s55z 5z");
-        assert_eq!(HandAnalyzer::new(&test).unwrap().shanten, 0);
+        assert!(HandAnalyzer::new(&test).unwrap().shanten.is_tenpai());
     }
 
     #[test]
     fn kan_hand_with_unrelated_rinshan_tile_is_not_a_win() {
         let test = Hand::from("567p123s678s8s 5555s 1m");
-        assert_eq!(HandAnalyzer::new(&test).unwrap().shanten, 0);
+        assert!(HandAnalyzer::new(&test).unwrap().shanten.is_tenpai());
     }
 
     #[test]
     fn opened_hand_cannot_be_seven_pairs_or_thirteen_orphans() {
         let test = Hand::from("123456789m11p 789s 1p");
         assert!(
-            HandAnalyzer::new_by_form(&test, Form::SevenPairs)
+            !HandAnalyzer::new_by_form(&test, Form::SevenPairs)
                 .unwrap()
                 .shanten
-                > 0
+                .is_tenpai_or_won()
         );
         assert!(
-            HandAnalyzer::new_by_form(&test, Form::ThirteenOrphans)
+            !HandAnalyzer::new_by_form(&test, Form::ThirteenOrphans)
                 .unwrap()
                 .shanten
-                > 0
+                .is_tenpai_or_won()
         );
     }
 
@@ -1033,7 +1061,8 @@ mod tests {
         let hand = Hand::from(hand_str);
         let shanten = HandAnalyzer::new(&hand).unwrap().shanten;
         assert_eq!(
-            shanten, expected,
+            shanten,
+            ShantenNumber(expected),
             "hand '{hand_str}': expected {expected}, got {shanten}"
         );
     }

--- a/crates/mahjong-core/src/hand_info/hand_analyzer.rs
+++ b/crates/mahjong-core/src/hand_info/hand_analyzer.rs
@@ -8,9 +8,7 @@ use crate::hand_info::block::*;
 use crate::tile::*;
 use crate::winning_hand::name::Form;
 
-/// 向聴数を表すニュータイプ
-///
-/// テンパイが`0`、和了が`-1`。意味のあるメソッドを通じて状態を判定できる。
+/// 向聴数
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ShantenNumber(i32);
 
@@ -23,13 +21,13 @@ impl ShantenNumber {
         self.0 == -1
     }
 
-    /// テンパイしているか（shanten == 0）
-    pub fn is_tenpai(&self) -> bool {
+    /// 聴牌しているか（shanten == 0）
+    pub fn is_ready(&self) -> bool {
         self.0 == 0
     }
 
-    /// テンパイ以上か（shanten <= 0）
-    pub fn is_tenpai_or_won(&self) -> bool {
+    /// 聴牌もしくは和了しているか（shanten <= 0）
+    pub fn is_ready_or_won(&self) -> bool {
         self.0 <= 0
     }
 
@@ -60,10 +58,10 @@ impl fmt::Display for ShantenNumber {
 /// 与えられた手牌について、向聴数が最小になる時の面子・対子等の組み合わせを計算して格納する
 ///
 /// 通常形・七対子の場合は面子・対子等の情報もVecに格納される。
-/// 国士無双の場合は（今のところ）向聴数のみが格納される。
+/// 国士無双の場合は向聴数のみが格納される。
 #[derive(Debug, Eq)]
 pub struct HandAnalyzer {
-    /// 向聴数：あと牌を何枚交換すれば聴牌できるかの最小数。テンパイが`0`、和了が`-1`。
+    /// 向聴数：あと牌を何枚交換すれば聴牌できるかの最小数。
     pub shanten: ShantenNumber,
     /// どの和了形か
     pub form: Form,
@@ -209,7 +207,7 @@ impl HandAnalyzer {
 
     /// 国士無双への向聴数を計算する
     ///
-    /// ブロック分解・Vecへの詰め込みは未実装（詰め込んでも意味がない）
+    /// ブロック分解・Vecへの詰め込みはしない（詰め込んでも意味がない）
     fn analyze_thirteen_orphans(hand: &Hand) -> Result<HandAnalyzer> {
         if !hand.opened().is_empty() {
             return Ok(HandAnalyzer::unavailable(Form::ThirteenOrphans));
@@ -250,15 +248,24 @@ impl HandAnalyzer {
     }
 }
 
-/// 向聴数のみを高速に計算する（ブロック分解・Vec格納なし）
+/// 向聴数のみを高速に計算する
 ///
-/// `HandAnalyzer::new()` と同じ結果を返すが、向聴数の数値のみを返す。
+/// `HandAnalyzer::new().shanten` と同じ結果を返すが、
+/// ブロック分解やVecへの格納を行わないため高速。
 /// CPU打牌評価など大量に呼び出す箇所で使用する。
 pub fn calc_shanten_number(hand: &Hand) -> ShantenNumber {
     let t = hand.summarize_tiles();
     let is_closed = hand.opened().is_empty();
-    let sp = if is_closed { calc_seven_pairs_shanten(&t).0 } else { i32::MAX };
-    let to = if is_closed { calc_thirteen_orphans_shanten(&t) } else { i32::MAX };
+    let sp = if is_closed {
+        calc_seven_pairs_shanten(&t).0
+    } else {
+        i32::MAX
+    };
+    let to = if is_closed {
+        calc_thirteen_orphans_shanten(&t)
+    } else {
+        i32::MAX
+    };
     let nm = calc_normal_shanten::<CountOnly>(hand)
         .map(|(s, _)| s)
         .unwrap_or(i32::MAX);
@@ -872,7 +879,7 @@ mod tests {
             HandAnalyzer::new_by_form(&test, Form::SevenPairs)
                 .unwrap()
                 .shanten
-                .is_tenpai()
+                .is_ready()
         );
     }
     #[test]
@@ -884,7 +891,7 @@ mod tests {
             HandAnalyzer::new_by_form(&test, Form::SevenPairs)
                 .unwrap()
                 .shanten
-                .is_tenpai()
+                .is_ready()
         );
     }
     #[test]
@@ -896,7 +903,7 @@ mod tests {
             HandAnalyzer::new_by_form(&test, Form::ThirteenOrphans)
                 .unwrap()
                 .shanten
-                .is_tenpai()
+                .is_ready()
         );
     }
 
@@ -994,7 +1001,7 @@ mod tests {
     fn tenpai_with_89_wait() {
         let test_str = "55m123567p56789s 9m";
         let test = Hand::from(test_str);
-        assert!(HandAnalyzer::new(&test).unwrap().shanten.is_tenpai());
+        assert!(HandAnalyzer::new(&test).unwrap().shanten.is_ready());
     }
 
     #[test]
@@ -1002,7 +1009,7 @@ mod tests {
     fn tenpai_with_89s_toitsu() {
         let test_str = "11m234p567p234s89s 1z";
         let test = Hand::from(test_str);
-        assert!(HandAnalyzer::new(&test).unwrap().shanten.is_tenpai());
+        assert!(HandAnalyzer::new(&test).unwrap().shanten.is_ready());
     }
 
     #[test]
@@ -1010,20 +1017,20 @@ mod tests {
     fn tenpai_with_89m_toitsu() {
         let test_str = "89m11p234p567s234s 2z";
         let test = Hand::from(test_str);
-        assert!(HandAnalyzer::new(&test).unwrap().shanten.is_tenpai());
+        assert!(HandAnalyzer::new(&test).unwrap().shanten.is_ready());
     }
 
     #[test]
     /// 4面子1塔子は和了ではなく聴牌
-    fn four_melds_and_one_taatsu_is_tenpai_not_win() {
+    fn four_melds_and_one_taatsu_is_ready_not_win() {
         let test = Hand::from("234678m56p567s55z 5z");
-        assert!(HandAnalyzer::new(&test).unwrap().shanten.is_tenpai());
+        assert!(HandAnalyzer::new(&test).unwrap().shanten.is_ready());
     }
 
     #[test]
     fn kan_hand_with_unrelated_rinshan_tile_is_not_a_win() {
         let test = Hand::from("567p123s678s8s 5555s 1m");
-        assert!(HandAnalyzer::new(&test).unwrap().shanten.is_tenpai());
+        assert!(HandAnalyzer::new(&test).unwrap().shanten.is_ready());
     }
 
     #[test]
@@ -1033,13 +1040,13 @@ mod tests {
             !HandAnalyzer::new_by_form(&test, Form::SevenPairs)
                 .unwrap()
                 .shanten
-                .is_tenpai_or_won()
+                .is_ready_or_won()
         );
         assert!(
             !HandAnalyzer::new_by_form(&test, Form::ThirteenOrphans)
                 .unwrap()
                 .shanten
-                .is_tenpai_or_won()
+                .is_ready_or_won()
         );
     }
 

--- a/crates/mahjong-core/src/hand_info/hand_analyzer.rs
+++ b/crates/mahjong-core/src/hand_info/hand_analyzer.rs
@@ -289,11 +289,19 @@ fn shanten_thirteen_orphans(hand: &Hand) -> i32 {
         return UNAVAILABLE_SHANTEN;
     }
     let to_tiles: [usize; 13] = [
-        Tile::M1 as usize, Tile::M9 as usize,
-        Tile::P1 as usize, Tile::P9 as usize,
-        Tile::S1 as usize, Tile::S9 as usize,
-        Tile::Z1 as usize, Tile::Z2 as usize, Tile::Z3 as usize,
-        Tile::Z4 as usize, Tile::Z5 as usize, Tile::Z6 as usize, Tile::Z7 as usize,
+        Tile::M1 as usize,
+        Tile::M9 as usize,
+        Tile::P1 as usize,
+        Tile::P9 as usize,
+        Tile::S1 as usize,
+        Tile::S9 as usize,
+        Tile::Z1 as usize,
+        Tile::Z2 as usize,
+        Tile::Z3 as usize,
+        Tile::Z4 as usize,
+        Tile::Z5 as usize,
+        Tile::Z6 as usize,
+        Tile::Z7 as usize,
     ];
     let t = hand.summarize_tiles();
     let mut pair: u32 = 0;
@@ -356,8 +364,7 @@ trait ShantenAccumulator: Sized {
     fn finalize(self, pre: Self::Preprocess) -> Self;
 }
 
-// --- CountOnly: カウンタのみ（高速版） ---
-
+// シャンテン数カウントのみの高速版
 struct CountOnlyPreprocess {
     same3: usize,
     seq3: usize,
@@ -365,9 +372,13 @@ struct CountOnlyPreprocess {
 
 impl PreprocessResult for CountOnlyPreprocess {
     #[inline(always)]
-    fn same3_count(&self) -> usize { self.same3 }
+    fn same3_count(&self) -> usize {
+        self.same3
+    }
     #[inline(always)]
-    fn seq3_count(&self) -> usize { self.seq3 }
+    fn seq3_count(&self) -> usize {
+        self.seq3
+    }
 }
 
 struct CountOnly {
@@ -389,48 +400,85 @@ impl ShantenAccumulator for CountOnly {
 
     #[inline(always)]
     fn new_tracking() -> Self {
-        CountOnly { same3: 0, seq3: 0, same2: 0, seq2: 0 }
+        CountOnly {
+            same3: 0,
+            seq3: 0,
+            same2: 0,
+            seq2: 0,
+        }
     }
 
     #[inline(always)]
-    fn push_same3(&mut self, _tile: usize) { self.same3 += 1; }
+    fn push_same3(&mut self, _tile: usize) {
+        self.same3 += 1;
+    }
     #[inline(always)]
-    fn pop_same3(&mut self) { self.same3 -= 1; }
+    fn pop_same3(&mut self) {
+        self.same3 -= 1;
+    }
     #[inline(always)]
-    fn same3_count(&self) -> usize { self.same3 }
+    fn same3_count(&self) -> usize {
+        self.same3
+    }
 
     #[inline(always)]
-    fn push_seq3(&mut self, _tile: usize) { self.seq3 += 1; }
+    fn push_seq3(&mut self, _tile: usize) {
+        self.seq3 += 1;
+    }
     #[inline(always)]
-    fn pop_seq3(&mut self) { self.seq3 -= 1; }
+    fn pop_seq3(&mut self) {
+        self.seq3 -= 1;
+    }
     #[inline(always)]
-    fn seq3_count(&self) -> usize { self.seq3 }
+    fn seq3_count(&self) -> usize {
+        self.seq3
+    }
 
     #[inline(always)]
-    fn push_same2(&mut self, _tile: usize) { self.same2 += 1; }
+    fn push_same2(&mut self, _tile: usize) {
+        self.same2 += 1;
+    }
     #[inline(always)]
-    fn pop_same2(&mut self) { self.same2 -= 1; }
+    fn pop_same2(&mut self) {
+        self.same2 -= 1;
+    }
     #[inline(always)]
-    fn same2_count(&self) -> usize { self.same2 }
+    fn same2_count(&self) -> usize {
+        self.same2
+    }
 
     #[inline(always)]
-    fn push_seq2(&mut self, _tile1: usize, _tile2: usize) { self.seq2 += 1; }
+    fn push_seq2(&mut self, _tile1: usize, _tile2: usize) {
+        self.seq2 += 1;
+    }
     #[inline(always)]
-    fn pop_seq2(&mut self) { self.seq2 -= 1; }
+    fn pop_seq2(&mut self) {
+        self.seq2 -= 1;
+    }
     #[inline(always)]
-    fn seq2_count(&self) -> usize { self.seq2 }
+    fn seq2_count(&self) -> usize {
+        self.seq2
+    }
 
     #[inline(always)]
     fn snapshot_best(&self, _pre: &CountOnlyPreprocess, _t: &TileSummarize, _head: usize) -> Self {
         // カウンタのみなのでスナップショット不要
-        CountOnly { same3: 0, seq3: 0, same2: 0, seq2: 0 }
+        CountOnly {
+            same3: 0,
+            seq3: 0,
+            same2: 0,
+            seq2: 0,
+        }
     }
 
     #[inline(always)]
-    fn finalize(self, _pre: CountOnlyPreprocess) -> Self { self }
+    fn finalize(self, _pre: CountOnlyPreprocess) -> Self {
+        self
+    }
 }
 
-// --- FullTracking: Vec 追跡（役判定・符計算用） ---
+// Vec に個々の面子などを格納する
+// 役判定や符計算用に使用する、ややコストのかかるバージョン
 
 struct FullTrackingPreprocess {
     same3: Vec<Same3>,
@@ -439,8 +487,12 @@ struct FullTrackingPreprocess {
 }
 
 impl PreprocessResult for FullTrackingPreprocess {
-    fn same3_count(&self) -> usize { self.same3.len() }
-    fn seq3_count(&self) -> usize { self.seq3.len() }
+    fn same3_count(&self) -> usize {
+        self.same3.len()
+    }
+    fn seq3_count(&self) -> usize {
+        self.seq3.len()
+    }
 }
 
 struct FullTracking {
@@ -458,7 +510,11 @@ impl ShantenAccumulator for FullTracking {
         let same3 = extract_independent_same3_full(t)?;
         let seq3 = extract_independent_seq3_full(t)?;
         let singles = extract_independent_singles_full(t)?;
-        Ok(FullTrackingPreprocess { same3, seq3, singles })
+        Ok(FullTrackingPreprocess {
+            same3,
+            seq3,
+            singles,
+        })
     }
 
     fn new_tracking() -> Self {
@@ -472,32 +528,61 @@ impl ShantenAccumulator for FullTracking {
     }
 
     fn push_same3(&mut self, tile: usize) {
-        self.same3.push(Same3::new(tile as TileType, tile as TileType, tile as TileType).unwrap());
+        self.same3
+            .push(Same3::new(tile as TileType, tile as TileType, tile as TileType).unwrap());
     }
-    fn pop_same3(&mut self) { self.same3.pop(); }
-    fn same3_count(&self) -> usize { self.same3.len() }
+    fn pop_same3(&mut self) {
+        self.same3.pop();
+    }
+    fn same3_count(&self) -> usize {
+        self.same3.len()
+    }
 
     fn push_seq3(&mut self, tile: usize) {
-        self.sequential3.push(Sequential3::new(
-            tile as TileType, (tile + 1) as TileType, (tile + 2) as TileType,
-        ).unwrap());
+        self.sequential3.push(
+            Sequential3::new(
+                tile as TileType,
+                (tile + 1) as TileType,
+                (tile + 2) as TileType,
+            )
+            .unwrap(),
+        );
     }
-    fn pop_seq3(&mut self) { self.sequential3.pop(); }
-    fn seq3_count(&self) -> usize { self.sequential3.len() }
+    fn pop_seq3(&mut self) {
+        self.sequential3.pop();
+    }
+    fn seq3_count(&self) -> usize {
+        self.sequential3.len()
+    }
 
     fn push_same2(&mut self, tile: usize) {
-        self.same2.push(Same2::new(tile as TileType, tile as TileType).unwrap());
+        self.same2
+            .push(Same2::new(tile as TileType, tile as TileType).unwrap());
     }
-    fn pop_same2(&mut self) { self.same2.pop(); }
-    fn same2_count(&self) -> usize { self.same2.len() }
+    fn pop_same2(&mut self) {
+        self.same2.pop();
+    }
+    fn same2_count(&self) -> usize {
+        self.same2.len()
+    }
 
     fn push_seq2(&mut self, tile1: usize, tile2: usize) {
-        self.sequential2.push(Sequential2::new(tile1 as TileType, tile2 as TileType).unwrap());
+        self.sequential2
+            .push(Sequential2::new(tile1 as TileType, tile2 as TileType).unwrap());
     }
-    fn pop_seq2(&mut self) { self.sequential2.pop(); }
-    fn seq2_count(&self) -> usize { self.sequential2.len() }
+    fn pop_seq2(&mut self) {
+        self.sequential2.pop();
+    }
+    fn seq2_count(&self) -> usize {
+        self.sequential2.len()
+    }
 
-    fn snapshot_best(&self, _pre: &FullTrackingPreprocess, t: &TileSummarize, _head: usize) -> Self {
+    fn snapshot_best(
+        &self,
+        _pre: &FullTrackingPreprocess,
+        t: &TileSummarize,
+        _head: usize,
+    ) -> Self {
         let mut single = Vec::new();
         for i in 0..Tile::LEN as usize {
             for _ in 0..t[i] {
@@ -520,8 +605,6 @@ impl ShantenAccumulator for FullTracking {
         self
     }
 }
-
-// --- 共通再帰ロジック ---
 
 /// 通常形のシャンテン数を計算する共通エントリポイント
 fn calc_normal_shanten<A: ShantenAccumulator>(hand: &Hand) -> Result<(i32, A)> {
@@ -658,8 +741,8 @@ fn is_isolated(t: &TileSummarize, i: usize) -> bool {
     }
     let pos = i % 9;
     let base = i - pos;
-    let left2  = pos < 2 || t[base + pos - 2] == 0;
-    let left1  = pos < 1 || t[base + pos - 1] == 0;
+    let left2 = pos < 2 || t[base + pos - 2] == 0;
+    let left1 = pos < 1 || t[base + pos - 1] == 0;
     let right1 = pos > 7 || t[base + pos + 1] == 0;
     let right2 = pos > 6 || t[base + pos + 2] == 0;
     left2 && left1 && right1 && right2
@@ -694,18 +777,23 @@ fn extract_independent_same3_full(t: &mut TileSummarize) -> Result<Vec<Same3>> {
 ///
 /// 一盃口を先に処理してから通常処理する。
 /// `on_found` は見つかった順子の先頭インデックスと個数（1 or 2）を受け取る。
-fn extract_independent_seq3_impl(
-    t: &mut TileSummarize,
-    mut on_found: impl FnMut(usize, u32),
-) {
+fn extract_independent_seq3_impl(t: &mut TileSummarize, mut on_found: impl FnMut(usize, u32)) {
     for n in (1u32..=2).rev() {
         for suit_start in (0..27).step_by(9) {
             for k in 0..=6usize {
                 let l = suit_start + k;
-                if k >= 2 && t[l - 2] > 0 { continue; }
-                if k >= 1 && t[l - 1] > 0 { continue; }
-                if k <= 5 && t[l + 3] > 0 { continue; }
-                if k <= 4 && t[l + 4] > 0 { continue; }
+                if k >= 2 && t[l - 2] > 0 {
+                    continue;
+                }
+                if k >= 1 && t[l - 1] > 0 {
+                    continue;
+                }
+                if k <= 5 && t[l + 3] > 0 {
+                    continue;
+                }
+                if k <= 4 && t[l + 4] > 0 {
+                    continue;
+                }
                 if t[l] == n && t[l + 1] == n && t[l + 2] == n {
                     t[l] -= n;
                     t[l + 1] -= n;
@@ -731,15 +819,22 @@ fn extract_independent_seq3_full(t: &mut TileSummarize) -> Result<Vec<Sequential
     let mut result = Vec::new();
     let mut err: Option<anyhow::Error> = None;
     extract_independent_seq3_impl(t, |l, n| {
-        if err.is_some() { return; }
+        if err.is_some() {
+            return;
+        }
         for _ in 0..n {
             match Sequential3::new(l as TileType, (l + 1) as TileType, (l + 2) as TileType) {
                 Ok(s) => result.push(s),
-                Err(e) => { err = Some(e); return; }
+                Err(e) => {
+                    err = Some(e);
+                    return;
+                }
             }
         }
     });
-    if let Some(e) = err { return Err(e); }
+    if let Some(e) = err {
+        return Err(e);
+    }
     Ok(result)
 }
 
@@ -938,8 +1033,18 @@ mod tests {
     #[test]
     fn opened_hand_cannot_be_seven_pairs_or_thirteen_orphans() {
         let test = Hand::from("123456789m11p 789s 1p");
-        assert!(HandAnalyzer::new_by_form(&test, Form::SevenPairs).unwrap().shanten > 0);
-        assert!(HandAnalyzer::new_by_form(&test, Form::ThirteenOrphans).unwrap().shanten > 0);
+        assert!(
+            HandAnalyzer::new_by_form(&test, Form::SevenPairs)
+                .unwrap()
+                .shanten
+                > 0
+        );
+        assert!(
+            HandAnalyzer::new_by_form(&test, Form::ThirteenOrphans)
+                .unwrap()
+                .shanten
+                > 0
+        );
     }
 
     /// 様々なパターンの手牌でシャンテン数が正しいことを検証する回帰テスト
@@ -959,6 +1064,9 @@ mod tests {
     fn shanten_regression(#[case] hand_str: &str, #[case] expected: i32) {
         let hand = Hand::from(hand_str);
         let shanten = HandAnalyzer::new(&hand).unwrap().shanten;
-        assert_eq!(shanten, expected, "hand '{hand_str}': expected {expected}, got {shanten}");
+        assert_eq!(
+            shanten, expected,
+            "hand '{hand_str}': expected {expected}, got {shanten}"
+        );
     }
 }

--- a/crates/mahjong-core/src/hand_info/hand_analyzer.rs
+++ b/crates/mahjong-core/src/hand_info/hand_analyzer.rs
@@ -1052,8 +1052,8 @@ mod tests {
 
     /// 様々なパターンの手牌でシャンテン数が正しいことを検証する回帰テスト
     #[rstest::rstest]
-    #[case::seven_pairs_tenpai("226699m99p228s66z 1z", 0)]
-    #[case::thirteen_orphans_tenpai("19m19p11s1234567z 5m", 0)]
+    #[case::seven_pairs_ready("226699m99p228s66z 1z", 0)]
+    #[case::thirteen_orphans_ready("19m19p11s1234567z 5m", 0)]
     #[case::normal_win_triplets("123m444p789s1112z 2z", -1)]
     #[case::normal_win_flush("222333444666s6z 6z", -1)]
     #[case::normal_win_nine_gates("1112345678999m 5m", -1)]

--- a/crates/mahjong-core/src/hand_info/hand_analyzer.rs
+++ b/crates/mahjong-core/src/hand_info/hand_analyzer.rs
@@ -215,9 +215,11 @@ impl HandAnalyzer {
     }
 }
 
-/// 和了しているか否か
-pub fn has_won(hand: &HandAnalyzer) -> bool {
-    hand.shanten == -1
+impl HandAnalyzer {
+    /// 和了しているか否か
+    pub fn has_won(&self) -> bool {
+        self.shanten == -1
+    }
 }
 
 /// 向聴数のみを高速に計算する（ブロック分解・Vec格納なし）

--- a/crates/mahjong-core/src/hand_info/hand_analyzer.rs
+++ b/crates/mahjong-core/src/hand_info/hand_analyzer.rs
@@ -129,47 +129,40 @@ impl HandAnalyzer {
     /// ```
     pub fn new_by_form(hand: &Hand, form: Form) -> Result<HandAnalyzer> {
         Ok(match form {
-            Form::SevenPairs => HandAnalyzer::calc_seven_pairs(hand)?,
-            Form::ThirteenOrphans => HandAnalyzer::calc_thirteen_orphans(hand)?,
-            Form::Normal => HandAnalyzer::calc_normal_form(hand)?,
+            Form::SevenPairs => HandAnalyzer::analyze_seven_pairs(hand)?,
+            Form::ThirteenOrphans => HandAnalyzer::analyze_thirteen_orphans(hand)?,
+            Form::Normal => HandAnalyzer::analyze_normal_form(hand)?,
         })
     }
 
-    /// 七対子への向聴数を計算する
+    /// 七対子への向聴数を計算・ブロック分解する
     ///
     /// Vecへの詰め込みは`same2`（対子）以外は`single`（単独）に詰め込まれる。
     /// 七対子はVecを使用する役として断么九・混老頭・混一色・清一色と複合しうる
-    fn calc_seven_pairs(hand: &Hand) -> Result<HandAnalyzer> {
+    fn analyze_seven_pairs(hand: &Hand) -> Result<HandAnalyzer> {
         if !hand.opened().is_empty() {
             return Ok(HandAnalyzer::unavailable(Form::SevenPairs));
         }
 
-        let mut pair: u32 = 0;
-        let mut kind: u32 = 0;
         let mut t = hand.summarize_tiles();
-        let mut same2: Vec<Same2> = Vec::new();
+        let (shanten, pair_count) = calc_seven_pairs_shanten(&t);
+        let _ = pair_count; // ブロック分解では直接使わない
 
+        let mut same2: Vec<Same2> = Vec::new();
         for i in 0..Tile::LEN {
-            if t[i] > 0 {
-                kind += 1;
-                if t[i] >= 2 {
-                    pair += 1;
-                    same2.push(Same2::new(i as TileType, i as TileType)?);
-                    t[i] -= 2;
-                }
+            if t[i] >= 2 {
+                same2.push(Same2::new(i as TileType, i as TileType)?);
+                t[i] -= 2;
             }
         }
-        let num_to_win: i32 = (7 - pair + if kind < 7 { 7 - kind } else { 0 }) as i32;
         let mut single: Vec<TileType> = Vec::new();
         for i in 0..Tile::LEN {
-            if t[i] > 0 {
-                for _ in 0..t[i] {
-                    single.push(i as TileType);
-                }
+            for _ in 0..t[i] {
+                single.push(i as TileType);
             }
         }
         Ok(HandAnalyzer {
-            shanten: num_to_win - 1,
+            shanten,
             form: Form::SevenPairs,
             same3: Vec::new(),
             sequential3: Vec::new(),
@@ -181,42 +174,16 @@ impl HandAnalyzer {
 
     /// 国士無双への向聴数を計算する
     ///
-    /// Vecへの詰め込みは未実装（詰め込んでも意味がない）
-    fn calc_thirteen_orphans(hand: &Hand) -> Result<HandAnalyzer> {
+    /// ブロック分解・Vecへの詰め込みは未実装（詰め込んでも意味がない）
+    fn analyze_thirteen_orphans(hand: &Hand) -> Result<HandAnalyzer> {
         if !hand.opened().is_empty() {
             return Ok(HandAnalyzer::unavailable(Form::ThirteenOrphans));
         }
 
-        let to_tiles = [
-            Tile::M1,
-            Tile::M9,
-            Tile::P1,
-            Tile::P9,
-            Tile::S1,
-            Tile::S9,
-            Tile::Z1,
-            Tile::Z2,
-            Tile::Z3,
-            Tile::Z4,
-            Tile::Z5,
-            Tile::Z6,
-            Tile::Z7,
-        ];
-        let mut pair: u32 = 0;
-        let mut kind: u32 = 0;
         let t = hand.summarize_tiles();
-
-        for i in &to_tiles {
-            if t[*i as usize] > 0 {
-                kind = kind + 1;
-                if t[*i as usize] >= 2 {
-                    pair += 1;
-                }
-            }
-        }
-        let num_to_win: i32 = (14 - kind - if pair > 0 { 1 } else { 0 }) as i32;
+        let shanten = calc_thirteen_orphans_shanten(&t);
         Ok(HandAnalyzer {
-            shanten: num_to_win - 1,
+            shanten,
             form: Form::ThirteenOrphans,
             same3: Vec::new(),
             sequential3: Vec::new(),
@@ -226,8 +193,8 @@ impl HandAnalyzer {
         })
     }
 
-    /// 通常の役への向聴数を計算する
-    fn calc_normal_form(hand: &Hand) -> Result<HandAnalyzer> {
+    /// 通常の役への向聴数を計算・ブロック分解する
+    fn analyze_normal_form(hand: &Hand) -> Result<HandAnalyzer> {
         let (shanten, tracking) = calc_normal_shanten::<FullTracking>(hand)?;
         let FullTracking {
             same3,
@@ -253,24 +220,25 @@ pub fn has_won(hand: &HandAnalyzer) -> bool {
     hand.shanten == -1
 }
 
-/// 向聴数のみを高速に計算する（ブロック分解のVec割り当てなし）
+/// 向聴数のみを高速に計算する（ブロック分解・Vec格納なし）
 ///
 /// `HandAnalyzer::new()` と同じ結果を返すが、向聴数の数値のみを返す。
 /// CPU打牌評価など大量に呼び出す箇所で使用する。
-pub fn shanten_number(hand: &Hand) -> i32 {
-    let sp = shanten_seven_pairs(hand);
-    let to = shanten_thirteen_orphans(hand);
+pub fn calc_shanten_number(hand: &Hand) -> i32 {
+    let t = hand.summarize_tiles();
+    let is_closed = hand.opened().is_empty();
+    let sp = if is_closed { calc_seven_pairs_shanten(&t).0 } else { UNAVAILABLE_SHANTEN };
+    let to = if is_closed { calc_thirteen_orphans_shanten(&t) } else { UNAVAILABLE_SHANTEN };
     let nm = calc_normal_shanten::<CountOnly>(hand)
         .map(|(s, _)| s)
         .unwrap_or(UNAVAILABLE_SHANTEN);
     min(min(sp, to), nm)
 }
 
-fn shanten_seven_pairs(hand: &Hand) -> i32 {
-    if !hand.opened().is_empty() {
-        return UNAVAILABLE_SHANTEN;
-    }
-    let t = hand.summarize_tiles();
+/// 七対子のシャンテン数を計算する共通ロジック
+///
+/// 戻り値: `(shanten, pair_count)`
+fn calc_seven_pairs_shanten(t: &TileSummarize) -> (i32, u32) {
     let mut pair: u32 = 0;
     let mut kind: u32 = 0;
     for i in 0..Tile::LEN as usize {
@@ -281,14 +249,13 @@ fn shanten_seven_pairs(hand: &Hand) -> i32 {
             }
         }
     }
-    (7 - pair + if kind < 7 { 7 - kind } else { 0 }) as i32 - 1
+    let shanten = (7 - pair + if kind < 7 { 7 - kind } else { 0 }) as i32 - 1;
+    (shanten, pair)
 }
 
-fn shanten_thirteen_orphans(hand: &Hand) -> i32 {
-    if !hand.opened().is_empty() {
-        return UNAVAILABLE_SHANTEN;
-    }
-    let to_tiles: [usize; 13] = [
+/// 国士無双のシャンテン数を計算する共通ロジック
+fn calc_thirteen_orphans_shanten(t: &TileSummarize) -> i32 {
+    const TO_TILES: [usize; 13] = [
         Tile::M1 as usize,
         Tile::M9 as usize,
         Tile::P1 as usize,
@@ -303,10 +270,9 @@ fn shanten_thirteen_orphans(hand: &Hand) -> i32 {
         Tile::Z6 as usize,
         Tile::Z7 as usize,
     ];
-    let t = hand.summarize_tiles();
     let mut pair: u32 = 0;
     let mut kind: u32 = 0;
-    for &i in &to_tiles {
+    for &i in &TO_TILES {
         if t[i] > 0 {
             kind += 1;
             if t[i] >= 2 {

--- a/crates/mahjong-core/src/winning_hand/check_1_han.rs
+++ b/crates/mahjong-core/src/winning_hand/check_1_han.rs
@@ -19,7 +19,7 @@ pub fn check_ready_hand(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     if status.has_claimed_open {
@@ -47,7 +47,7 @@ pub fn check_self_pick(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     if !status.has_claimed_open && status.is_self_picked {
@@ -67,7 +67,7 @@ pub fn check_one_shot(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     if !check_ready_hand(hand_analyzer, status, settings)?.1 {
@@ -89,7 +89,7 @@ pub fn check_last_tile_from_the_wall(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     if status.is_last_tile_from_the_wall && status.is_self_picked {
@@ -109,7 +109,7 @@ pub fn check_last_discard(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     if status.is_last_discard && !status.is_self_picked {
@@ -129,7 +129,7 @@ pub fn check_dead_wall_draw(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     if status.is_dead_wall_draw && status.is_self_picked {
@@ -149,7 +149,7 @@ pub fn check_robbing_a_quad(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     if status.is_robbing_a_quad && !status.is_self_picked {
@@ -169,7 +169,7 @@ pub fn check_double_ready(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     if status.has_claimed_open {
@@ -193,7 +193,7 @@ pub fn check_no_points_hand(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 門前でなければ平和は成立しない
@@ -263,7 +263,7 @@ pub fn check_one_set_of_identical_sequences(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 鳴いていたら一盃口は成立しない
@@ -310,7 +310,7 @@ pub fn check_all_simples(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 喰いタンなしなら鳴いている時点で抜ける
@@ -357,7 +357,7 @@ pub fn check_honor_tiles_players_wind(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     let mut has_player_wind = false;
@@ -385,7 +385,7 @@ pub fn check_honor_tiles_prevailing_wind(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     let mut has_prevailing_wind = false;
@@ -405,7 +405,7 @@ pub fn check_honor_tiles_prevailing_wind(
 
 /// 面子に三元牌の順子が含まれるか調べる
 pub fn check_honor_tiles_dragons(hand_analyzer: &HandAnalyzer, dragon: Dragon) -> Result<bool> {
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok(false);
     }
     let mut has_dragon = false;

--- a/crates/mahjong-core/src/winning_hand/check_1_han.rs
+++ b/crates/mahjong-core/src/winning_hand/check_1_han.rs
@@ -19,7 +19,7 @@ pub fn check_ready_hand(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     if status.has_claimed_open {
@@ -47,7 +47,7 @@ pub fn check_self_pick(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     if !status.has_claimed_open && status.is_self_picked {
@@ -67,7 +67,7 @@ pub fn check_one_shot(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     if !check_ready_hand(hand_analyzer, status, settings)?.1 {
@@ -89,7 +89,7 @@ pub fn check_last_tile_from_the_wall(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     if status.is_last_tile_from_the_wall && status.is_self_picked {
@@ -109,7 +109,7 @@ pub fn check_last_discard(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     if status.is_last_discard && !status.is_self_picked {
@@ -129,7 +129,7 @@ pub fn check_dead_wall_draw(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     if status.is_dead_wall_draw && status.is_self_picked {
@@ -149,7 +149,7 @@ pub fn check_robbing_a_quad(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     if status.is_robbing_a_quad && !status.is_self_picked {
@@ -169,7 +169,7 @@ pub fn check_double_ready(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     if status.has_claimed_open {
@@ -193,7 +193,7 @@ pub fn check_no_points_hand(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 門前でなければ平和は成立しない
@@ -263,7 +263,7 @@ pub fn check_one_set_of_identical_sequences(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 鳴いていたら一盃口は成立しない
@@ -310,7 +310,7 @@ pub fn check_all_simples(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 喰いタンなしなら鳴いている時点で抜ける
@@ -357,7 +357,7 @@ pub fn check_honor_tiles_players_wind(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     let mut has_player_wind = false;
@@ -385,7 +385,7 @@ pub fn check_honor_tiles_prevailing_wind(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     let mut has_prevailing_wind = false;
@@ -405,7 +405,7 @@ pub fn check_honor_tiles_prevailing_wind(
 
 /// 面子に三元牌の順子が含まれるか調べる
 pub fn check_honor_tiles_dragons(hand_analyzer: &HandAnalyzer, dragon: Dragon) -> Result<bool> {
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok(false);
     }
     let mut has_dragon = false;

--- a/crates/mahjong-core/src/winning_hand/check_2_han.rs
+++ b/crates/mahjong-core/src/winning_hand/check_2_han.rs
@@ -20,7 +20,7 @@ pub fn check_seven_pairs(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     if hand_analyzer.form == Form::SevenPairs {
@@ -41,7 +41,7 @@ pub fn check_three_color_straight(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 順子が3つ以上なければ三色同順はありえない
@@ -93,7 +93,7 @@ pub fn check_straight(
         settings.display_lang,
     );
 
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     let mut m = [false; 3];
@@ -135,7 +135,7 @@ pub fn check_all_triplet_hand(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     if hand_analyzer.same3.len() == 4 && hand_analyzer.same2.len() == 1 {
@@ -155,7 +155,7 @@ pub fn check_three_closed_triplets(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
 
@@ -206,7 +206,7 @@ pub fn check_three_color_triplets(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 刻子が3つ以上なければ三色同刻はありえない
@@ -251,7 +251,7 @@ pub fn check_terminal_or_honor_in_each_set(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
 
@@ -312,7 +312,7 @@ pub fn check_all_terminals_and_honors(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 混老頭は全ての面子・雀頭が么九牌（1,9）または字牌で構成される
@@ -360,7 +360,7 @@ pub fn check_little_three_dragons(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 小三元: 三元牌のうち2つが刻子、1つが雀頭
@@ -529,7 +529,7 @@ mod tests {
         let settings = Settings::new();
         status.is_self_picked = is_self_picked;
         status.has_claimed_open = has_claimed_open;
-        assert_eq!(test_analyzer.shanten, -1);
+        assert!(test_analyzer.shanten.has_won());
         assert_eq!(
             check_three_closed_triplets(&test_analyzer, &test, &status, &settings).unwrap(),
             expected

--- a/crates/mahjong-core/src/winning_hand/check_2_han.rs
+++ b/crates/mahjong-core/src/winning_hand/check_2_han.rs
@@ -20,7 +20,7 @@ pub fn check_seven_pairs(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     if hand_analyzer.form == Form::SevenPairs {
@@ -41,7 +41,7 @@ pub fn check_three_color_straight(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 順子が3つ以上なければ三色同順はありえない
@@ -93,7 +93,7 @@ pub fn check_straight(
         settings.display_lang,
     );
 
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     let mut m = [false; 3];
@@ -135,7 +135,7 @@ pub fn check_all_triplet_hand(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     if hand_analyzer.same3.len() == 4 && hand_analyzer.same2.len() == 1 {
@@ -155,7 +155,7 @@ pub fn check_three_closed_triplets(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
 
@@ -206,7 +206,7 @@ pub fn check_three_color_triplets(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 刻子が3つ以上なければ三色同刻はありえない
@@ -251,7 +251,7 @@ pub fn check_terminal_or_honor_in_each_set(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
 
@@ -312,7 +312,7 @@ pub fn check_all_terminals_and_honors(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 混老頭は全ての面子・雀頭が么九牌（1,9）または字牌で構成される
@@ -360,7 +360,7 @@ pub fn check_little_three_dragons(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 小三元: 三元牌のうち2つが刻子、1つが雀頭

--- a/crates/mahjong-core/src/winning_hand/check_3_han.rs
+++ b/crates/mahjong-core/src/winning_hand/check_3_han.rs
@@ -17,7 +17,7 @@ pub fn check_two_sets_of_identical_sequences(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 門前でなければ二盃口は成立しない
@@ -64,7 +64,7 @@ pub fn check_terminal_in_each_set(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 清老頭とは複合しないため、必ず順子が含まれる
@@ -115,7 +115,7 @@ pub fn check_half_flush(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     let mut has_honor = false;

--- a/crates/mahjong-core/src/winning_hand/check_3_han.rs
+++ b/crates/mahjong-core/src/winning_hand/check_3_han.rs
@@ -17,7 +17,7 @@ pub fn check_two_sets_of_identical_sequences(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 門前でなければ二盃口は成立しない
@@ -64,7 +64,7 @@ pub fn check_terminal_in_each_set(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 清老頭とは複合しないため、必ず順子が含まれる
@@ -115,7 +115,7 @@ pub fn check_half_flush(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     let mut has_honor = false;

--- a/crates/mahjong-core/src/winning_hand/check_5_han.rs
+++ b/crates/mahjong-core/src/winning_hand/check_5_han.rs
@@ -16,7 +16,7 @@ pub fn check_nagashi_mangan(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 流し満貫は状態フラグで判定する

--- a/crates/mahjong-core/src/winning_hand/check_5_han.rs
+++ b/crates/mahjong-core/src/winning_hand/check_5_han.rs
@@ -16,7 +16,7 @@ pub fn check_nagashi_mangan(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 流し満貫は状態フラグで判定する

--- a/crates/mahjong-core/src/winning_hand/check_6_han.rs
+++ b/crates/mahjong-core/src/winning_hand/check_6_han.rs
@@ -13,7 +13,7 @@ pub fn check_flush(
     settings: &Settings,
 ) -> Result<(&'static str, bool, u32)> {
     let name = get(Kind::Flush, status.has_claimed_open, settings.display_lang);
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 清一色: 1種類の数牌のみで構成される（字牌なし）

--- a/crates/mahjong-core/src/winning_hand/check_6_han.rs
+++ b/crates/mahjong-core/src/winning_hand/check_6_han.rs
@@ -13,7 +13,7 @@ pub fn check_flush(
     settings: &Settings,
 ) -> Result<(&'static str, bool, u32)> {
     let name = get(Kind::Flush, status.has_claimed_open, settings.display_lang);
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 清一色: 1種類の数牌のみで構成される（字牌なし）

--- a/crates/mahjong-core/src/winning_hand/check_yakuman.rs
+++ b/crates/mahjong-core/src/winning_hand/check_yakuman.rs
@@ -19,7 +19,7 @@ pub fn check_thirteen_orphans(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     return if hand_analyzer.form == Form::ThirteenOrphans {
@@ -49,7 +49,7 @@ pub fn check_four_concealed_triplets(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     if status.has_claimed_open
@@ -78,7 +78,7 @@ pub fn check_four_concealed_triplets_single_wait(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     if status.has_claimed_open || hand_analyzer.same3.len() != 4 {
@@ -102,7 +102,7 @@ pub fn check_big_three_dragons(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 大三元: 三元牌（白・發・中）の3つすべてが刻子
@@ -132,7 +132,7 @@ pub fn check_little_four_winds(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 小四喜: 風牌のうち3つが刻子、1つが雀頭
@@ -173,7 +173,7 @@ pub fn check_big_four_winds(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 大四喜: 風牌4つすべてが刻子
@@ -204,7 +204,7 @@ pub fn check_all_honors(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 字一色: すべての牌が字牌で構成される
@@ -243,7 +243,7 @@ pub fn check_all_terminals(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 清老頭: すべての牌が数牌の1と9のみで構成される（字牌なし・順子なし）
@@ -273,7 +273,7 @@ pub fn check_all_green(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 緑一色: 2s, 3s, 4s, 6s, 8s, 6z（發）のみで構成される
@@ -314,7 +314,7 @@ pub fn check_nine_gates(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 九蓮宝燈: 門前で同一種の数牌のみで、1112345678999+同種1枚の形
@@ -437,7 +437,7 @@ pub fn check_four_kans(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 四槓子: 4つの槓子を持っている
@@ -458,7 +458,7 @@ pub fn check_heavenly_hand(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 天和: 親の配牌時点で和了している（第一ツモ・親・自摸）
@@ -480,7 +480,7 @@ pub fn check_hand_of_earth(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !has_won(hand_analyzer) {
+    if !hand_analyzer.has_won() {
         return Ok((name, false, 0));
     }
     // 地和: 子の第一ツモで和了している（第一ツモ・子・自摸）

--- a/crates/mahjong-core/src/winning_hand/check_yakuman.rs
+++ b/crates/mahjong-core/src/winning_hand/check_yakuman.rs
@@ -19,7 +19,7 @@ pub fn check_thirteen_orphans(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     return if hand_analyzer.form == Form::ThirteenOrphans {
@@ -49,7 +49,7 @@ pub fn check_four_concealed_triplets(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     if status.has_claimed_open
@@ -78,7 +78,7 @@ pub fn check_four_concealed_triplets_single_wait(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     if status.has_claimed_open || hand_analyzer.same3.len() != 4 {
@@ -102,7 +102,7 @@ pub fn check_big_three_dragons(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 大三元: 三元牌（白・發・中）の3つすべてが刻子
@@ -132,7 +132,7 @@ pub fn check_little_four_winds(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 小四喜: 風牌のうち3つが刻子、1つが雀頭
@@ -173,7 +173,7 @@ pub fn check_big_four_winds(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 大四喜: 風牌4つすべてが刻子
@@ -204,7 +204,7 @@ pub fn check_all_honors(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 字一色: すべての牌が字牌で構成される
@@ -243,7 +243,7 @@ pub fn check_all_terminals(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 清老頭: すべての牌が数牌の1と9のみで構成される（字牌なし・順子なし）
@@ -273,7 +273,7 @@ pub fn check_all_green(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 緑一色: 2s, 3s, 4s, 6s, 8s, 6z（發）のみで構成される
@@ -314,7 +314,7 @@ pub fn check_nine_gates(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 九蓮宝燈: 門前で同一種の数牌のみで、1112345678999+同種1枚の形
@@ -437,7 +437,7 @@ pub fn check_four_kans(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 四槓子: 4つの槓子を持っている
@@ -458,7 +458,7 @@ pub fn check_heavenly_hand(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 天和: 親の配牌時点で和了している（第一ツモ・親・自摸）
@@ -480,7 +480,7 @@ pub fn check_hand_of_earth(
         status.has_claimed_open,
         settings.display_lang,
     );
-    if !hand_analyzer.has_won() {
+    if !hand_analyzer.shanten.has_won() {
         return Ok((name, false, 0));
     }
     // 地和: 子の第一ツモで和了している（第一ツモ・子・自摸）
@@ -536,7 +536,7 @@ mod tests {
         let settings = Settings::new();
         status.is_self_picked = is_self_picked;
         status.has_claimed_open = has_claimed_open;
-        assert_eq!(test_analyzer.shanten, -1);
+        assert!(test_analyzer.shanten.has_won());
         assert_eq!(
             check_four_concealed_triplets_single_wait(&test_analyzer, &test, &status, &settings)
                 .unwrap(),

--- a/crates/mahjong-server/src/cpu/client.rs
+++ b/crates/mahjong-server/src/cpu/client.rs
@@ -4,7 +4,7 @@
 //! プレイヤーと全く同じプロトコルでサーバとやり取りする。
 
 use mahjong_core::hand::Hand;
-use mahjong_core::hand_info::hand_analyzer::shanten_number;
+use mahjong_core::hand_info::hand_analyzer::calc_shanten_number;
 use mahjong_core::hand_info::opened::{OpenFrom, OpenTiles, OpenType};
 use mahjong_core::tile::Tile;
 
@@ -281,7 +281,7 @@ impl CpuClient {
 
             // 捨てた後にテンパイ（shanten == 0）を維持するか
             let hand = Hand::new(remaining, None);
-            let shanten = shanten_number(&hand);
+            let shanten = calc_shanten_number(&hand);
 
             if shanten == 0 {
                 // 安全度で比較
@@ -329,7 +329,7 @@ impl CpuClient {
                         .copied()
                         .collect();
                     let hand = Hand::new(remaining, None);
-                    if shanten_number(&hand) > 0 {
+                    if calc_shanten_number(&hand) > 0 {
                         continue; // テンパイが崩れるのでカンしない
                     }
                 }
@@ -352,7 +352,7 @@ impl CpuClient {
             all_tiles.push(drawn);
         }
         let hand = Hand::new(all_tiles, None);
-        let shanten = shanten_number(&hand);
+        let shanten = calc_shanten_number(&hand);
 
         // テンパイなら基本的に攻撃
         if shanten <= 0 {
@@ -488,7 +488,7 @@ impl CpuClient {
     fn call_reduces_shanten_pon(&self, called_tile: Tile) -> bool {
         // 現在の向聴数
         let current_hand = Hand::new(self.state.my_hand.clone(), None);
-        let current_shanten = shanten_number(&current_hand);
+        let current_shanten = calc_shanten_number(&current_hand);
 
         // ポン後の手牌（同じ種類の2枚を除去）
         let tt = called_tile.get();
@@ -516,13 +516,13 @@ impl CpuClient {
         });
 
         let new_hand = Hand::new_with_opened(remaining, opened, None);
-        shanten_number(&new_hand) < current_shanten
+        calc_shanten_number(&new_hand) < current_shanten
     }
 
     /// チーした場合に向聴数が下がるか
     fn call_reduces_shanten_chi(&self, called_tile: Tile, hand_tiles: [u32; 2]) -> bool {
         let current_hand = Hand::new(self.state.my_hand.clone(), None);
-        let current_shanten = shanten_number(&current_hand);
+        let current_shanten = calc_shanten_number(&current_hand);
 
         // チー後の手牌（指定の2枚を除去）
         let mut remaining = self.state.my_hand.clone();
@@ -544,12 +544,16 @@ impl CpuClient {
         });
 
         let new_hand = Hand::new_with_opened(remaining, opened, None);
-        shanten_number(&new_hand) < current_shanten
+        calc_shanten_number(&new_hand) < current_shanten
     }
 }
 
 /// 役牌かどうか判定
-fn is_yakuhai(tile_type: u32, seat_wind: mahjong_core::tile::Wind, prevailing_wind: mahjong_core::tile::Wind) -> bool {
+fn is_yakuhai(
+    tile_type: u32,
+    seat_wind: mahjong_core::tile::Wind,
+    prevailing_wind: mahjong_core::tile::Wind,
+) -> bool {
     use mahjong_core::tile::Tile as T;
     // 三元牌
     if tile_type == T::Z5 || tile_type == T::Z6 || tile_type == T::Z7 {
@@ -628,10 +632,18 @@ mod tests {
         client.handle_event(&ServerEvent::GameStarted {
             seat_wind: Wind::East,
             hand: vec![
-                Tile::new(Tile::M1), Tile::new(Tile::M2), Tile::new(Tile::M3),
-                Tile::new(Tile::P4), Tile::new(Tile::P5), Tile::new(Tile::P6),
-                Tile::new(Tile::S7), Tile::new(Tile::S8), Tile::new(Tile::S9),
-                Tile::new(Tile::Z1), Tile::new(Tile::Z1), Tile::new(Tile::Z1),
+                Tile::new(Tile::M1),
+                Tile::new(Tile::M2),
+                Tile::new(Tile::M3),
+                Tile::new(Tile::P4),
+                Tile::new(Tile::P5),
+                Tile::new(Tile::P6),
+                Tile::new(Tile::S7),
+                Tile::new(Tile::S8),
+                Tile::new(Tile::S9),
+                Tile::new(Tile::Z1),
+                Tile::new(Tile::Z1),
+                Tile::new(Tile::Z1),
                 Tile::new(Tile::Z2),
             ],
             scores: [25000; 4],

--- a/crates/mahjong-server/src/cpu/client.rs
+++ b/crates/mahjong-server/src/cpu/client.rs
@@ -279,11 +279,11 @@ impl CpuClient {
             let mut remaining: Vec<Tile> = all_tiles.clone();
             remaining.remove(i);
 
-            // 捨てた後にテンパイ（shanten == 0）を維持するか
+            // 捨てた後にテンパイを維持するか
             let hand = Hand::new(remaining, None);
             let shanten = calc_shanten_number(&hand);
 
-            if shanten == 0 {
+            if shanten.is_tenpai() {
                 // 安全度で比較
                 let safety = super::defense::evaluate_safety(tile, &self.state);
                 if best.is_none() || safety > best.unwrap().1 {
@@ -329,7 +329,7 @@ impl CpuClient {
                         .copied()
                         .collect();
                     let hand = Hand::new(remaining, None);
-                    if calc_shanten_number(&hand) > 0 {
+                    if !calc_shanten_number(&hand).is_tenpai_or_won() {
                         continue; // テンパイが崩れるのでカンしない
                     }
                 }
@@ -355,7 +355,7 @@ impl CpuClient {
         let shanten = calc_shanten_number(&hand);
 
         // テンパイなら基本的に攻撃
-        if shanten <= 0 {
+        if shanten.is_tenpai_or_won() {
             return true;
         }
 

--- a/crates/mahjong-server/src/cpu/client.rs
+++ b/crates/mahjong-server/src/cpu/client.rs
@@ -283,7 +283,7 @@ impl CpuClient {
             let hand = Hand::new(remaining, None);
             let shanten = calc_shanten_number(&hand);
 
-            if shanten.is_tenpai() {
+            if shanten.is_ready() {
                 // 安全度で比較
                 let safety = super::defense::evaluate_safety(tile, &self.state);
                 if best.is_none() || safety > best.unwrap().1 {
@@ -329,7 +329,7 @@ impl CpuClient {
                         .copied()
                         .collect();
                     let hand = Hand::new(remaining, None);
-                    if !calc_shanten_number(&hand).is_tenpai_or_won() {
+                    if !calc_shanten_number(&hand).is_ready_or_won() {
                         continue; // テンパイが崩れるのでカンしない
                     }
                 }
@@ -355,7 +355,7 @@ impl CpuClient {
         let shanten = calc_shanten_number(&hand);
 
         // テンパイなら基本的に攻撃
-        if shanten.is_tenpai_or_won() {
+        if shanten.is_ready_or_won() {
             return true;
         }
 

--- a/crates/mahjong-server/src/cpu/evaluator.rs
+++ b/crates/mahjong-server/src/cpu/evaluator.rs
@@ -4,8 +4,8 @@
 //! 入力は CpuGameState のみ（サーバ内部にはアクセスしない）。
 
 use mahjong_core::hand::Hand;
-use mahjong_core::hand_info::hand_analyzer::shanten_number;
-use mahjong_core::tile::{dora_indicator_to_dora, Tile, TileType, Wind};
+use mahjong_core::hand_info::hand_analyzer::calc_shanten_number;
+use mahjong_core::tile::{Tile, TileType, Wind, dora_indicator_to_dora};
 
 use super::client::CpuConfig;
 use super::defense;
@@ -56,7 +56,7 @@ pub fn evaluate_discards(state: &CpuGameState, config: &CpuConfig) -> Vec<Discar
 
         // 向聴数を高速計算（Vec割り当てなし）
         let hand = Hand::new(remaining.clone(), None);
-        let shanten = shanten_number(&hand);
+        let shanten = calc_shanten_number(&hand);
 
         // 有効牌数（受入数）を計算（既知の向聴数を渡して重複計算を回避）
         let acceptance_count = if config.level.uses_acceptance_count() {
@@ -106,7 +106,7 @@ fn count_acceptance(hand_tiles: &[Tile], visible_counts: &[u8; 34], current_shan
 
         // この牌を加えて向聴数が下がるか（高速計算）
         let test_hand = Hand::new(hand_tiles.to_vec(), Some(Tile::new(tile_type)));
-        let new_shanten = shanten_number(&test_hand);
+        let new_shanten = calc_shanten_number(&test_hand);
 
         if new_shanten < current_shanten {
             total += remaining as u32;
@@ -194,7 +194,11 @@ fn is_chunchanpai(tile_type: TileType) -> bool {
 }
 
 /// 打牌候補から最良の1枚を選ぶ
-pub fn select_best_discard(candidates: &[DiscardCandidate], config: &CpuConfig, attacking: bool) -> Option<Tile> {
+pub fn select_best_discard(
+    candidates: &[DiscardCandidate],
+    config: &CpuConfig,
+    attacking: bool,
+) -> Option<Tile> {
     if candidates.is_empty() {
         return None;
     }
@@ -257,15 +261,19 @@ mod tests {
     #[test]
     fn test_is_chunchanpai() {
         assert!(!is_chunchanpai(Tile::M1)); // 1m = 端牌
-        assert!(is_chunchanpai(Tile::M2));  // 2m = 中張牌
-        assert!(is_chunchanpai(Tile::M8));  // 8m = 中張牌
+        assert!(is_chunchanpai(Tile::M2)); // 2m = 中張牌
+        assert!(is_chunchanpai(Tile::M8)); // 8m = 中張牌
         assert!(!is_chunchanpai(Tile::M9)); // 9m = 端牌
         assert!(!is_chunchanpai(Tile::Z1)); // 東 = 字牌
     }
 
     #[test]
     fn test_count_dora_in_hand() {
-        let hand = vec![Tile::new(Tile::M2), Tile::new(Tile::M2), Tile::new(Tile::M3)];
+        let hand = vec![
+            Tile::new(Tile::M2),
+            Tile::new(Tile::M2),
+            Tile::new(Tile::M3),
+        ];
         let indicators = vec![Tile::new(Tile::M1)]; // ドラ表示牌1m → ドラは2m
         assert_eq!(count_dora_in_hand(&hand, &indicators), 2);
     }

--- a/crates/mahjong-server/src/cpu/evaluator.rs
+++ b/crates/mahjong-server/src/cpu/evaluator.rs
@@ -4,7 +4,7 @@
 //! 入力は CpuGameState のみ（サーバ内部にはアクセスしない）。
 
 use mahjong_core::hand::Hand;
-use mahjong_core::hand_info::hand_analyzer::calc_shanten_number;
+use mahjong_core::hand_info::hand_analyzer::{ShantenNumber, calc_shanten_number};
 use mahjong_core::tile::{Tile, TileType, Wind, dora_indicator_to_dora};
 
 use super::client::CpuConfig;
@@ -17,7 +17,7 @@ pub struct DiscardCandidate {
     /// 捨てる牌
     pub tile: Tile,
     /// 捨てた後の向聴数
-    pub shanten: i32,
+    pub shanten: ShantenNumber,
     /// 有効牌の残り枚数（受入数）
     pub acceptance_count: u32,
     /// 推定打点スコア（高いほど良い）
@@ -95,7 +95,7 @@ pub fn evaluate_discards(state: &CpuGameState, config: &CpuConfig) -> Vec<Discar
 ///
 /// 13枚の手牌に対して、各牌種を加えた時に向聴数が下がるものをカウント。
 /// `current_shanten` は呼び出し元で既に計算済みの向聴数。
-fn count_acceptance(hand_tiles: &[Tile], visible_counts: &[u8; 34], current_shanten: i32) -> u32 {
+fn count_acceptance(hand_tiles: &[Tile], visible_counts: &[u8; 34], current_shanten: ShantenNumber) -> u32 {
     let mut total = 0u32;
     for tile_type in 0..34u32 {
         // 場に4枚全て見えていたら受入不可
@@ -211,7 +211,7 @@ pub fn select_best_discard(
             let mut score = 0.0;
 
             // 向聴数が低いほど良い（負の方向にスコアリング）
-            score -= c.shanten as f64 * 100.0;
+            score -= c.shanten.as_i32() as f64 * 100.0;
 
             // 有効牌数が多いほど良い
             score += c.acceptance_count as f64 * params.speed_weight;

--- a/crates/mahjong-server/src/round.rs
+++ b/crates/mahjong-server/src/round.rs
@@ -1154,7 +1154,7 @@ impl Round {
             }
         }
 
-        hand_analyzer::calc_shanten_number(&hand).is_tenpai()
+        hand_analyzer::calc_shanten_number(&hand).is_ready()
     }
 
     /// プレイヤーがリーチ宣言可能か判定する
@@ -1532,7 +1532,7 @@ impl Round {
         let mut noten_players = Vec::new();
 
         for i in 0..4 {
-            if scoring::is_tenpai(&self.players[i]) {
+            if scoring::is_ready(&self.players[i]) {
                 tenpai_players.push(i);
             } else {
                 noten_players.push(i);

--- a/crates/mahjong-server/src/round.rs
+++ b/crates/mahjong-server/src/round.rs
@@ -1154,7 +1154,7 @@ impl Round {
             }
         }
 
-        hand_analyzer::calc_shanten_number(&hand) == 0
+        hand_analyzer::calc_shanten_number(&hand).is_tenpai()
     }
 
     /// プレイヤーがリーチ宣言可能か判定する

--- a/crates/mahjong-server/src/round.rs
+++ b/crates/mahjong-server/src/round.rs
@@ -1154,7 +1154,7 @@ impl Round {
             }
         }
 
-        hand_analyzer::shanten_number(&hand) == 0
+        hand_analyzer::calc_shanten_number(&hand) == 0
     }
 
     /// プレイヤーがリーチ宣言可能か判定する

--- a/crates/mahjong-server/src/scoring.rs
+++ b/crates/mahjong-server/src/scoring.rs
@@ -49,7 +49,7 @@ pub fn check_win(
     };
 
     // 和了形（shanten == -1）でなければ不成立
-    if analyzer.shanten != -1 {
+    if !analyzer.shanten.has_won() {
         return WinCheckResult {
             is_win: false,
             score_result: None,
@@ -121,7 +121,7 @@ pub fn check_ron_with_flags(
         }
     };
 
-    if analyzer.shanten != -1 {
+    if !analyzer.shanten.has_won() {
         return WinCheckResult {
             is_win: false,
             score_result: None,
@@ -169,7 +169,7 @@ pub fn get_waiting_tiles(player: &Player) -> Vec<TileType> {
         let mut hand = player.hand.clone();
         hand.set_drawn(Some(Tile::new(tile_type)));
 
-        if hand_analyzer::calc_shanten_number(&hand) == -1 {
+        if hand_analyzer::calc_shanten_number(&hand).has_won() {
             waiting.push(tile_type);
         }
     }
@@ -333,7 +333,7 @@ pub fn add_dora_to_score(
 
 /// プレイヤーがテンパイしているか判定する（13枚の手牌で）
 pub fn is_tenpai(player: &Player) -> bool {
-    hand_analyzer::calc_shanten_number(&player.hand) == 0
+    hand_analyzer::calc_shanten_number(&player.hand).is_tenpai()
 }
 
 /// ロン和了の点数移動を計算する

--- a/crates/mahjong-server/src/scoring.rs
+++ b/crates/mahjong-server/src/scoring.rs
@@ -332,8 +332,8 @@ pub fn add_dora_to_score(
 }
 
 /// プレイヤーがテンパイしているか判定する（13枚の手牌で）
-pub fn is_tenpai(player: &Player) -> bool {
-    hand_analyzer::calc_shanten_number(&player.hand).is_tenpai()
+pub fn is_ready(player: &Player) -> bool {
+    hand_analyzer::calc_shanten_number(&player.hand).is_ready()
 }
 
 /// ロン和了の点数移動を計算する

--- a/crates/mahjong-server/src/scoring.rs
+++ b/crates/mahjong-server/src/scoring.rs
@@ -169,7 +169,7 @@ pub fn get_waiting_tiles(player: &Player) -> Vec<TileType> {
         let mut hand = player.hand.clone();
         hand.set_drawn(Some(Tile::new(tile_type)));
 
-        if hand_analyzer::shanten_number(&hand) == -1 {
+        if hand_analyzer::calc_shanten_number(&hand) == -1 {
             waiting.push(tile_type);
         }
     }
@@ -333,7 +333,7 @@ pub fn add_dora_to_score(
 
 /// プレイヤーがテンパイしているか判定する（13枚の手牌で）
 pub fn is_tenpai(player: &Player) -> bool {
-    hand_analyzer::shanten_number(&player.hand) == 0
+    hand_analyzer::calc_shanten_number(&player.hand) == 0
 }
 
 /// ロン和了の点数移動を計算する


### PR DESCRIPTION
## Summary
- `HandAnalyzer::new()` (フル版) と `shanten_number()` (高速版) で重複していたシャンテン数計算ロジックを、`ShantenAccumulator` トレイトを用いた単一のジェネリックエンジンに統合
  - `CountOnly`: CPU AI 向けカウンタのみ（ヒープ確保なし、モノモーフィゼーションでゼロコスト）
  - `FullTracking`: 役判定・符計算向け Vec 追跡
  - 共通の `find_mentsu` / `find_tatsu` 再帰関数により、ロジックの乖離によるバグを防止
- 七対子・国士無双のシャンテン数計算も共通関数に統合し、重複を排除
- `ShantenNumber` ニュータイプを導入し、マジックナンバー比較を意味のあるメソッドに置換
  - `has_won()` — 和了（`-1`）判定
  - `is_ready()` — テンパイ（`0`）判定
  - `is_ready_or_won()` — テンパイ以上（`<= 0`）判定
- `has_won` をフリー関数から `ShantenNumber` のメソッドに移動
- `shanten_number()` を `calc_shanten_number()` にリネームし命名を統一
- テストを `shanten_regression` として期待値を明示する形に書き換え
- 前処理の `is_isolated()` ヘルパー共通化、フル版の対子判定バグ修正
- 12ファイル変更、約130行の削減 (862行削除、733行追加)

## Test plan
- [x] `cargo test` — 全278テスト通過（core 181 + server 91 + doctests 3 + client 3）
- [x] WASM ビルドで実際のゲームプレイに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)