### PR TITLE
Add chi/pon call selection UI with overlay refactoring

### DIFF
--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -896,57 +896,82 @@ impl GameState {
         discarded_tile
     }
 
-    /// 入力処理: クリックで牌を選択し、アクションを返す
-    pub fn handle_input(&mut self) -> Option<ClientAction> {
+    /// 入力処理: オーバーレイのクリック結果と手牌クリックを処理してアクションを返す
+    pub fn handle_input(&mut self, overlay_click: Option<crate::renderer::OverlayClick>) -> Option<ClientAction> {
+        use crate::renderer::OverlayClick;
+
         if self.phase != GamePhase::Playing {
             return None;
         }
 
-        if self.chi_option_selecting {
-            return self.handle_chi_selection_input();
-        }
-
-        if self.pon_option_selecting {
-            return self.handle_pon_selection_input();
-        }
-
-        if !self.available_calls.is_empty() {
-            return self.handle_call_input();
-        }
-
-        if !self.is_my_turn {
-            return None;
-        }
-
-        if self.is_riichi && self.drawn.is_some() && !self.can_tsumo {
+        // リーチ中はツモ切り自動処理（マウス入力不要）
+        if self.is_my_turn && self.is_riichi && self.drawn.is_some() && !self.can_tsumo {
             self.drawn.take();
             return Some(ClientAction::Discard { tile: None });
         }
 
-        if is_mouse_button_pressed(MouseButton::Left) {
-            let (mx, my) = mouse_position();
-
-            if self.can_tsumo {
-                // 和了ボタン（手牌上部の大きなボタン）
-                if mx >= crate::renderer::AGARI_BTN_X
-                    && mx <= crate::renderer::AGARI_BTN_X + crate::renderer::AGARI_BTN_W
-                    && my >= crate::renderer::AGARI_BTN_Y
-                    && my <= crate::renderer::AGARI_BTN_Y + crate::renderer::AGARI_BTN_H
-                {
-                    return Some(ClientAction::Tsumo);
+        // オーバーレイのクリック判定（draw_game が返した結果を処理）
+        if let Some(click) = overlay_click {
+            if self.chi_option_selecting {
+                match click {
+                    OverlayClick::Action(action) => {
+                        self.chi_option_selecting = false;
+                        self.chi_pending_options.clear();
+                        self.available_calls.clear();
+                        self.call_target_tile = None;
+                        return Some(action);
+                    }
+                    OverlayClick::CancelMeldSelection => {
+                        self.chi_option_selecting = false;
+                        self.chi_pending_options.clear();
+                    }
+                    _ => {}
                 }
+                return None;
             }
 
-            if self.can_riichi {
-                let riichi_x = 1000.0;
-                let riichi_y = 720.0;
-                let btn_w = 80.0;
-                let btn_h = 40.0;
-                if mx >= riichi_x
-                    && mx <= riichi_x + btn_w
-                    && my >= riichi_y
-                    && my <= riichi_y + btn_h
-                {
+            if self.pon_option_selecting {
+                match click {
+                    OverlayClick::Action(action) => {
+                        self.pon_option_selecting = false;
+                        self.pon_pending_options.clear();
+                        self.available_calls.clear();
+                        self.call_target_tile = None;
+                        return Some(action);
+                    }
+                    OverlayClick::CancelMeldSelection => {
+                        self.pon_option_selecting = false;
+                        self.pon_pending_options.clear();
+                    }
+                    _ => {}
+                }
+                return None;
+            }
+
+            if !self.available_calls.is_empty() {
+                match click {
+                    OverlayClick::Action(action) => {
+                        self.available_calls.clear();
+                        self.call_target_tile = None;
+                        return Some(action);
+                    }
+                    OverlayClick::ShowChiSelection { options } => {
+                        self.chi_pending_options = options;
+                        self.chi_option_selecting = true;
+                    }
+                    OverlayClick::ShowPonSelection { options } => {
+                        self.pon_pending_options = options;
+                        self.pon_option_selecting = true;
+                    }
+                    _ => {}
+                }
+                return None;
+            }
+
+            // 自分のターン：ツモ・リーチ・暗カン
+            match click {
+                OverlayClick::Action(action) => return Some(action),
+                OverlayClick::ToggleRiichi => {
                     if self.riichi_selection_mode {
                         self.clear_riichi_selection();
                     } else {
@@ -954,314 +979,84 @@ impl GameState {
                     }
                     return None;
                 }
+                _ => {}
             }
+        }
 
-            for (idx, tile) in self.self_kan_options.iter().enumerate() {
-                let x = 720.0 + idx as f32 * 110.0;
-                let y = 670.0;
-                let btn_w = 100.0;
-                let btn_h = 40.0;
-                if mx >= x && mx <= x + btn_w && my >= y && my <= y + btn_h {
-                    return Some(ClientAction::Kan {
-                        tile_index: tile.get() as usize,
-                    });
+        // オーバーレイがクリックされていない場合は手牌のクリックを処理
+        if !self.is_my_turn || !is_mouse_button_pressed(MouseButton::Left) {
+            return None;
+        }
+
+        // チー・ポン・鳴きパネル表示中は手牌クリックを無視
+        if self.chi_option_selecting || self.pon_option_selecting || !self.available_calls.is_empty() {
+            return None;
+        }
+
+        if self.is_riichi {
+            return None;
+        }
+
+        let (mx, my) = mouse_position();
+
+        // 手牌クリック
+        let hand_start_x = 100.0;
+        let hand_y = 680.0;
+        let tile_w = 48.0;
+        let tile_h = 68.0;
+        let hand_len = self.hand.len();
+
+        for i in 0..hand_len {
+            let x = hand_start_x + i as f32 * tile_w;
+            if mx >= x && mx <= x + tile_w && my >= hand_y && my <= hand_y + tile_h {
+                if self.riichi_selection_mode && !self.riichi_selectable_tiles.contains(&i) {
+                    return None;
                 }
-            }
 
-            if self.is_riichi {
+                if self.selected_tile == Some(i) {
+                    let discarded_tile = self.apply_local_discard_from_hand(i);
+                    if self.riichi_selection_mode {
+                        self.clear_riichi_selection();
+                        return Some(ClientAction::Riichi { tile: Some(discarded_tile) });
+                    }
+                    return Some(ClientAction::Discard { tile: Some(discarded_tile) });
+                }
+
+                self.selected_tile = Some(i);
+                self.selected_drawn = false;
+                self.selected_would_cause_furiten =
+                    self.would_discard_cause_furiten(Some(self.hand[i]));
                 return None;
             }
+        }
 
-            let hand_start_x = 100.0;
-            let hand_y = 680.0;
-            let tile_w = 48.0;
-            let tile_h = 68.0;
-            let hand_len = self.hand.len();
+        if self.drawn.is_some() {
+            let drawn_x = hand_start_x + hand_len as f32 * tile_w + 20.0;
+            if mx >= drawn_x && mx <= drawn_x + tile_w && my >= hand_y && my <= hand_y + tile_h {
+                if self.riichi_selection_mode && !self.riichi_selectable_drawn {
+                    return None;
+                }
 
-            for i in 0..hand_len {
-                let x = hand_start_x + i as f32 * tile_w;
-                if mx >= x && mx <= x + tile_w && my >= hand_y && my <= hand_y + tile_h {
-                    if self.riichi_selection_mode && !self.riichi_selectable_tiles.contains(&i) {
-                        return None;
-                    }
-
-                    if self.selected_tile == Some(i) {
-                        let discarded_tile = self.apply_local_discard_from_hand(i);
-                        if self.riichi_selection_mode {
-                            self.clear_riichi_selection();
-                            return Some(ClientAction::Riichi {
-                                tile: Some(discarded_tile),
-                            });
-                        }
-                        return Some(ClientAction::Discard {
-                            tile: Some(discarded_tile),
-                        });
-                    }
-
-                    self.selected_tile = Some(i);
+                if self.selected_drawn {
                     self.selected_drawn = false;
-                    self.selected_would_cause_furiten =
-                        self.would_discard_cause_furiten(Some(self.hand[i]));
-                    return None;
+                    self.drawn.take();
+                    if self.riichi_selection_mode {
+                        self.clear_riichi_selection();
+                        return Some(ClientAction::Riichi { tile: None });
+                    }
+                    return Some(ClientAction::Discard { tile: None });
                 }
-            }
 
-            if self.drawn.is_some() {
-                let drawn_x = hand_start_x + hand_len as f32 * tile_w + 20.0;
-                if mx >= drawn_x
-                    && mx <= drawn_x + tile_w
-                    && my >= hand_y
-                    && my <= hand_y + tile_h
-                {
-                    if self.riichi_selection_mode && !self.riichi_selectable_drawn {
-                        return None;
-                    }
-
-                    if self.selected_drawn {
-                        self.selected_drawn = false;
-                        self.drawn.take();
-                        if self.riichi_selection_mode {
-                            self.clear_riichi_selection();
-                            return Some(ClientAction::Riichi { tile: None });
-                        }
-                        return Some(ClientAction::Discard { tile: None });
-                    }
-
-                    self.selected_drawn = true;
-                    self.selected_tile = None;
-                    self.selected_would_cause_furiten =
-                        self.would_discard_cause_furiten(None);
-                    return None;
-                }
-            }
-        }
-
-        None
-    }
-
-    /// 鳴きボタンの入力処理
-    fn handle_call_input(&mut self) -> Option<ClientAction> {
-        if !is_mouse_button_pressed(MouseButton::Left) {
-            return None;
-        }
-
-        let (mx, my) = mouse_position();
-
-        let btn_w = crate::renderer::CALL_BTN_W;
-        let btn_h = crate::renderer::CALL_BTN_H;
-        let btn_spacing = crate::renderer::CALL_BTN_SPACING;
-
-        // 鳴きボタンの個数から base_x を計算（ロン有無に関わらず同一レイアウト）
-        let has_ron = self
-            .available_calls
-            .iter()
-            .any(|c| matches!(c, AvailableCall::Ron));
-        let non_ron_count = self.available_calls.iter().filter(|c| !matches!(c, AvailableCall::Ron)).count();
-        let total_btn_count = non_ron_count + 1; // +1 for pass
-        let btns_w = total_btn_count as f32 * btn_w + (total_btn_count - 1) as f32 * btn_spacing;
-        let pad = crate::renderer::CALL_PANEL_PAD;
-        let tile_area_w = crate::renderer::CALL_PANEL_TILE_W + 12.0; // tile_gap
-        let panel_w = tile_area_w + btns_w + pad * 2.0;
-        let panel_x = crate::renderer::CALL_PANEL_RIGHT_X_NO_RON - panel_w;
-        let base_x = panel_x + pad + tile_area_w;
-        let base_y = crate::renderer::CALL_BTN_BASE_Y_NO_RON;
-
-        // 和了ボタン（ロン）の判定 — 鳴きあり時はパネル上、ロンのみ時は右下
-        if has_ron {
-            let panel_y = crate::renderer::CALL_PANEL_BOTTOM_Y_NO_RON - crate::renderer::CALL_OVERLAY_PANEL_H;
-            let agari_y = if non_ron_count > 0 {
-                panel_y - crate::renderer::AGARI_BTN_GAP - crate::renderer::AGARI_BTN_H
-            } else {
-                crate::renderer::AGARI_BTN_Y
-            };
-            if mx >= crate::renderer::AGARI_BTN_X
-                && mx <= crate::renderer::AGARI_BTN_X + crate::renderer::AGARI_BTN_W
-                && my >= agari_y
-                && my <= agari_y + crate::renderer::AGARI_BTN_H
-            {
-                self.available_calls.clear();
-                return Some(ClientAction::Ron);
-            }
-        }
-
-        let mut btn_idx = 0;
-
-        for call in &self.available_calls {
-            if matches!(call, AvailableCall::Ron) {
-                continue;
-            }
-            let x = base_x + btn_idx as f32 * (btn_w + btn_spacing);
-            if mx >= x && mx <= x + btn_w && my >= base_y && my <= base_y + btn_h {
-                match call {
-                    AvailableCall::Ron => unreachable!(),
-                    AvailableCall::Pon { options } => {
-                        if options.len() == 1 {
-                            // 選択肢が1つのみなら即確定
-                            let tiles = options[0];
-                            self.available_calls.clear();
-                            return Some(ClientAction::Pon { tiles });
-                        } else if !options.is_empty() {
-                            // 複数の選択肢がある場合は選択UIを表示
-                            self.pon_pending_options = options.clone();
-                            self.pon_option_selecting = true;
-                        }
-                    }
-                    AvailableCall::Daiminkan => {
-                        let tile = self.call_target_tile?;
-                        self.available_calls.clear();
-                        return Some(ClientAction::Kan {
-                            tile_index: tile.get() as usize,
-                        });
-                    }
-                    AvailableCall::Chi { options } => {
-                        if options.len() == 1 {
-                            // 選択肢が1つのみなら即確定
-                            let tiles = options[0];
-                            self.available_calls.clear();
-                            return Some(ClientAction::Chi { tiles });
-                        } else if !options.is_empty() {
-                            // 複数の選択肢がある場合は選択UIを表示
-                            self.chi_pending_options = options.clone();
-                            self.chi_option_selecting = true;
-                        }
-                    }
-                }
-            }
-            btn_idx += 1;
-        }
-
-        // パスボタン（最後に配置）
-        let pass_x = base_x + btn_idx as f32 * (btn_w + btn_spacing);
-        if mx >= pass_x && mx <= pass_x + btn_w && my >= base_y && my <= base_y + btn_h {
-            self.available_calls.clear();
-            self.call_target_tile = None;
-            return Some(ClientAction::Pass);
-        }
-
-        None
-    }
-
-    /// チー選択UI（複数の組み合わせから選択）の入力処理
-    ///
-    /// renderer::CHI_SEL_* 定数で定義されたレイアウトと一致させること。
-    fn handle_chi_selection_input(&mut self) -> Option<ClientAction> {
-        if !is_mouse_button_pressed(MouseButton::Left) {
-            return None;
-        }
-        let (mx, my) = mouse_position();
-
-        let opt_count = self.chi_pending_options.len();
-        let tile_w: f32 = crate::renderer::CHI_SEL_TILE_W;
-        let tile_h: f32 = crate::renderer::CHI_SEL_TILE_H;
-        let tile_gap: f32 = crate::renderer::CHI_SEL_TILE_GAP;
-        let opt_w: f32 = tile_w * 3.0 + tile_gap * 2.0;
-        let opt_spacing: f32 = crate::renderer::CHI_SEL_OPT_SPACING;
-        let panel_w: f32 = opt_w * opt_count as f32 + opt_spacing * (opt_count as f32 - 1.0) + 80.0;
-        let panel_h: f32 = crate::renderer::CHI_SEL_PANEL_H;
-        let panel_x: f32 = crate::renderer::CALL_PANEL_RIGHT_X_NO_RON - panel_w;
-        let panel_y: f32 = crate::renderer::CALL_PANEL_BOTTOM_Y_NO_RON - panel_h;
-
-        let opts_start_x = panel_x + 40.0;
-        let opts_y = panel_y + 52.0;
-
-        let called_tile = match self.call_target_tile {
-            Some(t) => t,
-            None => {
-                self.chi_option_selecting = false;
-                self.chi_pending_options.clear();
+                self.selected_drawn = true;
+                self.selected_tile = None;
+                self.selected_would_cause_furiten = self.would_discard_cause_furiten(None);
                 return None;
             }
-        };
-
-        for (idx, &opt) in self.chi_pending_options.iter().enumerate() {
-            let ox = opts_start_x + idx as f32 * (opt_w + opt_spacing);
-            if mx >= ox && mx <= ox + opt_w && my >= opts_y && my <= opts_y + tile_h {
-                // この組み合わせを選択
-                let tiles = opt;
-                self.chi_option_selecting = false;
-                self.chi_pending_options.clear();
-                self.available_calls.clear();
-                self.call_target_tile = None;
-                return Some(ClientAction::Chi { tiles });
-            }
-            // called_tile のエリアもクリック可能にする（3枚分の横幅全体を反応させる）
-            let _ = called_tile; // used above
-        }
-
-        // キャンセルボタン
-        let cancel_w: f32 = 120.0;
-        let cancel_h: f32 = 36.0;
-        let cancel_x = panel_x + (panel_w - cancel_w) / 2.0;
-        let cancel_y = panel_y + panel_h - cancel_h - 14.0;
-        if mx >= cancel_x && mx <= cancel_x + cancel_w && my >= cancel_y && my <= cancel_y + cancel_h
-        {
-            self.chi_option_selecting = false;
-            self.chi_pending_options.clear();
         }
 
         None
     }
 
-    /// ポン選択UI（赤ドラ有無の組み合わせから選択）の入力処理
-    ///
-    /// renderer::CHI_SEL_* 定数と同じレイアウトを使用する。
-    fn handle_pon_selection_input(&mut self) -> Option<ClientAction> {
-        if !is_mouse_button_pressed(MouseButton::Left) {
-            return None;
-        }
-        let (mx, my) = mouse_position();
-
-        let opt_count = self.pon_pending_options.len();
-        let tile_w: f32 = crate::renderer::CHI_SEL_TILE_W;
-        let tile_h: f32 = crate::renderer::CHI_SEL_TILE_H;
-        let tile_gap: f32 = crate::renderer::CHI_SEL_TILE_GAP;
-        let opt_w: f32 = tile_w * 3.0 + tile_gap * 2.0;
-        let opt_spacing: f32 = crate::renderer::CHI_SEL_OPT_SPACING;
-        let panel_w: f32 = opt_w * opt_count as f32 + opt_spacing * (opt_count as f32 - 1.0) + 80.0;
-        let panel_h: f32 = crate::renderer::CHI_SEL_PANEL_H;
-        let panel_x: f32 = crate::renderer::CALL_PANEL_RIGHT_X_NO_RON - panel_w;
-        let panel_y: f32 = crate::renderer::CALL_PANEL_BOTTOM_Y_NO_RON - panel_h;
-
-        let opts_start_x = panel_x + 40.0;
-        let opts_y = panel_y + 52.0;
-
-        let called_tile = match self.call_target_tile {
-            Some(t) => t,
-            None => {
-                self.pon_option_selecting = false;
-                self.pon_pending_options.clear();
-                return None;
-            }
-        };
-
-        for (idx, &opt) in self.pon_pending_options.iter().enumerate() {
-            let ox = opts_start_x + idx as f32 * (opt_w + opt_spacing);
-            if mx >= ox && mx <= ox + opt_w && my >= opts_y && my <= opts_y + tile_h {
-                let tiles = opt;
-                self.pon_option_selecting = false;
-                self.pon_pending_options.clear();
-                self.available_calls.clear();
-                self.call_target_tile = None;
-                return Some(ClientAction::Pon { tiles });
-            }
-            let _ = called_tile;
-        }
-
-        // キャンセルボタン
-        let cancel_w: f32 = 120.0;
-        let cancel_h: f32 = 36.0;
-        let cancel_x = panel_x + (panel_w - cancel_w) / 2.0;
-        let cancel_y = panel_y + panel_h - cancel_h - 14.0;
-        if mx >= cancel_x && mx <= cancel_x + cancel_w && my >= cancel_y && my <= cancel_y + cancel_h
-        {
-            self.pon_option_selecting = false;
-            self.pon_pending_options.clear();
-        }
-
-        None
-    }
-
-    /// 風牌を相対位置（自分=0, 下家=1, 対面=2, 上家=3）に変換
     fn relative_player_index(&self, wind: Wind) -> usize {
         let my_idx = self
             .seat_wind

--- a/crates/mahjong-client/src/main.rs
+++ b/crates/mahjong-client/src/main.rs
@@ -42,6 +42,8 @@ async fn main() {
     loop {
         clear_background(Color::from_rgba(0, 100, 0, 255));
 
+        let overlay_click = renderer::draw_game(&game_state, font.as_ref(), &tile_textures);
+
         match game_state.phase {
             GamePhase::Setup => {
                 // 設定画面の入力処理
@@ -59,7 +61,7 @@ async fn main() {
 
             GamePhase::Playing => {
                 if let Some(ref mut adp) = adapter {
-                    let action = game_state.handle_input();
+                    let action = game_state.handle_input(overlay_click);
                     if let Some(act) = action {
                         adp.send_action(act);
                     }
@@ -99,8 +101,6 @@ async fn main() {
 
             GamePhase::WaitingForStart => {}
         }
-
-        renderer::draw_game(&game_state, font.as_ref(), &tile_textures);
 
         next_frame().await;
     }

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -3,14 +3,7 @@
 //! 埋め込みPNGを使って麻雀牌を描画する。
 
 mod overlay;
-pub use overlay::{
-    CHI_SEL_TILE_W, CHI_SEL_TILE_H, CHI_SEL_TILE_GAP, CHI_SEL_OPT_SPACING, CHI_SEL_PANEL_H,
-    CALL_BTN_W, CALL_BTN_H, CALL_BTN_SPACING, CALL_PANEL_PAD,
-    CALL_PANEL_TILE_W,
-    CALL_PANEL_RIGHT_X_NO_RON, CALL_PANEL_BOTTOM_Y_NO_RON, CALL_BTN_BASE_Y_NO_RON,
-    CALL_OVERLAY_PANEL_H,
-    AGARI_BTN_W, AGARI_BTN_H, AGARI_BTN_X, AGARI_BTN_Y, AGARI_BTN_GAP,
-};
+pub use overlay::OverlayClick;
 
 use macroquad::prelude::*;
 use mahjong_core::tile::Tile;
@@ -146,13 +139,15 @@ fn draw_jp_text(font: Option<&Font>, text: &str, x: f32, y: f32, font_size: u16,
     draw_text_ex(text, x, y, params);
 }
 
-pub fn draw_game(state: &GameState, font: Option<&Font>, tile_textures: &TileTextures) {
+pub fn draw_game(state: &GameState, font: Option<&Font>, tile_textures: &TileTextures) -> Option<OverlayClick> {
     match state.phase {
         GamePhase::Setup => {
             draw_setup(state, font);
+            None
         }
         GamePhase::WaitingForStart => {
             draw_jp_text(font, "ゲーム開始中...", 540.0, 400.0, 30, WHITE);
+            None
         }
         GamePhase::Playing => {
             draw_dora_indicators(state, font, tile_textures);
@@ -161,7 +156,7 @@ pub fn draw_game(state: &GameState, font: Option<&Font>, tile_textures: &TileTex
             draw_other_player_hands(state, tile_textures);
             draw_hand(state, font, tile_textures);
             draw_melds(state, tile_textures);
-            overlay::draw_action_buttons(state, font, tile_textures);
+            overlay::draw_action_buttons(state, font, tile_textures)
         }
         GamePhase::RoundResult => {
             draw_dora_indicators(state, font, tile_textures);
@@ -171,9 +166,11 @@ pub fn draw_game(state: &GameState, font: Option<&Font>, tile_textures: &TileTex
             draw_hand(state, font, tile_textures);
             draw_melds(state, tile_textures);
             draw_result(state, font, tile_textures);
+            None
         }
         GamePhase::GameOver => {
             draw_game_over(state, font);
+            None
         }
     }
 }

--- a/crates/mahjong-client/src/renderer/overlay.rs
+++ b/crates/mahjong-client/src/renderer/overlay.rs
@@ -1,76 +1,89 @@
-//! 鳴き・和了選択オーバーレイの描画
+//! 鳴き・和了選択オーバーレイの描画とクリック判定
 //!
-//! チー/ポン選択UI、鳴き確認パネル、和了ボタンを描画する。
-//! レイアウト定数は game.rs の入力処理と共有する。
+//! 各関数が描画とクリック判定を同時に行い、クリックされた場合に `Some(OverlayClick)` を返す。
 
 use macroquad::prelude::*;
 use mahjong_core::tile::Tile;
-use mahjong_server::protocol::AvailableCall;
+use mahjong_server::protocol::{AvailableCall, ClientAction};
 
 use crate::game::GameState;
 use super::{draw_jp_text, draw_tile_sprite, TileTextures, FONT_SIZE, SMALL_FONT, AGARI_FONT};
 
 // ─── チー／ポン選択UI定数 ─────────────────────────────────────────────────────
 
-/// チー／ポン選択UIの定数（renderer と game.rs 入力処理で共有）
-pub const CHI_SEL_TILE_W: f32 = 44.0;
-pub const CHI_SEL_TILE_H: f32 = 62.0;
-pub const CHI_SEL_TILE_GAP: f32 = 2.0;
-pub const CHI_SEL_OPT_SPACING: f32 = 24.0;
-pub const CHI_SEL_PANEL_H: f32 = 180.0;
+const CHI_SEL_TILE_W: f32 = 44.0;
+const CHI_SEL_TILE_H: f32 = 62.0;
+const CHI_SEL_TILE_GAP: f32 = 2.0;
+const CHI_SEL_OPT_SPACING: f32 = 24.0;
+const CHI_SEL_PANEL_H: f32 = 180.0;
 
 // ─── 鳴きパネル定数 ──────────────────────────────────────────────────────────
 
-/// 鳴きパネルのボタン定数（renderer と game.rs 入力処理で共有）
-pub const CALL_BTN_W: f32 = 100.0;
-pub const CALL_BTN_H: f32 = 40.0;
-pub const CALL_BTN_SPACING: f32 = 10.0;
-/// 鳴きパネル内のパディング（renderer と game.rs で共有）
-pub const CALL_PANEL_PAD: f32 = 14.0;
-/// 鳴きパネル内の捨て牌アイコンサイズ
-pub const CALL_PANEL_TILE_W: f32 = 44.0;
-pub const CALL_PANEL_TILE_H: f32 = 62.0;
+const CALL_BTN_W: f32 = 100.0;
+const CALL_BTN_H: f32 = 40.0;
+const CALL_BTN_SPACING: f32 = 10.0;
+const CALL_PANEL_PAD: f32 = 14.0;
+const CALL_PANEL_TILE_W: f32 = 44.0;
+const CALL_PANEL_TILE_H: f32 = 62.0;
 /// ノーロン時：鳴きパネル右端 X 座標（下家の手牌右端に合わせる）
-pub const CALL_PANEL_RIGHT_X_NO_RON: f32 = 820.0;
+const CALL_PANEL_RIGHT_X_NO_RON: f32 = 820.0;
 /// ノーロン時：鳴きパネル下端 Y 座標（手牌 y=680 のわずか上）
-pub const CALL_PANEL_BOTTOM_Y_NO_RON: f32 = 672.0;
-/// ノーロン時：鳴きパネルのボタン基準 Y 座標（panel_y + (panel_h - btn_h)/2 + title_h）
-pub const CALL_BTN_BASE_Y_NO_RON: f32 = 624.0;
-/// 鳴きオーバーレイパネルの高さ（20 + tile_h(62) + pad(14)）
-pub const CALL_OVERLAY_PANEL_H: f32 = 96.0;
+const CALL_PANEL_BOTTOM_Y_NO_RON: f32 = 672.0;
+/// ノーロン時：鳴きパネルのボタン基準 Y 座標
+const CALL_BTN_BASE_Y_NO_RON: f32 = 624.0;
+/// 鳴きオーバーレイパネルの高さ
+const CALL_OVERLAY_PANEL_H: f32 = 96.0;
 
 // ─── 和了ボタン定数 ──────────────────────────────────────────────────────────
 
-/// 和了ボタンの定数（描画・入力の両方で使用）
-/// 右端と下端を鳴きパネルと揃える
-pub const AGARI_BTN_W: f32 = 200.0;
-pub const AGARI_BTN_H: f32 = 60.0;
-pub const AGARI_BTN_X: f32 = CALL_PANEL_RIGHT_X_NO_RON - AGARI_BTN_W; // 620
-/// 和了ボタンのデフォルト Y（ロンのみ・ツモ時）= 下端を鳴きパネルと揃える
-pub const AGARI_BTN_Y: f32 = CALL_PANEL_BOTTOM_Y_NO_RON - AGARI_BTN_H; // 612
-/// 和了ボタンと鳴きパネルを同時表示する際の隙間
-pub const AGARI_BTN_GAP: f32 = 8.0;
+const AGARI_BTN_W: f32 = 200.0;
+const AGARI_BTN_H: f32 = 60.0;
+const AGARI_BTN_X: f32 = CALL_PANEL_RIGHT_X_NO_RON - AGARI_BTN_W; // 620
+const AGARI_BTN_Y: f32 = CALL_PANEL_BOTTOM_Y_NO_RON - AGARI_BTN_H; // 612
+const AGARI_BTN_GAP: f32 = 8.0;
+
+// ─── ヒット判定ヘルパー ───────────────────────────────────────────────────────
+
+fn hit_rect(mx: f32, my: f32, x: f32, y: f32, w: f32, h: f32) -> bool {
+    mx >= x && mx <= x + w && my >= y && my <= y + h
+}
+
+// ─── 公開型 ──────────────────────────────────────────────────────────────────
+
+/// オーバーレイボタンのクリック結果
+pub enum OverlayClick {
+    /// サーバに送信するアクション
+    Action(ClientAction),
+    /// リーチモードを切り替える
+    ToggleRiichi,
+    /// チー選択UIを表示する（複数の組み合わせがある場合）
+    ShowChiSelection { options: Vec<[Tile; 2]> },
+    /// ポン選択UIを表示する（複数の組み合わせがある場合）
+    ShowPonSelection { options: Vec<[Tile; 2]> },
+    /// 選択UIをキャンセルして鳴きパネルに戻る
+    CancelMeldSelection,
+}
 
 // ─── エントリポイント ─────────────────────────────────────────────────────────
 
-/// アクションボタン群の描画エントリポイント。mod.rs の draw_game から呼ばれる。
+/// アクションボタン群を描画し、クリックされたボタンを返す。mod.rs の draw_game から呼ばれる。
 pub(super) fn draw_action_buttons(
     state: &GameState,
     font: Option<&Font>,
     tile_textures: &TileTextures,
-) {
+) -> Option<OverlayClick> {
+    let clicked = is_mouse_button_pressed(MouseButton::Left);
+    let (mx, my) = mouse_position();
+
     // 選択オーバーレイ表示中は call_overlay の代わりに選択UIを右下に表示
     if state.chi_option_selecting {
-        draw_chi_selection_overlay(state, font, tile_textures);
-        return;
+        return draw_chi_selection_overlay(state, font, tile_textures, clicked, mx, my);
     }
     if state.pon_option_selecting {
-        draw_pon_selection_overlay(state, font, tile_textures);
-        return;
+        return draw_pon_selection_overlay(state, font, tile_textures, clicked, mx, my);
     }
     if !state.available_calls.is_empty() {
-        draw_call_overlay(state, font, tile_textures);
-        return;
+        return draw_call_overlay(state, font, tile_textures, clicked, mx, my);
     }
 
     if !state.is_my_turn {
@@ -82,7 +95,7 @@ pub(super) fn draw_action_buttons(
             FONT_SIZE,
             Color::new(0.8, 0.8, 0.8, 0.7),
         );
-        return;
+        return None;
     }
 
     if state.riichi_selection_mode {
@@ -105,54 +118,70 @@ pub(super) fn draw_action_buttons(
         );
     }
 
-    if state.drawn.is_some() {
-        // 和了ボタン（ツモ）を目立つ位置に表示
-        if state.can_tsumo {
-            draw_agari_button(font, AGARI_BTN_X, AGARI_BTN_Y);
-        }
+    if state.drawn.is_none() {
+        return None;
+    }
 
-        if state.can_riichi {
-            let riichi_bg = Color::new(0.1, 0.6, 0.1, 1.0);
-            draw_rectangle(1000.0, 720.0, 80.0, 40.0, riichi_bg);
-            draw_rectangle_lines(1000.0, 720.0, 80.0, 40.0, 2.0, WHITE);
-            draw_jp_text(font, "リーチ", 1008.0, 747.0, SMALL_FONT, WHITE);
-        }
+    let mut result = None;
 
-        for (idx, tile) in state.self_kan_options.iter().enumerate() {
-            let x = 720.0 + idx as f32 * 110.0;
-            let kan_bg = Color::new(0.1, 0.3, 0.8, 1.0);
-            draw_rectangle(x, 670.0, 100.0, 40.0, kan_bg);
-            draw_rectangle_lines(x, 670.0, 100.0, 40.0, 2.0, WHITE);
-            draw_jp_text(
-                font,
-                &format!("{}カン", tile.to_string()),
-                x + 10.0,
-                697.0,
-                SMALL_FONT,
-                WHITE,
-            );
-        }
-
-        if state.riichi_selection_mode {
-            draw_jp_text(
-                font,
-                "黄色の牌だけがリーチ打牌できます。リーチボタンでも解除できます。",
-                100.0,
-                770.0,
-                SMALL_FONT,
-                Color::new(0.9, 0.9, 0.5, 0.8),
-            );
-        } else if !state.is_riichi {
-            draw_jp_text(
-                font,
-                "牌をクリックで選択、もう一度クリックで打牌",
-                100.0,
-                770.0,
-                SMALL_FONT,
-                Color::new(0.8, 0.8, 0.8, 0.7),
-            );
+    // 和了ボタン（ツモ）
+    if state.can_tsumo {
+        draw_agari_button(font, AGARI_BTN_X, AGARI_BTN_Y);
+        if clicked && result.is_none() && hit_rect(mx, my, AGARI_BTN_X, AGARI_BTN_Y, AGARI_BTN_W, AGARI_BTN_H) {
+            result = Some(OverlayClick::Action(ClientAction::Tsumo));
         }
     }
+
+    // リーチボタン
+    if state.can_riichi {
+        const RIICHI_BTN_W: f32 = 80.0;
+        const RIICHI_BTN_H: f32 = 40.0;
+        let riichi_bg = Color::new(0.8, 0.2, 0.2, 1.0);
+        draw_rectangle(AGARI_BTN_X, AGARI_BTN_Y, RIICHI_BTN_W, RIICHI_BTN_H, riichi_bg);
+        draw_rectangle_lines(AGARI_BTN_X, AGARI_BTN_Y, RIICHI_BTN_W, RIICHI_BTN_H, 2.0, WHITE);
+        draw_jp_text(font, "リーチ", AGARI_BTN_X + 8.0, AGARI_BTN_Y + RIICHI_BTN_H - 8.0, SMALL_FONT, WHITE);
+        if clicked && result.is_none() && hit_rect(mx, my, AGARI_BTN_X, AGARI_BTN_Y, RIICHI_BTN_W, RIICHI_BTN_H) {
+            result = Some(OverlayClick::ToggleRiichi);
+        }
+    }
+
+    // 暗カンボタン
+    for (idx, tile) in state.self_kan_options.iter().enumerate() {
+        let x = 720.0 + idx as f32 * 110.0;
+        const KAN_BTN_W: f32 = 100.0;
+        const KAN_BTN_H: f32 = 40.0;
+        let kan_bg = Color::new(0.1, 0.3, 0.8, 1.0);
+        draw_rectangle(x, 670.0, KAN_BTN_W, KAN_BTN_H, kan_bg);
+        draw_rectangle_lines(x, 670.0, KAN_BTN_W, KAN_BTN_H, 2.0, WHITE);
+        draw_jp_text(font, &format!("{}カン", tile.to_string()), x + 10.0, 697.0, SMALL_FONT, WHITE);
+        if clicked && result.is_none() && hit_rect(mx, my, x, 670.0, KAN_BTN_W, KAN_BTN_H) {
+            result = Some(OverlayClick::Action(ClientAction::Kan {
+                tile_index: tile.get() as usize,
+            }));
+        }
+    }
+
+    if state.riichi_selection_mode {
+        draw_jp_text(
+            font,
+            "黄色の牌だけがリーチ打牌できます。リーチボタンでも解除できます。",
+            100.0,
+            770.0,
+            SMALL_FONT,
+            Color::new(0.9, 0.9, 0.5, 0.8),
+        );
+    } else if !state.is_riichi {
+        draw_jp_text(
+            font,
+            "牌をクリックで選択、もう一度クリックで打牌",
+            100.0,
+            770.0,
+            SMALL_FONT,
+            Color::new(0.8, 0.8, 0.8, 0.7),
+        );
+    }
+
+    result
 }
 
 // ─── 和了ボタン ───────────────────────────────────────────────────────────────
@@ -161,7 +190,6 @@ pub(super) fn draw_action_buttons(
 fn draw_agari_button(font: Option<&Font>, x: f32, y: f32) {
     let bg = Color::new(0.9, 0.05, 0.05, 1.0);
     let border = Color::new(1.0, 0.85, 0.0, 1.0);
-
     draw_rectangle(x, y, AGARI_BTN_W, AGARI_BTN_H, bg);
     draw_rectangle_lines(x, y, AGARI_BTN_W, AGARI_BTN_H, 4.0, border);
     draw_jp_text(font, "和　了", x + 50.0, y + 42.0, AGARI_FONT, WHITE);
@@ -169,43 +197,43 @@ fn draw_agari_button(font: Option<&Font>, x: f32, y: f32) {
 
 // ─── 鳴き確認オーバーレイ ────────────────────────────────────────────────────
 
-fn draw_call_overlay(state: &GameState, font: Option<&Font>, tile_textures: &TileTextures) {
-    let has_ron = state
-        .available_calls
-        .iter()
-        .any(|c| matches!(c, AvailableCall::Ron));
-    let has_non_ron = state
-        .available_calls
-        .iter()
-        .any(|c| !matches!(c, AvailableCall::Ron));
+fn draw_call_overlay(
+    state: &GameState,
+    font: Option<&Font>,
+    tile_textures: &TileTextures,
+    clicked: bool,
+    mx: f32,
+    my: f32,
+) -> Option<OverlayClick> {
+    let has_ron = state.available_calls.iter().any(|c| matches!(c, AvailableCall::Ron));
+    let has_non_ron = state.available_calls.iter().any(|c| !matches!(c, AvailableCall::Ron));
 
     if !has_non_ron {
-        // 鳴きなし・ロンのみ：和了ボタンを右下に単独表示
+        // ロンのみ：和了ボタンを右下に単独表示
         if has_ron {
             draw_agari_button(font, AGARI_BTN_X, AGARI_BTN_Y);
+            if clicked && hit_rect(mx, my, AGARI_BTN_X, AGARI_BTN_Y, AGARI_BTN_W, AGARI_BTN_H) {
+                return Some(OverlayClick::Action(ClientAction::Ron));
+            }
         }
-        return;
+        return None;
     }
-
-    // 鳴きあり（ロンの有無を問わずパネルを描画、ロンがあれば上に和了ボタンを追加）
 
     let btn_w = CALL_BTN_W;
     let btn_h = CALL_BTN_H;
     let btn_spacing = CALL_BTN_SPACING;
     let tile_w = CALL_PANEL_TILE_W;
     let tile_h = CALL_PANEL_TILE_H;
-    let tile_gap = 12.0_f32; // 牌とボタン間の隙間
+    let tile_gap = 12.0_f32;
 
-    // 非ロンボタンの個数（パスを除く）を数えてパネル幅を決定
     let non_ron_call_count = state
         .available_calls
         .iter()
         .filter(|c| !matches!(c, AvailableCall::Ron))
         .count();
-    let total_btn_count = non_ron_call_count + 1; // +1 for pass
+    let total_btn_count = non_ron_call_count + 1;
     let btns_w = total_btn_count as f32 * btn_w + (total_btn_count - 1) as f32 * btn_spacing;
 
-    // パネル領域: 牌アイコン + ボタン群 + パディング（ロン有無に関わらず同一レイアウト）
     let pad = CALL_PANEL_PAD;
     let tile_area_w = tile_w + tile_gap;
     let panel_w = tile_area_w + btns_w + pad * 2.0;
@@ -215,17 +243,21 @@ fn draw_call_overlay(state: &GameState, font: Option<&Font>, tile_textures: &Til
     let base_x = panel_x + pad + tile_area_w;
     let base_y = CALL_BTN_BASE_Y_NO_RON;
 
+    let mut result = None;
+
     // ロン＋鳴き同時：和了ボタンをパネルの上に表示
     if has_ron {
         let agari_y = panel_y - AGARI_BTN_GAP - AGARI_BTN_H;
         draw_agari_button(font, AGARI_BTN_X, agari_y);
+        if clicked && hit_rect(mx, my, AGARI_BTN_X, agari_y, AGARI_BTN_W, AGARI_BTN_H) {
+            result = Some(OverlayClick::Action(ClientAction::Ron));
+        }
     }
 
-    // パネル背景（チー／ポン選択UIと同じスタイル）
+    // パネル背景
     draw_rectangle(panel_x, panel_y, panel_w, panel_h, Color::new(0.0, 0.0, 0.0, 0.88));
     draw_rectangle_lines(panel_x, panel_y, panel_w, panel_h, 2.0, Color::new(1.0, 0.85, 0.3, 1.0));
 
-    // タイトル
     draw_jp_text(
         font,
         "鳴きますか？",
@@ -251,7 +283,6 @@ fn draw_call_overlay(state: &GameState, font: Option<&Font>, tile_textures: &Til
 
     let call_btn_bg = Color::new(0.8, 0.2, 0.2, 1.0);
     let pass_btn_bg = Color::new(0.35, 0.35, 0.35, 1.0);
-
     let mut btn_idx = 0;
 
     for call in &state.available_calls {
@@ -261,83 +292,120 @@ fn draw_call_overlay(state: &GameState, font: Option<&Font>, tile_textures: &Til
         let x = base_x + btn_idx as f32 * (btn_w + btn_spacing);
         match call {
             AvailableCall::Ron => unreachable!(),
-            AvailableCall::Pon { .. } => {
+            AvailableCall::Pon { options } => {
                 draw_rectangle(x, base_y, btn_w, btn_h, call_btn_bg);
                 draw_rectangle_lines(x, base_y, btn_w, btn_h, 2.0, WHITE);
                 draw_jp_text(font, "ポン", x + 28.0, base_y + 27.0, FONT_SIZE, WHITE);
+                if clicked && result.is_none() && hit_rect(mx, my, x, base_y, btn_w, btn_h) {
+                    result = if options.len() == 1 {
+                        Some(OverlayClick::Action(ClientAction::Pon { tiles: options[0] }))
+                    } else if !options.is_empty() {
+                        Some(OverlayClick::ShowPonSelection { options: options.clone() })
+                    } else {
+                        None
+                    };
+                }
             }
             AvailableCall::Daiminkan => {
                 draw_rectangle(x, base_y, btn_w, btn_h, call_btn_bg);
                 draw_rectangle_lines(x, base_y, btn_w, btn_h, 2.0, WHITE);
                 draw_jp_text(font, "カン", x + 18.0, base_y + 27.0, SMALL_FONT, WHITE);
+                if clicked && result.is_none() && hit_rect(mx, my, x, base_y, btn_w, btn_h) {
+                    if let Some(tile) = state.call_target_tile {
+                        result = Some(OverlayClick::Action(ClientAction::Kan {
+                            tile_index: tile.get() as usize,
+                        }));
+                    }
+                }
             }
-            AvailableCall::Chi { .. } => {
+            AvailableCall::Chi { options } => {
                 draw_rectangle(x, base_y, btn_w, btn_h, call_btn_bg);
                 draw_rectangle_lines(x, base_y, btn_w, btn_h, 2.0, WHITE);
                 draw_jp_text(font, "チー", x + 28.0, base_y + 27.0, FONT_SIZE, WHITE);
+                if clicked && result.is_none() && hit_rect(mx, my, x, base_y, btn_w, btn_h) {
+                    result = if options.len() == 1 {
+                        Some(OverlayClick::Action(ClientAction::Chi { tiles: options[0] }))
+                    } else if !options.is_empty() {
+                        Some(OverlayClick::ShowChiSelection { options: options.clone() })
+                    } else {
+                        None
+                    };
+                }
             }
         }
         btn_idx += 1;
     }
 
+    // パスボタン
     let pass_x = base_x + btn_idx as f32 * (btn_w + btn_spacing);
     draw_rectangle(pass_x, base_y, btn_w, btn_h, pass_btn_bg);
     draw_rectangle_lines(pass_x, base_y, btn_w, btn_h, 2.0, WHITE);
     draw_jp_text(font, "パス", pass_x + 28.0, base_y + 27.0, FONT_SIZE, WHITE);
+    if clicked && result.is_none() && hit_rect(mx, my, pass_x, base_y, btn_w, btn_h) {
+        result = Some(OverlayClick::Action(ClientAction::Pass));
+    }
+
+    result
 }
 
 // ─── チー／ポン選択オーバーレイ ──────────────────────────────────────────────
 
-/// チー選択オーバーレイを描画する。
-///
-/// 複数のチーの組み合わせがある場合に、プレイヤーが選択できるパネルを右下に表示する。
-/// レイアウト定数は CHI_SEL_* を使用し、game.rs の入力処理と一致させること。
 fn draw_chi_selection_overlay(
     state: &GameState,
     font: Option<&Font>,
     tile_textures: &TileTextures,
-) {
-    if let Some(called_tile) = state.call_target_tile {
-        draw_meld_selection_overlay(
-            font,
-            tile_textures,
-            "チーの組み合わせを選択",
-            called_tile,
-            &state.chi_pending_options,
-        );
-    }
+    clicked: bool,
+    mx: f32,
+    my: f32,
+) -> Option<OverlayClick> {
+    let called_tile = state.call_target_tile?;
+    draw_meld_selection_overlay(
+        font,
+        tile_textures,
+        "チーの組み合わせを選択",
+        called_tile,
+        &state.chi_pending_options,
+        clicked,
+        mx,
+        my,
+        |opt| ClientAction::Chi { tiles: opt },
+    )
 }
 
-/// ポン選択オーバーレイを描画する。
-///
-/// 赤ドラの有無で2通りの刻子が作れる場合に、どちらでポンするかをプレイヤーが選択できるパネル。
 fn draw_pon_selection_overlay(
     state: &GameState,
     font: Option<&Font>,
     tile_textures: &TileTextures,
-) {
-    if let Some(called_tile) = state.call_target_tile {
-        draw_meld_selection_overlay(
-            font,
-            tile_textures,
-            "ポンの組み合わせを選択",
-            called_tile,
-            &state.pon_pending_options,
-        );
-    }
+    clicked: bool,
+    mx: f32,
+    my: f32,
+) -> Option<OverlayClick> {
+    let called_tile = state.call_target_tile?;
+    draw_meld_selection_overlay(
+        font,
+        tile_textures,
+        "ポンの組み合わせを選択",
+        called_tile,
+        &state.pon_pending_options,
+        clicked,
+        mx,
+        my,
+        |opt| ClientAction::Pon { tiles: opt },
+    )
 }
 
-/// チー／ポン選択オーバーレイの共通描画処理。
-///
-/// 各オプションは [手牌A, 手牌B] の2枚で、called_tile を加えた3枚をソートして表示する。
-/// レイアウト定数は CHI_SEL_* を使用し、game.rs の入力処理と一致させること。
+/// チー／ポン選択オーバーレイの共通描画処理。描画しながらクリックを判定する。
 fn draw_meld_selection_overlay(
     font: Option<&Font>,
     tile_textures: &TileTextures,
     title: &str,
     called_tile: Tile,
     options: &[[Tile; 2]],
-) {
+    clicked: bool,
+    mx: f32,
+    my: f32,
+    make_action: impl Fn([Tile; 2]) -> ClientAction,
+) -> Option<OverlayClick> {
     let tile_w = CHI_SEL_TILE_W;
     let tile_h = CHI_SEL_TILE_H;
     let tile_gap = CHI_SEL_TILE_GAP;
@@ -347,15 +415,12 @@ fn draw_meld_selection_overlay(
     let opt_count = options.len();
     let opt_w = tile_w * 3.0 + tile_gap * 2.0;
     let panel_w = opt_w * opt_count as f32 + opt_spacing * (opt_count as f32 - 1.0) + 80.0;
-    // call_overlay と同じ右下に固定（右端・下端を揃える）
     let panel_x = CALL_PANEL_RIGHT_X_NO_RON - panel_w;
     let panel_y = CALL_PANEL_BOTTOM_Y_NO_RON - panel_h;
 
-    // パネル背景
     draw_rectangle(panel_x, panel_y, panel_w, panel_h, Color::new(0.0, 0.0, 0.0, 0.88));
     draw_rectangle_lines(panel_x, panel_y, panel_w, panel_h, 2.0, Color::new(1.0, 0.85, 0.3, 1.0));
 
-    // タイトル
     draw_jp_text(
         font,
         title,
@@ -368,79 +433,45 @@ fn draw_meld_selection_overlay(
     let opts_start_x = panel_x + 40.0;
     let opts_y = panel_y + 52.0;
 
-    let (mouse_x, mouse_y) = mouse_position();
+    let mut result = None;
 
     for (idx, &opt) in options.iter().enumerate() {
         let ox = opts_start_x + idx as f32 * (opt_w + opt_spacing);
+        let hovered = hit_rect(mx, my, ox, opts_y, opt_w, tile_h);
 
-        // マウスオーバーで明るいハイライト
-        let hovered = mouse_x >= ox
-            && mouse_x <= ox + opt_w
-            && mouse_y >= opts_y
-            && mouse_y <= opts_y + tile_h;
         if hovered {
-            draw_rectangle(
-                ox - 4.0,
-                opts_y - 4.0,
-                opt_w + 8.0,
-                tile_h + 8.0,
-                Color::new(1.0, 1.0, 0.4, 0.22),
-            );
-            draw_rectangle_lines(
-                ox - 4.0,
-                opts_y - 4.0,
-                opt_w + 8.0,
-                tile_h + 8.0,
-                2.0,
-                Color::new(1.0, 1.0, 0.4, 0.9),
-            );
+            draw_rectangle(ox - 4.0, opts_y - 4.0, opt_w + 8.0, tile_h + 8.0, Color::new(1.0, 1.0, 0.4, 0.22));
+            draw_rectangle_lines(ox - 4.0, opts_y - 4.0, opt_w + 8.0, tile_h + 8.0, 2.0, Color::new(1.0, 1.0, 0.4, 0.9));
         }
 
-        // 3枚の牌（[hand0, hand1, called_tile] をソートして表示）
         let mut display_tiles = [opt[0], opt[1], called_tile];
         display_tiles.sort();
 
         for (ti, tile) in display_tiles.iter().enumerate() {
             let tx = ox + ti as f32 * (tile_w + tile_gap);
-            // called_tile には薄い黄色のティントで区別
-            let tint = if *tile == called_tile {
-                Color::new(1.0, 1.0, 0.6, 1.0)
-            } else {
-                WHITE
-            };
-            draw_tile_sprite(
-                tile_textures.for_tile(tile),
-                tx,
-                opts_y,
-                tile_w - 1.0,
-                tile_h - 1.0,
-                tint,
-            );
+            let tint = if *tile == called_tile { Color::new(1.0, 1.0, 0.6, 1.0) } else { WHITE };
+            draw_tile_sprite(tile_textures.for_tile(tile), tx, opts_y, tile_w - 1.0, tile_h - 1.0, tint);
+        }
+
+        if clicked && result.is_none() && hovered {
+            result = Some(OverlayClick::Action(make_action(opt)));
         }
     }
 
     // キャンセルボタン
-    let cancel_w: f32 = 120.0;
-    let cancel_h: f32 = 36.0;
+    let cancel_w = 120.0_f32;
+    let cancel_h = 36.0_f32;
     let cancel_x = panel_x + (panel_w - cancel_w) / 2.0;
     let cancel_y = panel_y + panel_h - cancel_h - 14.0;
-    let cancel_hovered = mouse_x >= cancel_x
-        && mouse_x <= cancel_x + cancel_w
-        && mouse_y >= cancel_y
-        && mouse_y <= cancel_y + cancel_h;
-    let cancel_bg = if cancel_hovered {
-        Color::new(0.5, 0.5, 0.5, 1.0)
-    } else {
-        Color::new(0.3, 0.3, 0.3, 1.0)
-    };
+    let cancel_hovered = hit_rect(mx, my, cancel_x, cancel_y, cancel_w, cancel_h);
+    let cancel_bg = if cancel_hovered { Color::new(0.5, 0.5, 0.5, 1.0) } else { Color::new(0.3, 0.3, 0.3, 1.0) };
     draw_rectangle(cancel_x, cancel_y, cancel_w, cancel_h, cancel_bg);
     draw_rectangle_lines(cancel_x, cancel_y, cancel_w, cancel_h, 2.0, WHITE);
-    draw_jp_text(
-        font,
-        "キャンセル",
-        cancel_x + 10.0,
-        cancel_y + 24.0,
-        FONT_SIZE,
-        WHITE,
-    );
+    draw_jp_text(font, "キャンセル", cancel_x + 10.0, cancel_y + 24.0, FONT_SIZE, WHITE);
+
+    if clicked && result.is_none() && cancel_hovered {
+        result = Some(OverlayClick::CancelMeldSelection);
+    }
+
+    result
 }


### PR DESCRIPTION
Closes #66

## Summary

- Add chi/pon selection UI: when multiple meld combinations are available, display a panel for the player to choose
- Add call overlay panel (chi, pon, kan, pass buttons) and agari button, positioned in the bottom-right corner
- Add riichi button positioned alongside the agari button
- Refactor renderer: split overlay drawing into `renderer/overlay.rs`
- Unify overlay drawing and click detection into single functions — each draw function returns `Option<OverlayClick>` while drawing, eliminating separate hit-test functions and duplicate layout calculations

## Test plan

- [ ] Chi with multiple combinations shows selection UI
- [ ] Pon with red dora distinction shows selection UI
- [ ] Cancel button returns to call overlay
- [ ] Agari (tsumo/ron) button appears in bottom-right
- [ ] Riichi button appears and toggles riichi selection mode
- [ ] Build passes: `cargo build && cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)