### PR TITLE
Fix game freeze after kan

### DIFF
--- a/crates/mahjong-client/src/adapter.rs
+++ b/crates/mahjong-client/src/adapter.rs
@@ -220,3 +220,130 @@ impl LocalAdapter {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mahjong_core::hand::Hand;
+    use mahjong_core::tile::Tile;
+    use mahjong_server::player::Player;
+    use mahjong_server::round::TurnPhase;
+    use mahjong_server::protocol::ServerEvent;
+
+    /// カン後にゲームが進行できることを確認するテスト
+    #[test]
+    fn test_kan_advances_game() {
+        let mut adapter = LocalAdapter::new();
+
+        // ゲームを開始
+        adapter.table.start_round();
+
+        // player 0 (human) の手牌を「暗カン可能」なものに設定
+        {
+            let round = adapter.table.current_round_mut().unwrap();
+            let seat_wind = round.players[0].seat_wind;
+            // 1mが3枚(main)+1枚(drawn)=4枚 → 暗カン可能
+            let hand = Hand::from("2p3p4p5s6s7s7m8m9m1m1m1m 1m");
+            round.players[0] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
+            round.players[0].draw(hand.drawn().unwrap());
+            round.current_player = 0;
+            round.phase = TurnPhase::WaitForDiscard;
+            round.drain_events();
+        }
+
+        // 初期イベントを処理
+        adapter.process_all_events();
+        let _ = adapter.poll_events(0);
+
+        // player 0 が暗カンを実行
+        let kan_result = adapter.table.handle_action(0, ClientAction::Kan { tile_index: Tile::M1 as usize });
+        assert!(kan_result, "カンが失敗した");
+
+        adapter.process_all_events();
+
+        // カン後の状態確認
+        {
+            let round = adapter.table.current_round().unwrap();
+            assert_eq!(round.phase, TurnPhase::WaitForDiscard, "カン後のフェーズがWaitForDiscardでない");
+            assert_eq!(round.current_player, 0, "カン後の現在プレイヤーが0でない");
+            assert!(round.players[0].hand.drawn().is_some(), "カン後に嶺上牌が設定されていない");
+        }
+
+        // イベントを取得
+        let events = adapter.poll_events(0);
+        let has_tile_drawn = events.iter().any(|e| matches!(e, ServerEvent::TileDrawn { .. }));
+        assert!(has_tile_drawn, "カン後にTileDrawnイベントが来なかった: {:?}", events.iter().map(|e| std::mem::discriminant(e)).collect::<Vec<_>>());
+
+        // 打牌して進行できることを確認
+        let discard_result = adapter.table.handle_action(0, ClientAction::Discard { tile: None });
+        assert!(discard_result, "カン後の打牌が失敗した");
+    }
+
+    /// CPUプレイヤーがカンした後にゲームが正しく進行することを確認
+    #[test]
+    fn test_cpu_kan_advances_game() {
+        let mut adapter = LocalAdapter::new();
+
+        adapter.table.start_round();
+
+        // player 1 (CPU) の手牌を「暗カン可能」なものに設定
+        {
+            let round = adapter.table.current_round_mut().unwrap();
+            let seat_wind = round.players[1].seat_wind;
+            let hand = Hand::from("2p3p4p5s6s7s7m8m9m1m1m1m 1m");
+            round.players[1] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
+            round.players[1].draw(hand.drawn().unwrap());
+            round.current_player = 1;
+            round.phase = TurnPhase::WaitForDiscard;
+            round.drain_events();
+        }
+
+        // イベント処理（CPUが自動的にカンまたは打牌する）
+        adapter.process_all_events();
+
+        // ゲームが進行した（RoundOverでなくWaitForDiscardかDrawになっている）ことを確認
+        let phase = {
+            let round = adapter.table.current_round().unwrap();
+            round.phase.clone()
+        };
+        assert!(
+            phase == TurnPhase::WaitForDiscard || phase == TurnPhase::Draw || phase == TurnPhase::WaitForCalls,
+            "CPUカン後にゲームが詰まった: フェーズ = {:?}", phase
+        );
+
+        // さらに10ターン分ゲームを進める（フリーズしないことを確認）
+        for _i in 0..10 {
+            adapter.tick();
+            let _ = adapter.poll_events(0);
+            {
+                let round = adapter.table.current_round().unwrap();
+                if round.is_over() {
+                    break;
+                }
+            }
+            // WaitForDiscardかつhuman playerの番なら打牌
+            {
+                let (phase, current_player) = {
+                    let round = adapter.table.current_round().unwrap();
+                    (round.phase.clone(), round.current_player)
+                };
+                if phase == TurnPhase::WaitForDiscard && current_player == 0 {
+                    adapter.table.handle_action(0, ClientAction::Discard { tile: None });
+                    adapter.process_all_events();
+                }
+            }
+            // WaitForCallsかつhuman playerに鳴き機会があればパス
+            {
+                let (phase, human_responded) = {
+                    let round = adapter.table.current_round().unwrap();
+                    let responded = round.call_state.as_ref().map(|cs| cs.responded[0]).unwrap_or(true);
+                    (round.phase.clone(), responded)
+                };
+                if phase == TurnPhase::WaitForCalls && !human_responded {
+                    adapter.table.handle_action(0, ClientAction::Pass);
+                    adapter.process_all_events();
+                }
+            }
+        }
+    }
+}

