### PR TITLE
Unify meld representation and rename Open* to Meld*

### DIFF
--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -5,18 +5,10 @@
 use macroquad::prelude::*;
 use mahjong_core::hand::Hand;
 use mahjong_core::hand_info::hand_analyzer::HandAnalyzer;
-use mahjong_core::hand_info::opened::{OpenFrom, OpenTiles, OpenType};
+use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
 use mahjong_core::tile::{Tile, TileType, Wind};
 use mahjong_server::cpu::client::{CpuConfig, CpuLevel, CpuPersonality};
 use mahjong_server::protocol::{AvailableCall, CallType, ClientAction, DrawReason, PlayerHandInfo, ServerEvent};
-
-/// 副露（鳴き）の表示情報
-#[derive(Debug, Clone)]
-pub struct MeldInfo {
-    #[allow(dead_code)]
-    pub call_type: CallType,
-    pub tiles: Vec<Tile>,
-}
 
 /// 捨て牌の表示情報
 #[derive(Debug, Clone)]
@@ -33,7 +25,7 @@ pub struct OtherPlayerHand {
     /// 手牌（公開時のみ設定。非公開時は空）
     pub hand: Vec<Tile>,
     /// 副露（鳴き）一覧
-    pub melds: Vec<MeldInfo>,
+    pub melds: Vec<Meld>,
     /// 手牌が公開されているか（和了時・テンパイ時）
     pub revealed: bool,
     /// 非公開時の手牌枚数（裏向き表示用）
@@ -72,7 +64,7 @@ pub struct GameState {
     /// 和了時の手牌情報（結果画面表示用）
     pub win_hand: Vec<Tile>,
     /// 和了時の副露
-    pub win_melds: Vec<Vec<Tile>>,
+    pub win_melds: Vec<Meld>,
     /// 和了牌
     pub win_tile: Option<Tile>,
     /// ツモ和了かロン和了か（true=ツモ）
@@ -110,7 +102,7 @@ pub struct GameState {
     /// 鳴き対象の捨てたプレイヤー
     pub call_discarder: Option<Wind>,
     /// 自分の副露（鳴き）一覧
-    pub melds: Vec<MeldInfo>,
+    pub melds: Vec<Meld>,
     /// 局番号（0=東1局, 1=東2局, ...）
     pub round_number: usize,
     /// 本場数
@@ -125,6 +117,8 @@ pub struct GameState {
     pub other_players: [OtherPlayerHand; 3],
     /// リーチ宣言済みで次の打牌がリーチ宣言牌となるプレイヤーの風（一時フラグ）
     pending_riichi_player: Option<Wind>,
+    /// 直前に捨て牌したプレイヤーの風（鳴き元の判定に使用）
+    last_discarder: Option<Wind>,
     /// 対局開始前設定
     pub setup_state: SetupState,
 }
@@ -247,6 +241,7 @@ impl GameState {
             selected_would_cause_furiten: false,
             other_players: [OtherPlayerHand::new(), OtherPlayerHand::new(), OtherPlayerHand::new()],
             pending_riichi_player: None,
+            last_discarder: None,
             setup_state: SetupState::new(),
         }
     }
@@ -292,6 +287,7 @@ impl GameState {
                 self.is_furiten = false;
                 self.selected_would_cause_furiten = false;
                 self.other_players = [OtherPlayerHand::new(), OtherPlayerHand::new(), OtherPlayerHand::new()];
+                self.last_discarder = None;
             }
 
             ServerEvent::TileDrawn {
@@ -330,6 +326,7 @@ impl GameState {
                 tile,
                 is_tsumogiri,
             } => {
+                self.last_discarder = Some(player);
                 let relative_idx = self.relative_player_index(player);
                 let is_riichi = self.pending_riichi_player == Some(player);
                 if is_riichi {
@@ -372,13 +369,30 @@ impl GameState {
             ServerEvent::PlayerCalled {
                 player,
                 call_type,
-                called_tile: _,
+                called_tile,
                 tiles,
             } => {
                 // 鳴き選択肢をクリア
                 self.available_calls.clear();
                 self.call_target_tile = None;
                 self.refresh_self_kan_options();
+
+                // CallType → MeldType 変換
+                let category = Self::call_type_to_meld_type(&call_type);
+
+                // 鳴き元の判定
+                let meld_from = match call_type {
+                    CallType::Ankan => MeldFrom::Myself,
+                    CallType::Kakan => MeldFrom::Myself,
+                    _ => {
+                        if let Some(discarder) = self.call_discarder.or(self.last_discarder) {
+                            Self::compute_meld_direction(player, discarder)
+                        } else {
+                            MeldFrom::Previous
+                        }
+                    }
+                };
+
                 self.call_discarder = None;
 
                 // 他プレイヤーが鳴いた場合、副露情報を記録
@@ -390,43 +404,39 @@ impl GameState {
                         CallType::Ron => {}
                         CallType::Kakan => {
                             if let Some(meld) = other.melds.iter_mut().find(|m| {
-                                m.call_type == CallType::Pon
+                                m.category == MeldType::Pon
                                     && m.tiles.first().map(|t| t.get()) == tiles.first().map(|t| t.get())
                             }) {
-                                meld.call_type = CallType::Kakan;
+                                meld.category = MeldType::Kakan;
                                 meld.tiles = tiles.clone();
-                                // 加カンは手牌1枚減（ポンの3枚→カンの4枚、手牌から1枚使用）
+                                // from はポン時のままにする
                                 other.concealed_count = other.concealed_count.saturating_sub(1);
                             } else {
-                                other.melds.push(MeldInfo {
-                                    call_type: call_type.clone(),
-                                    tiles: tiles.clone(),
+                                other.melds.push(Meld {
+                                    category, tiles: tiles.clone(),
+                                    from: meld_from, called_tile: Some(called_tile),
                                 });
                                 other.concealed_count = other.concealed_count.saturating_sub(1);
                             }
                         }
                         CallType::Ankan => {
-                            other.melds.push(MeldInfo {
-                                call_type: call_type.clone(),
-                                tiles: tiles.clone(),
+                            other.melds.push(Meld {
+                                category, tiles: tiles.clone(),
+                                from: MeldFrom::Myself, called_tile: None,
                             });
-                            // 暗カンは手牌から4枚使うが、ツモ牌を含む
                             other.concealed_count = other.concealed_count.saturating_sub(3);
                         }
                         CallType::Pon | CallType::Chi => {
-                            other.melds.push(MeldInfo {
-                                call_type: call_type.clone(),
-                                tiles: tiles.clone(),
+                            other.melds.push(Meld {
+                                category, tiles: tiles.clone(),
+                                from: meld_from, called_tile: Some(called_tile),
                             });
-                            // ポン/チーは手牌から2枚使用（1枚は捨て牌から取る）
-                            // 鳴き後に打牌するので結果として手牌枚数は同じ
-                            // ただし打牌前は手牌が1枚少ない状態
                             other.concealed_count = other.concealed_count.saturating_sub(2);
                         }
                         CallType::Daiminkan => {
-                            other.melds.push(MeldInfo {
-                                call_type: call_type.clone(),
-                                tiles: tiles.clone(),
+                            other.melds.push(Meld {
+                                category, tiles: tiles.clone(),
+                                from: meld_from, called_tile: Some(called_tile),
                             });
                             other.concealed_count = other.concealed_count.saturating_sub(3);
                         }
@@ -436,13 +446,21 @@ impl GameState {
                 // 自分が鳴いた場合、副露情報を保存し打牌待ちへ
                 if Some(player) == self.seat_wind {
                     match call_type {
-                        CallType::Ron => {
-                            // ロンの場合は局終了イベントが続く
+                        CallType::Ron => {}
+                        CallType::Pon | CallType::Chi | CallType::Daiminkan => {
+                            self.melds.push(Meld {
+                                category, tiles: tiles.clone(),
+                                from: meld_from, called_tile: Some(called_tile),
+                            });
+                            self.is_my_turn = true;
+                            self.drawn = None;
+                            self.clear_riichi_selection();
+                            self.self_kan_options.clear();
                         }
-                        CallType::Pon | CallType::Chi | CallType::Daiminkan | CallType::Ankan => {
-                            self.melds.push(MeldInfo {
-                                call_type: call_type.clone(),
-                                tiles: tiles.clone(),
+                        CallType::Ankan => {
+                            self.melds.push(Meld {
+                                category, tiles: tiles.clone(),
+                                from: MeldFrom::Myself, called_tile: None,
                             });
                             self.is_my_turn = true;
                             self.drawn = None;
@@ -451,15 +469,15 @@ impl GameState {
                         }
                         CallType::Kakan => {
                             if let Some(meld) = self.melds.iter_mut().find(|meld| {
-                                meld.call_type == CallType::Pon
+                                meld.category == MeldType::Pon
                                     && meld.tiles.first().map(|tile| tile.get()) == tiles.first().map(|tile| tile.get())
                             }) {
-                                meld.call_type = CallType::Kakan;
+                                meld.category = MeldType::Kakan;
                                 meld.tiles = tiles.clone();
                             } else {
-                                self.melds.push(MeldInfo {
-                                    call_type: call_type.clone(),
-                                    tiles: tiles.clone(),
+                                self.melds.push(Meld {
+                                    category, tiles: tiles.clone(),
+                                    from: meld_from, called_tile: Some(called_tile),
                                 });
                             }
                             self.is_my_turn = true;
@@ -521,9 +539,16 @@ impl GameState {
                 self.win_is_tsumo = loser.is_none();
 
                 // 和了者の手牌情報を保存
-                if let Some(info) = player_hands.iter().find(|p| p.wind == winner) {
-                    self.win_hand = info.hand.clone();
-                    self.win_melds = info.melds.iter().map(|m| m.tiles.clone()).collect();
+                if let Some(_info) = player_hands.iter().find(|p| p.wind == winner) {
+                    self.win_hand = _info.hand.clone();
+                    // 既存の Meld（from 情報付き）を使用
+                    let relative_idx = self.relative_player_index(winner);
+                    if relative_idx == 0 {
+                        // 自分が和了者
+                        self.win_melds = self.melds.clone();
+                    } else {
+                        self.win_melds = self.other_players[relative_idx - 1].melds.clone();
+                    }
                 } else {
                     self.win_hand.clear();
                     self.win_melds.clear();
@@ -626,10 +651,15 @@ impl GameState {
             }
             let other = &mut self.other_players[relative_idx - 1];
             // 副露を更新
-            other.melds = info.melds.iter().map(|m| MeldInfo {
-                call_type: m.call_type.clone(),
-                tiles: m.tiles.clone(),
-            }).collect();
+            // 副露を更新（既存の from 情報を保持）
+            if other.melds.is_empty() {
+                other.melds = info.melds.iter().map(|m| Meld {
+                    category: Self::call_type_to_meld_type(&m.call_type),
+                    tiles: m.tiles.clone(),
+                    from: MeldFrom::Unknown, // フォールバック
+                    called_tile: None,
+                }).collect();
+            }
             // 和了者の手牌を公開
             if info.wind == winner {
                 other.hand = info.hand.clone();
@@ -647,10 +677,15 @@ impl GameState {
             }
             let other = &mut self.other_players[relative_idx - 1];
             // 副露を更新
-            other.melds = info.melds.iter().map(|m| MeldInfo {
-                call_type: m.call_type.clone(),
-                tiles: m.tiles.clone(),
-            }).collect();
+            // 副露を更新（既存の from 情報を保持）
+            if other.melds.is_empty() {
+                other.melds = info.melds.iter().map(|m| Meld {
+                    category: Self::call_type_to_meld_type(&m.call_type),
+                    tiles: m.tiles.clone(),
+                    from: MeldFrom::Unknown, // フォールバック
+                    called_tile: None,
+                }).collect();
+            }
             // テンパイ者の手牌を公開
             if tenpai.contains(&info.wind) {
                 other.hand = info.hand.clone();
@@ -672,7 +707,7 @@ impl GameState {
             return false;
         }
 
-        let mut hand = Hand::new_with_opened(self.hand.clone(), self.opened_tiles_for_analysis(), self.drawn);
+        let mut hand = Hand::new_with_melds(self.hand.clone(), self.melds_for_analysis(), self.drawn);
         match tile {
             Some(target) => {
                 let drawn = hand.drawn();
@@ -698,26 +733,16 @@ impl GameState {
         }
     }
 
-    fn opened_tiles_for_analysis(&self) -> Vec<OpenTiles> {
+    fn melds_for_analysis(&self) -> Vec<Meld> {
         self.melds
             .iter()
-            .filter_map(|meld| match meld.call_type {
-                CallType::Chi => Some(OpenTiles {
-                    tiles: [meld.tiles[0], meld.tiles[1], meld.tiles[2]],
-                    category: OpenType::Chi,
-                    from: OpenFrom::Unknown,
-                }),
-                CallType::Pon => Some(OpenTiles {
-                    tiles: [meld.tiles[0], meld.tiles[1], meld.tiles[2]],
-                    category: OpenType::Pon,
-                    from: OpenFrom::Unknown,
-                }),
-                CallType::Daiminkan | CallType::Ankan | CallType::Kakan => Some(OpenTiles {
-                    tiles: [meld.tiles[0], meld.tiles[1], meld.tiles[2]],
-                    category: OpenType::Kan,
-                    from: OpenFrom::Unknown,
-                }),
-                CallType::Ron => None,
+            .map(|meld| {
+                let mut m = meld.clone();
+                // HandAnalyzer は3枚で解析するため、カンの場合は3枚に切り詰める
+                if m.category.is_kan() && m.tiles.len() > 3 {
+                    m.tiles.truncate(3);
+                }
+                m
             })
             .collect()
     }
@@ -758,7 +783,7 @@ impl GameState {
         }
 
         // 手牌13枚でテンパイか確認
-        let hand = Hand::new_with_opened(hand_tiles, self.opened_tiles_for_analysis(), None);
+        let hand = Hand::new_with_melds(hand_tiles, self.melds_for_analysis(), None);
         let analyzer = match HandAnalyzer::new(&hand) {
             Ok(a) => a,
             Err(_) => return false,
@@ -827,7 +852,7 @@ impl GameState {
             }
 
             let has_pon = self.melds.iter().any(|meld| {
-                meld.call_type == CallType::Pon
+                meld.category == MeldType::Pon
                     && meld.tiles.first().map(|tile| tile.get()) == Some(idx as u32)
             });
             if has_pon && *count >= 1 {
@@ -1077,6 +1102,30 @@ impl GameState {
         (their_idx + 4 - my_idx) % 4
     }
 
+    /// CallType → MeldType 変換
+    fn call_type_to_meld_type(call_type: &CallType) -> MeldType {
+        match call_type {
+            CallType::Chi => MeldType::Chi,
+            CallType::Pon => MeldType::Pon,
+            CallType::Ankan | CallType::Daiminkan => MeldType::Kan,
+            CallType::Kakan => MeldType::Kakan,
+            CallType::Ron => MeldType::Pon, // フォールバック（使われない）
+        }
+    }
+
+    /// 鳴いたプレイヤー(caller)から見て、鳴き元(discarder)がどの位置かを返す
+    fn compute_meld_direction(caller: Wind, discarder: Wind) -> MeldFrom {
+        let caller_idx = caller.to_index();
+        let discarder_idx = discarder.to_index();
+        let rel = (discarder_idx + 4 - caller_idx) % 4;
+        match rel {
+            3 => MeldFrom::Previous,  // 上家
+            2 => MeldFrom::Opposite,   // 対面
+            1 => MeldFrom::Following, // 下家
+            _ => MeldFrom::Myself,   // 自家（通常ここには来ない）
+        }
+    }
+
     /// 風牌を日本語の名前に変換
     fn wind_to_name(&self, wind: Wind) -> &'static str {
         match wind {
@@ -1151,14 +1200,16 @@ mod tests {
         state.hand = hand.tiles().to_vec();
         state.hand.sort();
         state.drawn = hand.drawn();
-        state.melds.push(MeldInfo {
-            call_type: CallType::Ankan,
+        state.melds.push(Meld {
+            category: MeldType::Kan,
             tiles: vec![
                 Tile::new(Tile::M3),
                 Tile::new(Tile::M3),
                 Tile::new(Tile::M3),
                 Tile::new(Tile::M3),
             ],
+            from: MeldFrom::Myself,
+            called_tile: None,
         });
 
         assert!(state.can_discard_for_riichi(Some(Tile::new(Tile::M5))));

--- a/crates/mahjong-client/src/renderer.rs
+++ b/crates/mahjong-client/src/renderer.rs
@@ -7,6 +7,8 @@ use mahjong_core::tile::Tile;
 use mahjong_server::cpu::client::CpuConfig;
 use mahjong_server::protocol::AvailableCall;
 
+use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
+
 use crate::game::{GamePhase, GameState, SetupState};
 
 /// 牌を描画する色
@@ -478,22 +480,16 @@ fn draw_melds(state: &GameState, tile_textures: &TileTextures) {
         return;
     }
 
-    let meld_tile_w: f32 = 40.0;
-    let meld_tile_h: f32 = 56.0;
+    let tw: f32 = 40.0;
+    let th: f32 = 56.0;
     let meld_y: f32 = 692.0;
     let meld_gap: f32 = 12.0;
     let mut x = 1220.0;
 
     for meld in state.melds.iter().rev() {
-        let tile_count = meld.tiles.len();
-        let meld_width = tile_count as f32 * meld_tile_w;
+        let meld_width = calc_meld_width(meld, tw, th);
         x -= meld_width;
-
-        for (i, tile) in meld.tiles.iter().enumerate() {
-            let tx = x + i as f32 * meld_tile_w;
-            draw_meld_tile(tx, meld_y, tile, meld_tile_w, meld_tile_h, tile_textures);
-        }
-
+        draw_meld_group(meld, x, meld_y, tw, th, tile_textures);
         x -= meld_gap;
     }
 }
@@ -510,6 +506,167 @@ fn draw_meld_tile(
     draw_rectangle(x, y, w - 2.0, h - 2.0, bg);
     draw_rectangle_lines(x, y, w - 2.0, h - 2.0, 2.0, TILE_BORDER);
     draw_tile_sprite(tile_textures.for_tile(tile), x + 2.0, y + 1.0, w - 6.0, h - 6.0, WHITE);
+}
+
+/// 横向きの副露牌を描画する（90°回転）
+fn draw_meld_tile_sideways(
+    x: f32,
+    y: f32,
+    tile: &mahjong_core::tile::Tile,
+    tw: f32,
+    th: f32,
+    tile_textures: &TileTextures,
+) {
+    // 横向き牌のバウンディングボックス: 幅=th, 高さ=tw
+    let bg = Color::new(0.9, 0.95, 1.0, 1.0);
+    draw_rectangle(x, y, th - 2.0, tw - 2.0, bg);
+    draw_rectangle_lines(x, y, th - 2.0, tw - 2.0, 2.0, TILE_BORDER);
+    draw_tile_sprite_rotated(
+        tile_textures.for_tile(tile),
+        x + 1.0, y + 1.0, tw - 6.0, th - 6.0, WHITE,
+        std::f32::consts::FRAC_PI_2,
+    );
+}
+
+/// 裏向きの副露牌を描画する（暗槓用）
+fn draw_meld_tile_back(
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+    tile_textures: &TileTextures,
+) {
+    let bg = Color::new(0.5, 0.6, 0.5, 1.0);
+    draw_rectangle(x, y, w - 2.0, h - 2.0, bg);
+    draw_rectangle_lines(x, y, w - 2.0, h - 2.0, 2.0, TILE_BORDER);
+    draw_tile_sprite(&tile_textures.back, x + 2.0, y + 1.0, w - 6.0, h - 6.0, WHITE);
+}
+
+/// 鳴き元に応じて横向き牌の位置インデックスを返す
+fn sideways_index(from: MeldFrom, tile_count: usize) -> usize {
+    match from {
+        MeldFrom::Previous => 0,              // 上家: 左端
+        MeldFrom::Opposite => 1,              // 対面: 左から2番目
+        MeldFrom::Following => tile_count - 1, // 下家: 右端
+        _ => 0,                               // Unknown/Myself: フォールバック
+    }
+}
+
+/// 副露グループの描画幅を計算する
+fn calc_meld_width(meld: &Meld, tw: f32, th: f32) -> f32 {
+    match meld.category {
+        MeldType::Kan if meld.from == MeldFrom::Myself => {
+            // 暗槓: 4枚すべて縦向き
+            4.0 * tw
+        }
+        MeldType::Kakan => {
+            // 加槓: 横向き牌の位置に2枚重ね（幅はth）、残りは縦向き
+            2.0 * tw + th
+        }
+        MeldType::Chi | MeldType::Pon => {
+            // チー/ポン: 1枚横向き（幅th）、残り2枚縦向き
+            2.0 * tw + th
+        }
+        MeldType::Kan => {
+            // 大明槓: 1枚横向き（幅th）、残り3枚縦向き
+            3.0 * tw + th
+        }
+    }
+}
+
+/// 副露グループを描画する
+fn draw_meld_group(
+    meld: &Meld,
+    base_x: f32,
+    base_y: f32,
+    tw: f32,
+    th: f32,
+    tile_textures: &TileTextures,
+) {
+    match meld.category {
+        MeldType::Kan if meld.from == MeldFrom::Myself => {
+            // 暗槓: 1,4枚目裏向き、2,3枚目表向き、全て縦向き
+            for i in 0..4 {
+                let x = base_x + i as f32 * tw;
+                if i == 0 || i == 3 {
+                    draw_meld_tile_back(x, base_y, tw, th, tile_textures);
+                } else {
+                    draw_meld_tile(x, base_y, &meld.tiles[i], tw, th, tile_textures);
+                }
+            }
+        }
+        MeldType::Chi => {
+            // チー: 鳴いた牌を左端に横向き、残り2枚を順番に縦向き
+            let mut sorted_tiles = meld.tiles.clone();
+            sorted_tiles.sort();
+            let called = meld.called_tile;
+
+            let mut x = base_x;
+            if let Some(ct) = called {
+                draw_meld_tile_sideways(x, base_y + (th - tw), &ct, tw, th, tile_textures);
+                x += th;
+                let mut skipped = false;
+                for tile in &sorted_tiles {
+                    if !skipped && tile.get() == ct.get() {
+                        skipped = true;
+                        continue;
+                    }
+                    draw_meld_tile(x, base_y, tile, tw, th, tile_textures);
+                    x += tw;
+                }
+            } else {
+                for tile in &sorted_tiles {
+                    draw_meld_tile(x, base_y, tile, tw, th, tile_textures);
+                    x += tw;
+                }
+            }
+        }
+        MeldType::Pon => {
+            // ポン: 鳴き元に応じて横向き牌の位置を決定
+            let side_idx = sideways_index(meld.from, 3);
+            let mut x = base_x;
+            for i in 0..3 {
+                if i == side_idx {
+                    draw_meld_tile_sideways(x, base_y + (th - tw), &meld.tiles[i], tw, th, tile_textures);
+                    x += th;
+                } else {
+                    draw_meld_tile(x, base_y, &meld.tiles[i], tw, th, tile_textures);
+                    x += tw;
+                }
+            }
+        }
+        MeldType::Kan => {
+            // 大明槓: 鳴き元に応じて横向き牌の位置を決定（4枚）
+            let side_idx = sideways_index(meld.from, 4);
+            let mut x = base_x;
+            for i in 0..4 {
+                if i == side_idx {
+                    draw_meld_tile_sideways(x, base_y + (th - tw), &meld.tiles[i], tw, th, tile_textures);
+                    x += th;
+                } else {
+                    draw_meld_tile(x, base_y, &meld.tiles[i], tw, th, tile_textures);
+                    x += tw;
+                }
+            }
+        }
+        MeldType::Kakan => {
+            // 加槓: ポンの横向き位置に2枚重ね
+            let side_idx = sideways_index(meld.from, 3);
+            let mut x = base_x;
+            for i in 0..3 {
+                if i == side_idx {
+                    draw_meld_tile_sideways(x, base_y + (th - tw), &meld.tiles[i], tw, th, tile_textures);
+                    if meld.tiles.len() > 3 {
+                        draw_meld_tile_sideways(x, base_y + (th - tw) - tw, &meld.tiles[3], tw, th, tile_textures);
+                    }
+                    x += th;
+                } else {
+                    draw_meld_tile(x, base_y, &meld.tiles[i], tw, th, tile_textures);
+                    x += tw;
+                }
+            }
+        }
+    }
 }
 
 fn draw_tile(
@@ -624,14 +781,14 @@ fn draw_other_player_hands(state: &GameState, tile_textures: &TileTextures) {
         } else {
             other.concealed_count
         };
-        let meld_tile_count: usize = other.melds.iter().map(|m| m.tiles.len()).sum();
+        let meld_widths: f32 = other.melds.iter().map(|m| calc_meld_width(m, tw, th)).sum();
         let meld_gaps = if other.melds.is_empty() {
             0.0
         } else {
             meld_gap + (other.melds.len() as f32 - 1.0) * meld_gap
         };
         let total_width =
-            hand_count as f32 * tile_step + meld_tile_count as f32 * tile_step + meld_gaps;
+            hand_count as f32 * tile_step + meld_widths + meld_gaps;
         let start_x = BOARD_CENTER_X - total_width / 2.0;
 
         set_camera(&make_board_camera(PLAYER_ROTATIONS[relative_idx]));
@@ -658,10 +815,8 @@ fn draw_other_player_hands(state: &GameState, tile_textures: &TileTextures) {
             if i > 0 {
                 x += meld_gap;
             }
-            for tile in &meld.tiles {
-                draw_tile_sprite(tile_textures.for_tile(tile), x, base_y, tw, th, WHITE);
-                x += tile_step;
-            }
+            draw_meld_group(meld, x, base_y, tw, th, tile_textures);
+            x += calc_meld_width(meld, tw, th);
         }
 
         set_default_camera();
@@ -866,7 +1021,7 @@ fn draw_result(state: &GameState, font: Option<&Font>, tile_textures: &TileTextu
     // 手牌の合計幅を計算して開始位置を決定（ドラ表示もこの左端に揃える）
     let hand_tiles = state.win_hand.len() as f32;
     let win_tile_w = if state.win_tile.is_some() { tw + win_tile_gap } else { 0.0 };
-    let meld_tiles: f32 = state.win_melds.iter().map(|m| m.len() as f32 * tw).sum();
+    let meld_tiles: f32 = state.win_melds.iter().map(|m| calc_meld_width(m, tw, th)).sum();
     let meld_gaps = if state.win_melds.is_empty() {
         0.0
     } else {
@@ -948,10 +1103,8 @@ fn draw_result(state: &GameState, font: Option<&Font>, tile_textures: &TileTextu
                 if i > 0 {
                     x += meld_gap;
                 }
-                for tile in meld {
-                    draw_tile_sprite(tile_textures.for_tile(tile), x, next_y, tw, th, WHITE);
-                    x += tw;
-                }
+                draw_meld_group(meld, x, next_y, tw, th, tile_textures);
+                x += calc_meld_width(meld, tw, th);
             }
         }
     }

--- a/crates/mahjong-core/src/hand.rs
+++ b/crates/mahjong-core/src/hand.rs
@@ -1,4 +1,4 @@
-use crate::hand_info::opened::*;
+use crate::hand_info::meld::*;
 use crate::tile::*;
 use std::collections::VecDeque;
 
@@ -8,7 +8,7 @@ pub struct Hand {
     /// 現在の手牌（副露がなければ13枚）
     tiles: Vec<Tile>,
     /// 副露
-    opened: Vec<OpenTiles>,
+    melds: Vec<Meld>,
     /// ツモってきた牌
     drawn: Option<Tile>,
 }
@@ -29,8 +29,8 @@ impl Hand {
     }
 
     /// 副露を追加する
-    pub fn add_opened(&mut self, open: OpenTiles) {
-        self.opened.push(open);
+    pub fn add_meld(&mut self, open: Meld) {
+        self.melds.push(open);
     }
 
     /// 指定インデックスの牌を手牌から除去する
@@ -44,13 +44,13 @@ impl Hand {
     }
 
     pub fn new(tiles: Vec<Tile>, drawn: Option<Tile>) -> Hand {
-        return Hand::new_with_opened(tiles, Vec::new(), drawn);
+        return Hand::new_with_melds(tiles, Vec::new(), drawn);
     }
-    pub fn new_with_opened(tiles: Vec<Tile>, opened: Vec<OpenTiles>, drawn: Option<Tile>) -> Hand {
+    pub fn new_with_melds(tiles: Vec<Tile>, melds: Vec<Meld>, drawn: Option<Tile>) -> Hand {
         Hand {
             tiles,
             drawn,
-            opened,
+            melds,
         }
     }
 
@@ -60,13 +60,13 @@ impl Hand {
     }
 
     /// 副露を返す
-    pub fn opened(&self) -> &[OpenTiles] {
-        &self.opened
+    pub fn melds(&self) -> &[Meld] {
+        &self.melds
     }
 
     /// 副露の可変参照を返す
-    pub fn opened_mut(&mut self) -> &mut Vec<OpenTiles> {
-        &mut self.opened
+    pub fn melds_mut(&mut self) -> &mut Vec<Meld> {
+        &mut self.melds
     }
 
     /// 手牌をソートする
@@ -86,9 +86,9 @@ impl Hand {
         //
         // 解析用途では副露は常に1面子として扱う。槓子の4枚目まで数えると
         // 「4面子1雀頭に加えて孤立牌が1枚ある」手を和了形と誤認しうる。
-        for i in 0..self.opened.len() {
-            for j in 0..self.opened[i].tiles.len() {
-                result[self.opened[i].tiles[j].get() as usize] += 1;
+        for i in 0..self.melds.len() {
+            for j in 0..self.melds[i].tiles.len() {
+                result[self.melds[i].tiles[j].get() as usize] += 1;
             }
         }
 
@@ -107,16 +107,16 @@ impl Hand {
             result.push(self.tiles[i].to_char());
         }
 
-        for i in 0..self.opened.len() {
+        for i in 0..self.melds.len() {
             result.push_str(&format!(
                 " {}{}{}",
-                self.opened[i].tiles[0].to_char(),
-                self.opened[i].tiles[1].to_char(),
-                self.opened[i].tiles[2].to_char()
+                self.melds[i].tiles[0].to_char(),
+                self.melds[i].tiles[1].to_char(),
+                self.melds[i].tiles[2].to_char()
             ));
             // カンなら4枚目を追加する
-            if self.opened[i].category == OpenType::Kan {
-                result.push(self.opened[i].tiles[0].to_char());
+            if self.melds[i].category.is_kan() {
+                result.push(self.melds[i].tiles[0].to_char());
             }
         }
 
@@ -135,16 +135,16 @@ impl Hand {
             result.push_str(&self.tiles[i].to_string());
         }
 
-        for i in 0..self.opened.len() {
+        for i in 0..self.melds.len() {
             result.push_str(&format!(
                 " {}{}{}",
-                self.opened[i].tiles[0].to_string(),
-                self.opened[i].tiles[1].to_string(),
-                self.opened[i].tiles[2].to_string()
+                self.melds[i].tiles[0].to_string(),
+                self.melds[i].tiles[1].to_string(),
+                self.melds[i].tiles[2].to_string()
             ));
             // カンなら4枚目を追加する
-            if self.opened[i].category == OpenType::Kan {
-                result.push_str(&format!("{}", self.opened[i].tiles[0].to_string(),));
+            if self.melds[i].category.is_kan() {
+                result.push_str(&format!("{}", self.melds[i].tiles[0].to_string(),));
             }
         }
 
@@ -189,10 +189,10 @@ impl Hand {
         let tiles = self.tiles.clone();
         let mut result = Hand::make_short_str(tiles);
 
-        for i in 0..self.opened.len() {
-            let mut op_tiles = Vec::from(self.opened[i].tiles);
-            if self.opened[i].category == OpenType::Kan {
-                op_tiles.push(self.opened[i].tiles[0]);
+        for i in 0..self.melds.len() {
+            let mut op_tiles = self.melds[i].tiles.clone();
+            if self.melds[i].category.is_kan() && op_tiles.len() == 3 {
+                op_tiles.push(self.melds[i].tiles[0]);
             }
             result.push_str(&format!(" {}", Hand::make_short_str(op_tiles)));
         }
@@ -228,7 +228,7 @@ impl Hand {
     pub fn from(hand_str: &str) -> Hand {
         let mut itr = hand_str.split_ascii_whitespace();
         let hand = Hand::str_to_tiles(itr.next().unwrap_or(""));
-        let mut opened: Vec<OpenTiles> = Vec::new();
+        let mut melds: Vec<Meld> = Vec::new();
         let mut drawn: Option<Tile> = None;
 
         while let Some(tile_str) = itr.next() {
@@ -239,35 +239,29 @@ impl Hand {
                     drawn = Some(t);
                 }
                 3 => {
-                    opened.push(OpenTiles {
-                        tiles: [
-                            *tile_vec.get(0).unwrap(),
-                            *tile_vec.get(1).unwrap(),
-                            *tile_vec.get(2).unwrap(),
-                        ],
-                        category: if *tile_vec.get(0).unwrap() == *tile_vec.get(1).unwrap() {
-                            OpenType::Pon
+                    melds.push(Meld {
+                        tiles: tile_vec.clone(),
+                        category: if tile_vec[0] == tile_vec[1] {
+                            MeldType::Pon
                         } else {
-                            OpenType::Chi
+                            MeldType::Chi
                         },
-                        from: OpenFrom::Unknown,
+                        from: MeldFrom::Unknown,
+                        called_tile: None,
                     });
                 }
                 4 => {
-                    opened.push(OpenTiles {
-                        tiles: [
-                            *tile_vec.get(0).unwrap(),
-                            *tile_vec.get(1).unwrap(),
-                            *tile_vec.get(2).unwrap(),
-                        ],
-                        category: OpenType::Kan,
-                        from: OpenFrom::Unknown,
+                    melds.push(Meld {
+                        tiles: tile_vec[..3].to_vec(),
+                        category: MeldType::Kan,
+                        from: MeldFrom::Unknown,
+                        called_tile: None,
                     });
                 }
                 _ => {}
             }
         }
-        return Hand::new_with_opened(hand, opened, drawn);
+        return Hand::new_with_melds(hand, melds, drawn);
     }
 
     pub fn from_summarized(sum: &TileSummarize) -> Hand {
@@ -329,7 +323,7 @@ mod tests {
     }
 
     #[test]
-    fn from_with_no_opened_test() {
+    fn from_with_no_melds_test() {
         let test_str = "123m456p789s1115z 5z";
         let test = Hand::from(test_str);
         assert_eq!(test.tiles[0], Tile::new(Tile::M1));
@@ -342,16 +336,16 @@ mod tests {
         let test_str = "123m456p1115z 789s 5z";
         let test = Hand::from(test_str);
         assert_eq!(test.tiles[0], Tile::new(Tile::M1));
-        assert_eq!(test.opened[0].category, OpenType::Chi);
+        assert_eq!(test.melds[0].category, MeldType::Chi);
         assert_eq!(
-            test.opened[0].tiles,
-            [
+            test.melds[0].tiles,
+            vec![
                 Tile::new(Tile::S7),
                 Tile::new(Tile::S8),
                 Tile::new(Tile::S9)
             ]
         );
-        assert_eq!(test.opened[0].from, OpenFrom::Unknown);
+        assert_eq!(test.melds[0].from, MeldFrom::Unknown);
         assert_eq!(test.drawn, Some(Tile::new(Tile::Z5)));
         assert_eq!(test.to_short_string(), test_str);
     }
@@ -361,16 +355,16 @@ mod tests {
         let test_str = "123m456p789s5z 111z 5z";
         let test = Hand::from(test_str);
         assert_eq!(test.tiles[0], Tile::new(Tile::M1));
-        assert_eq!(test.opened[0].category, OpenType::Pon);
+        assert_eq!(test.melds[0].category, MeldType::Pon);
         assert_eq!(
-            test.opened[0].tiles,
-            [
+            test.melds[0].tiles,
+            vec![
                 Tile::new(Tile::Z1),
                 Tile::new(Tile::Z1),
                 Tile::new(Tile::Z1)
             ]
         );
-        assert_eq!(test.opened[0].from, OpenFrom::Unknown);
+        assert_eq!(test.melds[0].from, MeldFrom::Unknown);
         assert_eq!(test.drawn, Some(Tile::new(Tile::Z5)));
         assert_eq!(test.to_short_string(), test_str);
     }
@@ -380,16 +374,16 @@ mod tests {
         let test_str = "123m456p789s5z 1111z 5z";
         let test = Hand::from(test_str);
         assert_eq!(test.tiles[0], Tile::new(Tile::M1));
-        assert_eq!(test.opened[0].category, OpenType::Kan);
+        assert_eq!(test.melds[0].category, MeldType::Kan);
         assert_eq!(
-            test.opened[0].tiles,
-            [
+            test.melds[0].tiles,
+            vec![
                 Tile::new(Tile::Z1),
                 Tile::new(Tile::Z1),
                 Tile::new(Tile::Z1)
             ]
         );
-        assert_eq!(test.opened[0].from, OpenFrom::Unknown);
+        assert_eq!(test.melds[0].from, MeldFrom::Unknown);
         assert_eq!(test.drawn, Some(Tile::new(Tile::Z5)));
         assert_eq!(test.to_short_string(), test_str);
     }

--- a/crates/mahjong-core/src/hand_info.rs
+++ b/crates/mahjong-core/src/hand_info.rs
@@ -1,4 +1,4 @@
-pub mod opened;
+pub mod meld;
 pub mod hand_analyzer;
 pub mod block;
 pub mod status;

--- a/crates/mahjong-core/src/hand_info/hand_analyzer.rs
+++ b/crates/mahjong-core/src/hand_info/hand_analyzer.rs
@@ -174,7 +174,7 @@ impl HandAnalyzer {
     /// Vecへの詰め込みは`same2`（対子）以外は`single`（単独）に詰め込まれる。
     /// 七対子はVecを使用する役として断么九・混老頭・混一色・清一色と複合しうる
     fn analyze_seven_pairs(hand: &Hand) -> Result<HandAnalyzer> {
-        if !hand.opened().is_empty() {
+        if !hand.melds().is_empty() {
             return Ok(HandAnalyzer::unavailable(Form::SevenPairs));
         }
 
@@ -209,7 +209,7 @@ impl HandAnalyzer {
     ///
     /// ブロック分解・Vecへの詰め込みはしない（詰め込んでも意味がない）
     fn analyze_thirteen_orphans(hand: &Hand) -> Result<HandAnalyzer> {
-        if !hand.opened().is_empty() {
+        if !hand.melds().is_empty() {
             return Ok(HandAnalyzer::unavailable(Form::ThirteenOrphans));
         }
 
@@ -255,7 +255,7 @@ impl HandAnalyzer {
 /// CPU打牌評価など大量に呼び出す箇所で使用する。
 pub fn calc_shanten_number(hand: &Hand) -> ShantenNumber {
     let t = hand.summarize_tiles();
-    let is_closed = hand.opened().is_empty();
+    let is_closed = hand.melds().is_empty();
     let sp = if is_closed {
         calc_seven_pairs_shanten(&t).0
     } else {

--- a/crates/mahjong-core/src/hand_info/meld.rs
+++ b/crates/mahjong-core/src/hand_info/meld.rs
@@ -4,18 +4,27 @@ use crate::tile::*;
 
 /// 副露の種類
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
-pub enum OpenType {
+pub enum MeldType {
     /// チー
     Chi,
     /// ポン
     Pon,
-    /// カン
+    /// カン（暗カン・大明カン）
     Kan,
+    /// 加カン（ポンに1枚追加）
+    Kakan,
+}
+
+impl MeldType {
+    /// カン系（Kan または Kakan）かどうかを返す
+    pub fn is_kan(&self) -> bool {
+        matches!(self, MeldType::Kan | MeldType::Kakan)
+    }
 }
 
 /// 誰から副露したか
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
-pub enum OpenFrom {
+pub enum MeldFrom {
     /// 上家（チー・ポン・明カン）
     Previous,
     /// 自家（暗カンしたときのみ）
@@ -30,11 +39,14 @@ pub enum OpenFrom {
 
 /// 副露状態を表す構造体
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OpenTiles {
-    /// 3枚の牌が入る。カンした時も3枚（4枚目は自明）
-    pub tiles: [Tile; 3],
+pub struct Meld {
+    /// 副露で公開された牌
+    pub tiles: Vec<Tile>,
     /// 副露の種類
-    pub category: OpenType,
+    pub category: MeldType,
     /// 誰から副露したか
-    pub from: OpenFrom,
+    pub from: MeldFrom,
+    /// 鳴いた牌（捨て牌から取った牌。暗カンの場合は None）
+    #[serde(default)]
+    pub called_tile: Option<Tile>,
 }

--- a/crates/mahjong-core/src/scoring/fu.rs
+++ b/crates/mahjong-core/src/scoring/fu.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use crate::hand::Hand;
 use crate::hand_info::hand_analyzer::HandAnalyzer;
-use crate::hand_info::opened::{OpenFrom, OpenType};
+use crate::hand_info::meld::{MeldFrom, MeldType};
 use crate::hand_info::status::Status;
 use crate::tile::{Dragon, Tile, TileType, Wind};
 use crate::winning_hand::name::Form;
@@ -173,9 +173,9 @@ fn calculate_mentsu_fu(
 ) -> Result<()> {
     // 副露面子の牌種を収集（analyzer.same3 との重複排除用）
     let opened_triplet_tiles: Vec<TileType> = hand
-        .opened()
+        .melds()
         .iter()
-        .filter(|o| o.category == OpenType::Pon || o.category == OpenType::Kan)
+        .filter(|o| o.category == MeldType::Pon || o.category.is_kan())
         .map(|o| o.tiles[0].get())
         .collect();
 
@@ -225,9 +225,9 @@ fn calculate_mentsu_fu(
     }
 
     // 副露面子
-    for open in hand.opened() {
+    for open in hand.melds() {
         match open.category {
-            OpenType::Pon => {
+            MeldType::Pon => {
                 let tile = open.tiles[0].get();
                 let is_terminal_or_honor = is_terminal_or_honor(tile);
                 let fu = if is_terminal_or_honor { 4 } else { 2 };
@@ -238,10 +238,10 @@ fn calculate_mentsu_fu(
                 };
                 details.push(FuDetail { name, fu });
             }
-            OpenType::Kan => {
+            MeldType::Kan | MeldType::Kakan => {
                 let tile = open.tiles[0].get();
                 let is_terminal_or_honor = is_terminal_or_honor(tile);
-                let is_concealed = open.from == OpenFrom::Myself;
+                let is_concealed = open.from == MeldFrom::Myself;
                 let fu = if is_concealed {
                     if is_terminal_or_honor { 32 } else { 16 }
                 } else {
@@ -262,7 +262,7 @@ fn calculate_mentsu_fu(
                 };
                 details.push(FuDetail { name, fu });
             }
-            OpenType::Chi => {
+            MeldType::Chi => {
                 // チーの順子は0符
             }
         }

--- a/crates/mahjong-core/src/winning_hand/check_2_han.rs
+++ b/crates/mahjong-core/src/winning_hand/check_2_han.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use crate::hand::Hand;
 use crate::hand_info::block::BlockProperty;
 use crate::hand_info::hand_analyzer::*;
-use crate::hand_info::opened::{OpenFrom, OpenType};
+use crate::hand_info::meld::{MeldFrom, MeldType};
 use crate::hand_info::status::*;
 use crate::settings::*;
 use crate::tile::{Dragon, Tile};
@@ -161,9 +161,9 @@ pub fn check_three_closed_triplets(
 
     let mut concealed_triplet_count = hand_analyzer.same3.len();
 
-    for open in hand.opened() {
-        let is_open_triplet = matches!(open.category, OpenType::Pon)
-            || (matches!(open.category, OpenType::Kan) && open.from != OpenFrom::Myself);
+    for open in hand.melds() {
+        let is_open_triplet = matches!(open.category, MeldType::Pon)
+            || (open.category.is_kan() && open.from != MeldFrom::Myself);
         if is_open_triplet {
             concealed_triplet_count = concealed_triplet_count.saturating_sub(1);
         }
@@ -172,11 +172,11 @@ pub fn check_three_closed_triplets(
     if !status.is_self_picked {
         if let Some(winning_tile) = hand.drawn() {
             let winning_tile_type = winning_tile.get();
-            let completes_open_triplet = hand.opened().iter().any(|open| {
+            let completes_open_triplet = hand.melds().iter().any(|open| {
                 open.tiles[0].get() == winning_tile_type
-                    && (matches!(open.category, OpenType::Pon)
-                        || (matches!(open.category, OpenType::Kan)
-                            && open.from != OpenFrom::Myself))
+                    && (matches!(open.category, MeldType::Pon)
+                        || (open.category.is_kan()
+                            && open.from != MeldFrom::Myself))
             });
             let completes_concealed_triplet = hand_analyzer
                 .same3

--- a/crates/mahjong-server/src/cpu/client.rs
+++ b/crates/mahjong-server/src/cpu/client.rs
@@ -5,7 +5,7 @@
 
 use mahjong_core::hand::Hand;
 use mahjong_core::hand_info::hand_analyzer::calc_shanten_number;
-use mahjong_core::hand_info::opened::{OpenFrom, OpenTiles, OpenType};
+use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
 use mahjong_core::tile::Tile;
 
 use crate::protocol::{AvailableCall, ClientAction, ServerEvent};
@@ -463,25 +463,20 @@ impl CpuClient {
         None
     }
 
-    /// 既存の副露を OpenTiles に変換する
-    fn build_existing_opened(&self) -> Vec<OpenTiles> {
-        let mut opened = Vec::new();
+    /// 既存の副露を取得する
+    fn build_existing_melds(&self) -> Vec<Meld> {
         let my_idx = super::state::CpuGameState::wind_to_index(self.state.my_seat_wind);
-        for meld in &self.state.player_melds[my_idx] {
-            if meld.tiles.len() >= 3 {
-                let ot = OpenTiles {
-                    tiles: [meld.tiles[0], meld.tiles[1], meld.tiles[2]],
-                    category: match meld.call_type {
-                        crate::protocol::CallType::Chi => OpenType::Chi,
-                        crate::protocol::CallType::Pon => OpenType::Pon,
-                        _ => OpenType::Kan,
-                    },
-                    from: OpenFrom::Unknown,
-                };
-                opened.push(ot);
-            }
-        }
-        opened
+        self.state.player_melds[my_idx]
+            .iter()
+            .map(|open| {
+                // 手分析用に3枚に切り詰め
+                let mut o = open.clone();
+                if o.tiles.len() > 3 {
+                    o.tiles.truncate(3);
+                }
+                o
+            })
+            .collect()
     }
 
     /// ポンした場合に向聴数が下がるか
@@ -508,14 +503,15 @@ impl CpuClient {
         }
 
         // 既存の副露 + 今回のポンを含めた Hand を作成
-        let mut opened = self.build_existing_opened();
-        opened.push(OpenTiles {
-            tiles: [called_tile, called_tile, called_tile],
-            category: OpenType::Pon,
-            from: OpenFrom::Unknown,
+        let mut melds = self.build_existing_melds();
+        melds.push(Meld {
+            tiles: vec![called_tile, called_tile, called_tile],
+            category: MeldType::Pon,
+            from: MeldFrom::Unknown,
+            called_tile: Some(called_tile),
         });
 
-        let new_hand = Hand::new_with_opened(remaining, opened, None);
+        let new_hand = Hand::new_with_melds(remaining, melds, None);
         calc_shanten_number(&new_hand) < current_shanten
     }
 
@@ -536,14 +532,15 @@ impl CpuClient {
         }
 
         // 既存の副露 + 今回のチーを含めた Hand を作成
-        let mut opened = self.build_existing_opened();
-        opened.push(OpenTiles {
-            tiles: [called_tile, chi_tiles_for_meld[0], chi_tiles_for_meld[1]],
-            category: OpenType::Chi,
-            from: OpenFrom::Previous,
+        let mut melds = self.build_existing_melds();
+        melds.push(Meld {
+            tiles: vec![called_tile, chi_tiles_for_meld[0], chi_tiles_for_meld[1]],
+            category: MeldType::Chi,
+            from: MeldFrom::Previous,
+            called_tile: Some(called_tile),
         });
 
-        let new_hand = Hand::new_with_opened(remaining, opened, None);
+        let new_hand = Hand::new_with_melds(remaining, melds, None);
         calc_shanten_number(&new_hand) < current_shanten
     }
 }

--- a/crates/mahjong-server/src/cpu/state.rs
+++ b/crates/mahjong-server/src/cpu/state.rs
@@ -3,18 +3,10 @@
 //! ServerEvent のストリームだけから構築される、プレイヤー視点のゲーム状態。
 //! プレイヤーが画面から読み取れる情報と同等の情報のみを保持する。
 
+use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
 use mahjong_core::tile::{Tile, Wind};
 
 use crate::protocol::{AvailableCall, CallType, ServerEvent};
-
-/// 副露情報（PlayerCalledイベントから構築）
-#[derive(Debug, Clone)]
-pub struct MeldInfo {
-    /// 鳴きの種類
-    pub call_type: CallType,
-    /// 公開された牌
-    pub tiles: Vec<Tile>,
-}
 
 /// CPUが保持するゲーム状態（全て ServerEvent から構築）
 #[derive(Debug, Clone)]
@@ -45,7 +37,7 @@ pub struct CpuGameState {
     /// 各プレイヤーのリーチ状態
     pub player_riichi: [bool; 4],
     /// 各プレイヤーの副露情報
-    pub player_melds: [Vec<MeldInfo>; 4],
+    pub player_melds: [Vec<Meld>; 4],
     /// ドラ表示牌
     pub dora_indicators: Vec<Tile>,
     /// 場風
@@ -202,23 +194,26 @@ impl CpuGameState {
                 ..
             } => {
                 let idx = Self::wind_to_index(*player);
-                self.player_melds[idx].push(MeldInfo {
-                    call_type: call_type.clone(),
+                let category = match call_type {
+                    CallType::Chi => MeldType::Chi,
+                    CallType::Pon => MeldType::Pon,
+                    CallType::Ankan | CallType::Daiminkan => MeldType::Kan,
+                    CallType::Kakan => MeldType::Kakan,
+                    CallType::Ron => MeldType::Pon, // フォールバック（使われない）
+                };
+                let from = match call_type {
+                    CallType::Ankan => MeldFrom::Myself,
+                    _ => MeldFrom::Unknown,
+                };
+                self.player_melds[idx].push(Meld {
                     tiles: tiles.clone(),
+                    category,
+                    from,
+                    called_tile: Some(*called_tile),
                 });
-
-                // 捨て牌から鳴かれた牌を除去する必要はない
-                // （サーバが is_called フラグを管理するので、CPUは捨て牌リストをそのまま保持）
-
-                // 鳴かれた牌が自分の捨て牌にあった場合の処理は不要
-                // （捨て牌はそのまま保持 — 現物判定に使うため）
 
                 self.pending_calls.clear();
                 self.pending_call_tile = None;
-
-                // 自分が鳴いた場合、called_tile の情報を保持
-                // （HandUpdated で手牌が更新される）
-                let _ = called_tile; // 明示的に使わないことを示す
             }
 
             ServerEvent::PlayerRiichi {

--- a/crates/mahjong-server/src/player.rs
+++ b/crates/mahjong-server/src/player.rs
@@ -3,7 +3,7 @@
 //! 各プレイヤーの手牌、捨て牌、点数、リーチ状態などを管理する。
 
 use mahjong_core::hand::Hand;
-use mahjong_core::hand_info::opened::{OpenFrom, OpenTiles, OpenType};
+use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
 use mahjong_core::tile::{Tile, TileType, Wind};
 use serde::{Deserialize, Serialize};
 
@@ -140,9 +140,9 @@ impl Player {
 
     /// 門前（鳴いていない）かどうか
     pub fn is_menzen(&self) -> bool {
-        self.hand.opened().iter().all(|o| {
+        self.hand.melds().iter().all(|o| {
             // 暗カンは門前扱い
-            o.from == OpenFrom::Myself
+            o.from == MeldFrom::Myself
         })
     }
 
@@ -252,9 +252,9 @@ impl Player {
         }
 
         self.hand
-            .opened()
+            .melds()
             .iter()
-            .filter(|open| open.category == OpenType::Pon)
+            .filter(|open| open.category == MeldType::Pon)
             .filter_map(|open| {
                 let tile_type = open.tiles[0].get();
                 (counts[tile_type as usize] >= 1).then_some(tile_type)
@@ -291,7 +291,7 @@ impl Player {
     /// ポンを実行する
     ///
     /// 手牌から同じ種類の牌2枚を取り除き、鳴いた牌と合わせて副露に追加する。
-    pub fn do_pon(&mut self, called_tile: Tile, from: OpenFrom) {
+    pub fn do_pon(&mut self, called_tile: Tile, from: MeldFrom) {
         let tt = called_tile.get();
         let mut indices: Vec<usize> = Vec::new();
         for (i, t) in self.hand.tiles().iter().enumerate() {
@@ -305,10 +305,11 @@ impl Player {
 
         self.hand.remove_tiles_by_indices(&mut indices);
 
-        self.hand.add_opened(OpenTiles {
-            tiles: [t1, t2, called_tile],
-            category: OpenType::Pon,
+        self.hand.add_meld(Meld {
+            tiles: vec![t1, t2, called_tile],
+            category: MeldType::Pon,
             from,
+            called_tile: Some(called_tile),
         });
 
         self.is_first_turn = false;
@@ -338,10 +339,11 @@ impl Player {
         let mut chi_tiles = [t1, t2, called_tile];
         chi_tiles.sort();
 
-        self.hand.add_opened(OpenTiles {
-            tiles: chi_tiles,
-            category: OpenType::Chi,
-            from: OpenFrom::Previous, // チーは常に上家から
+        self.hand.add_meld(Meld {
+            tiles: chi_tiles.to_vec(),
+            category: MeldType::Chi,
+            from: MeldFrom::Previous, // チーは常に上家から
+            called_tile: Some(called_tile),
         });
 
         self.is_first_turn = false;
@@ -349,7 +351,7 @@ impl Player {
     }
 
     /// 大明カンを実行する
-    pub fn do_daiminkan(&mut self, called_tile: Tile, from: OpenFrom) {
+    pub fn do_daiminkan(&mut self, called_tile: Tile, from: MeldFrom) {
         let tt = called_tile.get();
         let mut indices: Vec<usize> = Vec::new();
         for (i, t) in self.hand.tiles().iter().enumerate() {
@@ -364,10 +366,11 @@ impl Player {
         let t3 = self.hand.tiles()[indices[2]];
 
         self.hand.remove_tiles_by_indices(&mut indices);
-        self.hand.add_opened(OpenTiles {
-            tiles: [t1, t2, t3],
-            category: OpenType::Kan,
+        self.hand.add_meld(Meld {
+            tiles: vec![t1, t2, t3],
+            category: MeldType::Kan,
             from,
+            called_tile: Some(called_tile),
         });
 
         self.is_first_turn = false;
@@ -401,10 +404,11 @@ impl Player {
         }
 
         self.hand.remove_tiles_by_indices(&mut indices);
-        self.hand.add_opened(OpenTiles {
-            tiles: [kan_tiles[0], kan_tiles[1], kan_tiles[2]],
-            category: OpenType::Kan,
-            from: OpenFrom::Myself,
+        self.hand.add_meld(Meld {
+            tiles: vec![kan_tiles[0], kan_tiles[1], kan_tiles[2]],
+            category: MeldType::Kan,
+            from: MeldFrom::Myself,
+            called_tile: None,
         });
 
         self.is_first_turn = false;
@@ -434,11 +438,11 @@ impl Player {
 
         let open = self
             .hand
-            .opened_mut()
+            .melds_mut()
             .iter_mut()
-            .find(|open| open.category == OpenType::Pon && open.tiles[0].get() == tile_type)
+            .find(|open| open.category == MeldType::Pon && open.tiles[0].get() == tile_type)
             .expect("加カン対象のポンがありません");
-        open.category = OpenType::Kan;
+        open.category = MeldType::Kakan;
 
         self.is_first_turn = false;
         self.is_ippatsu = false;
@@ -447,18 +451,18 @@ impl Player {
     /// 手牌に含まれる槓子の数を返す
     pub fn kan_count(&self) -> usize {
         self.hand
-            .opened()
+            .melds()
             .iter()
-            .filter(|open| open.category == OpenType::Kan)
+            .filter(|open| open.category.is_kan())
             .count()
     }
 
-    /// 捨てたプレイヤーと自分の相対位置から OpenFrom を返す
-    pub fn open_from_relative(caller: usize, discarder: usize) -> OpenFrom {
+    /// 捨てたプレイヤーと自分の相対位置から MeldFrom を返す
+    pub fn meld_from_relative(caller: usize, discarder: usize) -> MeldFrom {
         match (caller + 4 - discarder) % 4 {
-            1 => OpenFrom::Previous,   // 上家（カミチャ）
-            2 => OpenFrom::Opposite,   // 対面（トイメン）
-            3 => OpenFrom::Following,  // 下家（シモチャ）
+            1 => MeldFrom::Previous,   // 上家（カミチャ）
+            2 => MeldFrom::Opposite,   // 対面（トイメン）
+            3 => MeldFrom::Following,  // 下家（シモチャ）
             _ => unreachable!(),
         }
     }
@@ -637,13 +641,13 @@ mod tests {
         let mut player = Player::new(Wind::South, tiles, 25000);
         let called = Tile::new(Tile::M1);
 
-        player.do_pon(called, OpenFrom::Previous);
+        player.do_pon(called, MeldFrom::Previous);
 
         // 手牌が11枚になること（13 - 2 = 11）
         assert_eq!(player.hand.tiles().len(), 11);
         // 副露が1つ
-        assert_eq!(player.hand.opened().len(), 1);
-        assert_eq!(player.hand.opened()[0].category, OpenType::Pon);
+        assert_eq!(player.hand.melds().len(), 1);
+        assert_eq!(player.hand.melds()[0].category, MeldType::Pon);
         // 門前でなくなる
         assert!(!player.is_menzen());
     }
@@ -673,8 +677,8 @@ mod tests {
         // 手牌が11枚になること
         assert_eq!(player.hand.tiles().len(), 11);
         // 副露が1つ
-        assert_eq!(player.hand.opened().len(), 1);
-        assert_eq!(player.hand.opened()[0].category, OpenType::Chi);
+        assert_eq!(player.hand.melds().len(), 1);
+        assert_eq!(player.hand.melds()[0].category, MeldType::Chi);
         // 門前でなくなる
         assert!(!player.is_menzen());
     }
@@ -715,11 +719,11 @@ mod tests {
         let hand = Hand::from("111m234p567s789m1z");
         let mut player = Player::new(Wind::South, hand.tiles().to_vec(), 25000);
 
-        player.do_daiminkan(Tile::new(Tile::M1), OpenFrom::Previous);
+        player.do_daiminkan(Tile::new(Tile::M1), MeldFrom::Previous);
 
         assert_eq!(player.hand.tiles().len(), 10);
-        assert_eq!(player.hand.opened().len(), 1);
-        assert_eq!(player.hand.opened()[0].category, OpenType::Kan);
+        assert_eq!(player.hand.melds().len(), 1);
+        assert_eq!(player.hand.melds()[0].category, MeldType::Kan);
         assert!(!player.is_menzen());
     }
 
@@ -733,8 +737,8 @@ mod tests {
 
         assert_eq!(player.hand.tiles().len(), 10);
         assert!(player.hand.drawn().is_none());
-        assert_eq!(player.hand.opened().len(), 1);
-        assert_eq!(player.hand.opened()[0].category, OpenType::Kan);
+        assert_eq!(player.hand.melds().len(), 1);
+        assert_eq!(player.hand.melds()[0].category, MeldType::Kan);
         assert!(player.is_menzen());
     }
 
@@ -747,8 +751,8 @@ mod tests {
 
         assert_eq!(player.hand.tiles().len(), 10);
         assert!(player.hand.drawn().is_none());
-        assert_eq!(player.hand.opened().len(), 1);
-        assert_eq!(player.hand.opened()[0].category, OpenType::Kan);
+        assert_eq!(player.hand.melds().len(), 1);
+        assert_eq!(player.hand.melds()[0].category, MeldType::Kakan);
         assert!(!player.is_menzen());
     }
 
@@ -762,18 +766,18 @@ mod tests {
         assert!(player.hand.drawn().is_none());
         assert_eq!(player.hand.tiles().len(), 10);
         assert!(player.hand.tiles().contains(&Tile::new(Tile::S9)));
-        assert_eq!(player.hand.opened().len(), 1);
-        assert_eq!(player.hand.opened()[0].category, OpenType::Kan);
+        assert_eq!(player.hand.melds().len(), 1);
+        assert_eq!(player.hand.melds()[0].category, MeldType::Kakan);
     }
 
     #[test]
-    fn test_open_from_relative() {
+    fn test_meld_from_relative() {
         // プレイヤー1から見たプレイヤー0 → 上家（Previous）
-        assert_eq!(Player::open_from_relative(1, 0), OpenFrom::Previous);
+        assert_eq!(Player::meld_from_relative(1, 0), MeldFrom::Previous);
         // プレイヤー2から見たプレイヤー0 → 対面（Opposite）
-        assert_eq!(Player::open_from_relative(2, 0), OpenFrom::Opposite);
+        assert_eq!(Player::meld_from_relative(2, 0), MeldFrom::Opposite);
         // プレイヤー3から見たプレイヤー0 → 下家（Following）
-        assert_eq!(Player::open_from_relative(3, 0), OpenFrom::Following);
+        assert_eq!(Player::meld_from_relative(3, 0), MeldFrom::Following);
     }
 
     #[test]

--- a/crates/mahjong-server/src/round.rs
+++ b/crates/mahjong-server/src/round.rs
@@ -181,15 +181,22 @@ impl Round {
         self.players
             .iter()
             .map(|p| {
-                let melds: Vec<MeldTiles> = p.hand.opened().iter().map(|open| {
-                    let mut tiles: Vec<Tile> = open.tiles.to_vec();
+                let melds: Vec<MeldTiles> = p.hand.melds().iter().map(|open| {
+                    let mut tiles: Vec<Tile> = open.tiles.clone();
                     let call_type = match open.category {
-                        mahjong_core::hand_info::opened::OpenType::Chi => CallType::Chi,
-                        mahjong_core::hand_info::opened::OpenType::Pon => CallType::Pon,
-                        mahjong_core::hand_info::opened::OpenType::Kan => CallType::Ankan,
+                        mahjong_core::hand_info::meld::MeldType::Chi => CallType::Chi,
+                        mahjong_core::hand_info::meld::MeldType::Pon => CallType::Pon,
+                        mahjong_core::hand_info::meld::MeldType::Kan => {
+                            if open.from == mahjong_core::hand_info::meld::MeldFrom::Myself {
+                                CallType::Ankan
+                            } else {
+                                CallType::Daiminkan
+                            }
+                        }
+                        mahjong_core::hand_info::meld::MeldType::Kakan => CallType::Kakan,
                     };
                     // カンの場合は4枚にする
-                    if open.category == mahjong_core::hand_info::opened::OpenType::Kan {
+                    if open.category.is_kan() && tiles.len() == 3 {
                         tiles.push(tiles[0]);
                     }
                     MeldTiles { call_type, tiles }
@@ -772,7 +779,7 @@ impl Round {
 
     /// ポンを実行する
     fn execute_pon(&mut self, caller: usize, discarder: usize, called_tile: Tile) {
-        let from = Player::open_from_relative(caller, discarder);
+        let from = Player::meld_from_relative(caller, discarder);
         self.players[caller].do_pon(called_tile, from);
 
         // 捨て牌を「鳴かれた」としてマーク
@@ -790,7 +797,7 @@ impl Round {
         let caller_wind = self.players[caller].seat_wind;
         let tiles: Vec<Tile> = self.players[caller]
             .hand
-            .opened()
+            .melds()
             .last()
             .unwrap()
             .tiles
@@ -823,7 +830,7 @@ impl Round {
 
     /// 大明カンを実行する
     fn execute_daiminkan(&mut self, caller: usize, discarder: usize, called_tile: Tile) {
-        let from = Player::open_from_relative(caller, discarder);
+        let from = Player::meld_from_relative(caller, discarder);
         self.players[caller].do_daiminkan(called_tile, from);
 
         if let Some(last_discard) = self.players[discarder].discards.last_mut() {
@@ -836,7 +843,7 @@ impl Round {
         }
 
         let caller_wind = self.players[caller].seat_wind;
-        let open = self.players[caller].hand.opened().last().unwrap();
+        let open = self.players[caller].hand.melds().last().unwrap();
         let mut tiles = open.tiles.to_vec();
         tiles.push(called_tile);
 
@@ -889,7 +896,7 @@ impl Round {
         let caller_wind = self.players[caller].seat_wind;
         let tiles: Vec<Tile> = self.players[caller]
             .hand
-            .opened()
+            .melds()
             .last()
             .unwrap()
             .tiles
@@ -928,9 +935,11 @@ impl Round {
         }
 
         let caller_wind = self.players[caller].seat_wind;
-        let open = self.players[caller].hand.opened().iter().rev().find(|open| open.category == mahjong_core::hand_info::opened::OpenType::Kan && open.tiles[0].get() == tile_type).unwrap();
-        let mut tiles = open.tiles.to_vec();
-        tiles.push(Tile::new(tile_type));
+        let open = self.players[caller].hand.melds().iter().rev().find(|open| open.category == mahjong_core::hand_info::meld::MeldType::Kakan && open.tiles[0].get() == tile_type).unwrap();
+        let mut tiles = open.tiles.clone();
+        if tiles.len() == 3 {
+            tiles.push(Tile::new(tile_type));
+        }
 
         for i in 0..4 {
             self.events.push((
@@ -1040,7 +1049,7 @@ impl Round {
         }
 
         let caller_wind = self.players[player_idx].seat_wind;
-        let open = self.players[player_idx].hand.opened().last().unwrap();
+        let open = self.players[player_idx].hand.melds().last().unwrap();
         let mut tiles = open.tiles.to_vec();
         tiles.push(open.tiles[0]);
         let called_tile = Tile::new(tile_type);
@@ -1921,7 +1930,7 @@ mod tests {
         assert!(round.do_kan(Tile::M1));
         assert_eq!(round.phase, TurnPhase::WaitForDiscard);
         assert!(round.players[0].hand.drawn().is_some());
-        assert_eq!(round.players[0].hand.opened().len(), 1);
+        assert_eq!(round.players[0].hand.melds().len(), 1);
         assert_eq!(round.wall.dora_indicators().len(), 2);
     }
 
@@ -1939,7 +1948,7 @@ mod tests {
         assert!(round.do_kan(Tile::M1));
         assert_eq!(round.phase, TurnPhase::WaitForDiscard);
         assert!(round.players[0].hand.drawn().is_some());
-        assert_eq!(round.players[0].hand.opened()[0].category, mahjong_core::hand_info::opened::OpenType::Kan);
+        assert_eq!(round.players[0].hand.melds()[0].category, mahjong_core::hand_info::meld::MeldType::Kakan);
         assert_eq!(round.wall.dora_indicators().len(), 2);
     }
 

--- a/crates/mahjong-server/src/scoring.rs
+++ b/crates/mahjong-server/src/scoring.rs
@@ -270,11 +270,11 @@ pub fn add_dora_to_score(
     if let Some(tile) = extra_tile {
         all_tiles.push(tile);
     }
-    for open in hand.opened() {
+    for open in hand.melds() {
         for &tile in &open.tiles {
             all_tiles.push(tile);
         }
-        if open.category == mahjong_core::hand_info::opened::OpenType::Kan {
+        if open.category.is_kan() && open.tiles.len() == 3 {
             all_tiles.push(open.tiles[0]);
         }
     }
@@ -522,21 +522,23 @@ mod tests {
 
     #[test]
     fn test_check_win_open_tanyao_tsumo() {
-        use mahjong_core::hand_info::opened::{OpenFrom, OpenTiles, OpenType};
+        use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
 
         let hand = Hand::from("56677m66s 5m");
         let tiles: Vec<Tile> = hand.tiles().to_vec();
         let drawn = hand.drawn();
         let mut player = Player::new(Wind::South, tiles, 25000);
-        player.hand.add_opened(OpenTiles {
-            tiles: [Tile::new(Tile::P4), Tile::new(Tile::P5), Tile::new(Tile::P6)],
-            category: OpenType::Chi,
-            from: OpenFrom::Previous,
+        player.hand.add_meld(Meld {
+            tiles: vec![Tile::new(Tile::P4), Tile::new(Tile::P5), Tile::new(Tile::P6)],
+            category: MeldType::Chi,
+            from: MeldFrom::Previous,
+            called_tile: None,
         });
-        player.hand.add_opened(OpenTiles {
-            tiles: [Tile::new(Tile::M2), Tile::new(Tile::M3), Tile::new(Tile::M4)],
-            category: OpenType::Chi,
-            from: OpenFrom::Previous,
+        player.hand.add_meld(Meld {
+            tiles: vec![Tile::new(Tile::M2), Tile::new(Tile::M3), Tile::new(Tile::M4)],
+            category: MeldType::Chi,
+            from: MeldFrom::Previous,
+            called_tile: None,
         });
         if let Some(d) = drawn {
             player.draw(d);


### PR DESCRIPTION
## Summary
- Replaces the duplicated `MeldInfo` client struct with the core `OpenTiles` struct, then renames all `Open`-prefixed types to use the standard English mahjong term "meld" for consistency across all three crates
- Renames: `OpenTiles` → `Meld`, `OpenType` → `MeldType`, `OpenFrom` → `MeldFrom`, `opened.rs` → `meld.rs`, and all related methods (`hand.opened()` → `hand.melds()`, etc.)
- Adds `Kakan` variant to `MeldType`, `called_tile` field to `Meld`, changes tiles from `[Tile; 3]` to `Vec<Tile>`, and implements correct visual rendering of called tiles with sideways positioning based on caller direction

Closes #71

## Test plan
- [x] All 278 tests pass (`cargo test`)
- [x] Build succeeds with no warnings
- [x] No remaining references to old `Open*` type names
- [ ] Manual verification of meld rendering in-game (chi/pon/kan sideways tile positioning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)