--- a/crates/mahjong-server/src/cpu/state.rs
+++ b/crates/mahjong-server/src/cpu/state.rs
@@ -58,6 +58,8 @@ pub struct CpuGameState {
     // --- 鳴き後打牌フラグ ---
     /// 鳴き後に打牌が必要か
     pub need_discard_after_call: bool,
+    /// 直前の鳴きがカン系（嶺上ツモ待ち）か
+    pub pending_kan_draw: bool,
 }
 
 impl CpuGameState {
@@ -83,6 +85,7 @@ impl CpuGameState {
             pending_calls: Vec::new(),
             pending_call_tile: None,
             need_discard_after_call: false,
+            pending_kan_draw: false,
         }
     }
 
@@ -129,6 +132,7 @@ impl CpuGameState {
                 self.pending_calls.clear();
                 self.pending_call_tile = None;
                 self.need_discard_after_call = false;
+                self.pending_kan_draw = false;
             }
 
             ServerEvent::TileDrawn {
@@ -214,6 +218,11 @@ impl CpuGameState {
 
                 self.pending_calls.clear();
                 self.pending_call_tile = None;
+                // カン系（嶺上ツモ待ち）かどうかを記録する
+                self.pending_kan_draw = matches!(
+                    call_type,
+                    CallType::Ankan | CallType::Daiminkan | CallType::Kakan
+                );
             }
 
             ServerEvent::PlayerRiichi {
@@ -237,8 +246,13 @@ impl CpuGameState {
             ServerEvent::HandUpdated { hand } => {
                 self.my_hand = hand.clone();
                 self.my_drawn = None;
-                // 鳴き後は打牌が必要
-                self.need_discard_after_call = true;
+                if self.pending_kan_draw {
+                    // カン系: 嶺上ツモ（TileDrawn）が来るまで打牌不要
+                    self.pending_kan_draw = false;
+                } else {
+                    // ポン/チー後: 打牌が必要
+                    self.need_discard_after_call = true;
+                }
             }
 
             ServerEvent::RoundWon { scores, .. } => {

--- a/crates/mahjong-server/src/player.rs
+++ b/crates/mahjong-server/src/player.rs
@@ -401,6 +401,11 @@ impl Player {
         if drawn_matches {
             kan_tiles.push(drawn.unwrap());
             self.hand.set_drawn(None);
+        } else if let Some(d) = drawn {
+            // ツモ牌がカン牌でない場合、手牌に戻す（嶺上ツモで上書きされないよう）
+            self.hand.tiles_mut().push(d);
+            self.hand.sort();
+            self.hand.set_drawn(None);
         }
 
         self.hand.remove_tiles_by_indices(&mut indices);


### PR DESCRIPTION
## Summary

Fixes #85

- **CPU double-action bug**: `HandUpdated` after a kan unconditionally set `need_discard_after_call=true`, causing the CPU to discard prematurely before the rinshan tile arrived via `TileDrawn`. Added `pending_kan_draw` flag to `CpuGameState` so that `HandUpdated` following a kan-type call skips the discard trigger and waits for the rinshan draw instead.
- **Tile loss in `do_ankan`**: When all 4 kan tiles were in `hand.tiles()` and `drawn` held a different tile, `do_ankan` left `drawn` intact. `draw_after_kan` then overwrote it with the rinshan tile via `player.draw()`, permanently losing the original drawn tile. Fixed by moving the non-kan drawn tile back into `hand.tiles()` before the kan meld is formed.

## Test plan

- [ ] `adapter::tests::test_kan_advances_game` — human player performs ankan, verifies phase=`WaitForDiscard`, rinshan is set as drawn, `TileDrawn` event received, subsequent discard succeeds
- [ ] `adapter::tests::test_cpu_kan_advances_game` — CPU player performs ankan, verifies game does not freeze over 10 ticks
- [ ] All existing tests pass (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)