### PR TITLE
Add triple ron draw and multiple ron (double/triple ron)

### DIFF
--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -10,6 +10,17 @@ use mahjong_core::tile::{Tile, TileType, Wind};
 use mahjong_server::cpu::client::{CpuConfig, CpuLevel, CpuPersonality};
 use mahjong_server::protocol::{AvailableCall, CallType, ClientAction, DrawReason, PlayerHandInfo, ServerEvent};
 
+/// 1人分の和了結果（結果画面の1ページ分）
+#[derive(Debug, Clone)]
+pub struct WinResult {
+    pub win_hand: Vec<Tile>,
+    pub win_melds: Vec<Meld>,
+    pub win_tile: Option<Tile>,
+    pub win_is_tsumo: bool,
+    pub uradora_indicators: Vec<Tile>,
+    pub result_message: String,
+}
+
 /// 捨て牌の表示情報
 #[derive(Debug, Clone)]
 pub struct DiscardInfo {
@@ -91,6 +102,10 @@ pub struct GameState {
     pub riichi_selectable_drawn: bool,
     /// 局の結果メッセージ
     pub result_message: Option<String>,
+    /// 和了結果一覧（ダブロン・トリロン時は複数）
+    pub win_results: Vec<WinResult>,
+    /// 現在表示中の和了結果インデックス
+    pub win_result_index: usize,
     /// 自分の手番か
     pub is_my_turn: bool,
     /// ゲームフェーズ
@@ -238,6 +253,8 @@ impl GameState {
             riichi_selectable_tiles: Vec::new(),
             riichi_selectable_drawn: false,
             result_message: None,
+            win_results: Vec::new(),
+            win_result_index: 0,
             is_my_turn: false,
             phase: GamePhase::Setup,
             available_calls: Vec::new(),
@@ -285,6 +302,8 @@ impl GameState {
                 self.discards = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
                 self.pending_riichi_player = None;
                 self.result_message = None;
+                self.win_results.clear();
+                self.win_result_index = 0;
                 self.phase = GamePhase::Playing;
                 self.available_calls.clear();
                 self.chi_option_selecting = false;
@@ -558,27 +577,24 @@ impl GameState {
             } => {
                 self.scores = scores;
                 self.riichi_sticks = 0;
-                self.uradora_indicators = uradora_indicators.clone();
-                self.win_tile = Some(winning_tile);
-                self.win_is_tsumo = loser.is_none();
 
-                // 和了者の手牌情報を保存
-                if let Some(_info) = player_hands.iter().find(|p| p.wind == winner) {
-                    self.win_hand = _info.hand.clone();
-                    // 既存の Meld（from 情報付き）を使用
-                    let relative_idx = self.relative_player_index(winner);
-                    if relative_idx == 0 {
-                        // 自分が和了者
-                        self.win_melds = self.melds.clone();
+                // 手牌情報を取得
+                let (win_hand, win_melds) =
+                    if let Some(info) = player_hands.iter().find(|p| p.wind == winner) {
+                        let hand = info.hand.clone();
+                        let relative_idx = self.relative_player_index(winner);
+                        let melds = if relative_idx == 0 {
+                            self.melds.clone()
+                        } else {
+                            self.other_players[relative_idx - 1].melds.clone()
+                        };
+                        (hand, melds)
                     } else {
-                        self.win_melds = self.other_players[relative_idx - 1].melds.clone();
-                    }
-                } else {
-                    self.win_hand.clear();
-                    self.win_melds.clear();
-                }
+                        (Vec::new(), Vec::new())
+                    };
 
                 self.update_other_player_hands_on_win(&player_hands, winner);
+
                 let winner_name = self.wind_to_name(winner);
                 let win_type = if loser.is_some() { "ロン" } else { "ツモ" };
                 let loser_text = if let Some(l) = loser {
@@ -587,7 +603,6 @@ impl GameState {
                     String::new()
                 };
 
-                // 役一覧を構築
                 let mut yaku_text = String::new();
                 for (name, y_han) in &yaku_list {
                     if !yaku_text.is_empty() {
@@ -596,7 +611,6 @@ impl GameState {
                     yaku_text.push_str(&format!("{} {}翻", name, y_han));
                 }
 
-                // 点数表示
                 let rank_display = if rank_name.is_empty() {
                     format!("{}符{}翻", fu, han)
                 } else {
@@ -611,20 +625,29 @@ impl GameState {
 
                 let msg = format!(
                     "{}が{}和了！{}{}\n{}\n{} → {}点",
-                    winner_name,
-                    win_type,
-                    loser_text,
-                    riichi_sticks_text,
-                    yaku_text,
-                    rank_display,
-                    score_points
+                    winner_name, win_type, loser_text, riichi_sticks_text, yaku_text,
+                    rank_display, score_points
                 );
-                self.result_message = Some(msg);
-                self.phase = GamePhase::RoundResult;
-                self.is_my_turn = false;
-                self.available_calls.clear();
-                self.clear_riichi_selection();
-                self.self_kan_options.clear();
+
+                self.win_results.push(WinResult {
+                    win_hand,
+                    win_melds,
+                    win_tile: Some(winning_tile),
+                    win_is_tsumo: loser.is_none(),
+                    uradora_indicators,
+                    result_message: msg,
+                });
+
+                // 最初のRoundWonでフェーズ遷移・表示を初期化
+                if self.phase != GamePhase::RoundResult {
+                    self.win_result_index = 0;
+                    self.apply_current_win_result();
+                    self.phase = GamePhase::RoundResult;
+                    self.is_my_turn = false;
+                    self.available_calls.clear();
+                    self.clear_riichi_selection();
+                    self.self_kan_options.clear();
+                }
             }
 
             ServerEvent::RoundDraw {
@@ -643,6 +666,7 @@ impl GameState {
                     DrawReason::FourRiichi => "四家立直",
                     DrawReason::NineTerminals => "九種九牌",
                     DrawReason::FourKans => "四槓散了",
+                    DrawReason::TripleRon => "三家和",
                 };
                 let mut msg = format!("流局（{}）", reason_text);
 
@@ -668,6 +692,34 @@ impl GameState {
                 self.clear_riichi_selection();
                 self.self_kan_options.clear();
             }
+        }
+    }
+
+    /// 現在の win_result_index が指すページを GameState の表示用フィールドに反映する
+    fn apply_current_win_result(&mut self) {
+        if let Some(wr) = self.win_results.get(self.win_result_index) {
+            let wr = wr.clone();
+            self.win_hand = wr.win_hand;
+            self.win_melds = wr.win_melds;
+            self.win_tile = wr.win_tile;
+            self.win_is_tsumo = wr.win_is_tsumo;
+            self.uradora_indicators = wr.uradora_indicators;
+            self.result_message = Some(wr.result_message);
+        }
+    }
+
+    /// 次の和了結果ページへ進む
+    ///
+    /// 次のページがある場合: 表示を更新して true を返す
+    /// 最後のページだった場合: false を返す（呼び出し元が next_round() を呼ぶ）
+    pub fn advance_win_result(&mut self) -> bool {
+        let next = self.win_result_index + 1;
+        if next < self.win_results.len() {
+            self.win_result_index = next;
+            self.apply_current_win_result();
+            true
+        } else {
+            false
         }
     }
 

--- a/crates/mahjong-client/src/main.rs
+++ b/crates/mahjong-client/src/main.rs
@@ -77,14 +77,17 @@ async fn main() {
 
             GamePhase::RoundResult => {
                 if is_mouse_button_pressed(MouseButton::Left) {
-                    if let Some(ref mut adp) = adapter {
-                        if adp.is_game_over() {
-                            game_state.phase = GamePhase::GameOver;
-                        } else {
-                            adp.next_round();
-                            let events = adp.poll_events(0);
-                            for event in events {
-                                game_state.handle_event(event);
+                    // まだ表示していない和了者がいれば次のページへ、なければ次の局へ
+                    if !game_state.advance_win_result() {
+                        if let Some(ref mut adp) = adapter {
+                            if adp.is_game_over() {
+                                game_state.phase = GamePhase::GameOver;
+                            } else {
+                                adp.next_round();
+                                let events = adp.poll_events(0);
+                                for event in events {
+                                    game_state.handle_event(event);
+                                }
                             }
                         }
                     }

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -963,14 +963,12 @@ fn draw_result(state: &GameState, font: Option<&Font>, tile_textures: &TileTextu
         }
     }
 
-    draw_jp_text(
-        font,
-        "クリックで次の局へ",
-        480.0,
-        530.0,
-        FONT_SIZE,
-        Color::new(0.8, 0.8, 0.8, 0.7),
-    );
+    let next_label = if state.win_result_index + 1 < state.win_results.len() {
+        "クリックで次の和了へ"
+    } else {
+        "クリックで次の局へ"
+    };
+    draw_jp_text(font, next_label, 480.0, 530.0, FONT_SIZE, Color::new(0.8, 0.8, 0.8, 0.7));
 }
 
 fn draw_game_over(state: &GameState, font: Option<&Font>) {

--- a/crates/mahjong-core/src/settings.rs
+++ b/crates/mahjong-core/src/settings.rs
@@ -29,6 +29,14 @@ pub struct Settings {
     /// 九種九牌ありかなしか（デフォルトはあり）
     /// ありの場合: 配牌時にヤオ九牌が9種以上あれば流局宣言可能
     pub nine_terminals_draw: bool,
+    /// 三家和流局ありかなしか（デフォルトはなし）
+    /// ありの場合: 1人の捨て牌に対して3人全員がロン宣言したら流局
+    pub triple_ron_draw: bool,
+    /// 複数同時ロン（ダブロン・トリロン）を許可するか（デフォルトはあり）
+    /// ありの場合: 2人または3人がロン宣言した場合、全員の和了を認める
+    /// なしの場合: 打順が最も早い1人のみ和了を認める（上家取り）
+    /// ※ triple_ron_draw=true かつ 3人ロンの場合は、こちらより三家和流局が優先される
+    pub multiple_ron: bool,
 }
 
 impl Settings {
@@ -40,6 +48,8 @@ impl Settings {
             four_winds_draw: true,
             four_riichi_draw: false,
             nine_terminals_draw: true,
+            triple_ron_draw: false,
+            multiple_ron: true,
         }
     }
 }

--- a/crates/mahjong-server/src/protocol.rs
+++ b/crates/mahjong-server/src/protocol.rs
@@ -19,6 +19,8 @@ pub enum DrawReason {
     NineTerminals,
     /// 四槓散了
     FourKans,
+    /// 三家和
+    TripleRon,
 }
 
 /// 鳴きの種類

--- a/crates/mahjong-server/src/round.rs
+++ b/crates/mahjong-server/src/round.rs
@@ -8,7 +8,9 @@ use mahjong_core::settings::Settings;
 use mahjong_core::tile::{Tile, TileType, Wind};
 
 use crate::player::Player;
-use crate::protocol::{AvailableCall, CallType, DrawReason, MeldTiles, PlayerHandInfo, ServerEvent};
+use crate::protocol::{
+    AvailableCall, CallType, DrawReason, MeldTiles, PlayerHandInfo, ServerEvent,
+};
 use crate::scoring;
 use crate::wall::Wall;
 
@@ -31,13 +33,11 @@ pub enum TurnPhase {
 #[derive(Debug, Clone)]
 pub enum RoundResult {
     /// ツモ和了
-    Tsumo {
-        winner: usize,
-        winning_tile: Tile,
-    },
-    /// ロン和了
+    Tsumo { winner: usize, winning_tile: Tile },
+    /// ロン和了（1人・ダブロン・トリロン共通）
     Ron {
-        winner: usize,
+        /// 和了プレイヤーのインデックス（打順優先順: 下家→対面→上家）
+        winners: Vec<usize>,
         loser: usize,
         winning_tile: Tile,
     },
@@ -188,26 +188,31 @@ impl Round {
         self.players
             .iter()
             .map(|p| {
-                let melds: Vec<MeldTiles> = p.hand.melds().iter().map(|open| {
-                    let mut tiles: Vec<Tile> = open.tiles.clone();
-                    let call_type = match open.category {
-                        mahjong_core::hand_info::meld::MeldType::Chi => CallType::Chi,
-                        mahjong_core::hand_info::meld::MeldType::Pon => CallType::Pon,
-                        mahjong_core::hand_info::meld::MeldType::Kan => {
-                            if open.from == mahjong_core::hand_info::meld::MeldFrom::Myself {
-                                CallType::Ankan
-                            } else {
-                                CallType::Daiminkan
+                let melds: Vec<MeldTiles> = p
+                    .hand
+                    .melds()
+                    .iter()
+                    .map(|open| {
+                        let mut tiles: Vec<Tile> = open.tiles.clone();
+                        let call_type = match open.category {
+                            mahjong_core::hand_info::meld::MeldType::Chi => CallType::Chi,
+                            mahjong_core::hand_info::meld::MeldType::Pon => CallType::Pon,
+                            mahjong_core::hand_info::meld::MeldType::Kan => {
+                                if open.from == mahjong_core::hand_info::meld::MeldFrom::Myself {
+                                    CallType::Ankan
+                                } else {
+                                    CallType::Daiminkan
+                                }
                             }
+                            mahjong_core::hand_info::meld::MeldType::Kakan => CallType::Kakan,
+                        };
+                        // カンの場合は4枚にする
+                        if open.category.is_kan() && tiles.len() == 3 {
+                            tiles.push(tiles[0]);
                         }
-                        mahjong_core::hand_info::meld::MeldType::Kakan => CallType::Kakan,
-                    };
-                    // カンの場合は4枚にする
-                    if open.category.is_kan() && tiles.len() == 3 {
-                        tiles.push(tiles[0]);
-                    }
-                    MeldTiles { call_type, tiles }
-                }).collect();
+                        MeldTiles { call_type, tiles }
+                    })
+                    .collect();
 
                 PlayerHandInfo {
                     wind: p.seat_wind,
@@ -235,7 +240,13 @@ impl Round {
 
     /// デバッグ用に自分のツモ時の判定状態を出力する
     #[cfg(debug_assertions)]
-    fn log_draw_diagnostics(&self, player_idx: usize, source: &str, can_tsumo: bool, can_riichi: bool) {
+    fn log_draw_diagnostics(
+        &self,
+        player_idx: usize,
+        source: &str,
+        can_tsumo: bool,
+        can_riichi: bool,
+    ) {
         if player_idx != 0 {
             return;
         }
@@ -312,7 +323,6 @@ impl Round {
             }
         }
     }
-
 
     /// ツモフェーズを実行する
     /// 山から1枚引いて現在のプレイヤーに配る
@@ -461,12 +471,8 @@ impl Round {
     /// 打牌後の鳴き候補を全てチェックする
     fn check_available_calls(&self, discarded_tile: Tile, discarder: usize) -> CallState {
         let is_last_tile = self.wall.is_empty();
-        let mut available_calls: [Vec<AvailableCall>; 4] = [
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-        ];
+        let mut available_calls: [Vec<AvailableCall>; 4] =
+            [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
         let mut responded = [true; 4]; // デフォルトは応答済み（対象外）
 
         for i in 0..4 {
@@ -479,12 +485,8 @@ impl Round {
             // リーチ中は鳴き不可（ロンのみ可）
             // ロン判定: フリテンでなく、和了形であること
             if !player.is_furiten() {
-                let win_result = scoring::check_ron(
-                    player,
-                    discarded_tile,
-                    self.prevailing_wind,
-                    is_last_tile,
-                );
+                let win_result =
+                    scoring::check_ron(player, discarded_tile, self.prevailing_wind, is_last_tile);
                 if win_result.is_win {
                     available_calls[i].push(AvailableCall::Ron);
                 }
@@ -648,16 +650,31 @@ impl Round {
 
         // 1. ロン（最優先）
         if !call_state.ron_declared.is_empty() {
-            let is_robbing_a_quad = matches!(call_state.resolution, CallResolution::AfterKakan { .. });
+            let is_robbing_a_quad =
+                matches!(call_state.resolution, CallResolution::AfterKakan { .. });
             let discarder = call_state.discarder;
-            let winner = call_state
-                .ron_declared
-                .iter()
-                .min_by_key(|&&p| (p + 4 - discarder) % 4)
-                .copied()
-                .unwrap();
+            let winning_tile = call_state.discarded_tile;
+            let ron_count = call_state.ron_declared.len();
 
-            self.execute_ron(winner, discarder, call_state.discarded_tile, is_robbing_a_quad);
+            // 打順優先順（下家→対面→上家）でソート
+            let mut sorted_winners = call_state.ron_declared.clone();
+            sorted_winners.sort_by_key(|&p| (p + 4 - discarder) % 4);
+
+            if ron_count >= 3 && self.settings.triple_ron_draw {
+                // 三家和流局（最優先）
+                self.declare_special_draw(DrawReason::TripleRon);
+                return;
+            }
+
+            // 複数同時ロンが有効かつ2人以上: 全員和了
+            let winners = if ron_count >= 2 && self.settings.multiple_ron {
+                sorted_winners
+            } else {
+                // 上家取り: 最優先の1人のみ和了
+                vec![sorted_winners[0]]
+            };
+
+            self.execute_ron(winners, discarder, winning_tile, is_robbing_a_quad);
             return;
         }
 
@@ -665,7 +682,6 @@ impl Round {
             self.execute_kakan(caller, tile_type);
             return;
         }
-
 
         // 2. 大明カン
         if let Some(caller) = call_state.daiminkan_declared {
@@ -675,13 +691,23 @@ impl Round {
 
         // 3. ポン
         if let Some((caller, hand_tile_types)) = call_state.pon_declared {
-            self.execute_pon(caller, call_state.discarder, call_state.discarded_tile, hand_tile_types);
+            self.execute_pon(
+                caller,
+                call_state.discarder,
+                call_state.discarded_tile,
+                hand_tile_types,
+            );
             return;
         }
 
         // 4. チー
         if let Some((caller, hand_tile_types)) = call_state.chi_declared {
-            self.execute_chi(caller, call_state.discarder, call_state.discarded_tile, hand_tile_types);
+            self.execute_chi(
+                caller,
+                call_state.discarder,
+                call_state.discarded_tile,
+                hand_tile_types,
+            );
             return;
         }
 
@@ -693,112 +719,167 @@ impl Round {
         self.check_special_draws();
     }
 
-    /// ロン和了を実行する
-    fn execute_ron(&mut self, winner: usize, loser: usize, winning_tile: Tile, is_robbing_a_quad: bool) {
+    /// ロン和了を実行する（通常・ダブロン・トリロン共通）
+    ///
+    /// - winners: ロン和了者の打順優先順（下家→対面→上家）でソート済みのインデックスリスト
+    /// - 本場ボーナスと供託棒は最初の和了者（打順最優先）のみが取得する
+    fn execute_ron(
+        &mut self,
+        winners: Vec<usize>,
+        loser: usize,
+        winning_tile: Tile,
+        is_robbing_a_quad: bool,
+    ) {
         let is_last_tile = self.wall.is_empty();
+        let dora_indicators = self.wall.dora_indicators();
+        let riichi_sticks = self.riichi_sticks;
+        let player_hands = self.build_player_hands();
 
-        // 一時的にdrawnを設定して点数計算
-        let win_result = scoring::check_ron_with_flags(
-            &self.players[winner],
-            winning_tile,
-            self.prevailing_wind,
-            is_last_tile,
-            is_robbing_a_quad,
-        );
+        struct WinnerData {
+            winner: usize,
+            score_result: mahjong_core::scoring::score::ScoreResult,
+            deltas: [i32; 4],
+            uradora_indicators: Vec<Tile>,
+            score_points: i32,
+        }
 
-        if !win_result.is_win {
-            // ロンできないはずだが安全のため
+        // 打順が最も早い和了者を rank=0 として本場・供託ボーナスの基準にする
+        let mut winner_data: Vec<WinnerData> = Vec::new();
+
+        for (rank, &winner) in winners.iter().enumerate() {
+            let honba_for_this = if rank == 0 { self.honba } else { 0 };
+
+            let win_result = scoring::check_ron_with_flags(
+                &self.players[winner],
+                winning_tile,
+                self.prevailing_wind,
+                is_last_tile,
+                is_robbing_a_quad,
+            );
+
+            if !win_result.is_win {
+                continue;
+            }
+
+            let mut score_result = win_result.score_result.unwrap();
+
+            let uradora_indicators = if self.players[winner].is_riichi {
+                self.wall.uradora_indicators()
+            } else {
+                vec![]
+            };
+
+            scoring::add_dora_to_score(
+                &mut score_result,
+                &self.players[winner].hand,
+                Some(winning_tile),
+                &dora_indicators,
+                &uradora_indicators,
+            );
+
+            let winner_is_dealer = self.players[winner].is_dealer();
+            let deltas = scoring::calculate_ron_score_deltas(
+                winner,
+                loser,
+                &score_result,
+                winner_is_dealer,
+                honba_for_this,
+            );
+
+            // 供託棒は打順最優先の和了者（winner_data の先頭）のみ取得
+            let riichi_bonus = if winner_data.is_empty() {
+                (riichi_sticks as i32) * 1000
+            } else {
+                0
+            };
+            let score_points = deltas[winner] + riichi_bonus;
+
+            winner_data.push(WinnerData {
+                winner,
+                score_result,
+                deltas,
+                uradora_indicators,
+                score_points,
+            });
+        }
+
+        // 安全のため: 和了成立者が0人ならフェーズを進めて返す
+        if winner_data.is_empty() {
             self.current_player = (loser + 1) % 4;
             self.phase = TurnPhase::Draw;
             return;
         }
 
-        let mut score_result = win_result.score_result.unwrap();
-
-        // ドラ・赤ドラ・裏ドラを加算
-        let dora_indicators = self.wall.dora_indicators();
-        let uradora_indicators = if self.players[winner].is_riichi {
-            self.wall.uradora_indicators()
-        } else {
-            vec![]
-        };
-        scoring::add_dora_to_score(
-            &mut score_result,
-            &self.players[winner].hand,
-            Some(winning_tile),
-            &dora_indicators,
-            &uradora_indicators,
-        );
-
-        let winner_is_dealer = self.players[winner].is_dealer();
-
-        let deltas = scoring::calculate_ron_score_deltas(
-            winner,
-            loser,
-            &score_result,
-            winner_is_dealer,
-            self.honba,
-        );
-        let riichi_sticks = self.riichi_sticks;
-
-        for i in 0..4 {
-            self.players[i].score += deltas[i];
+        // 全スコアデルタを合算して適用
+        for wd in &winner_data {
+            for i in 0..4 {
+                self.players[i].score += wd.deltas[i];
+            }
         }
+        // 供託棒は打順最優先の和了者に付与
         if riichi_sticks > 0 {
-            self.players[winner].score += (riichi_sticks as i32) * 1000;
+            self.players[winner_data[0].winner].score += (riichi_sticks as i32) * 1000;
             self.riichi_sticks = 0;
         }
 
         if !is_robbing_a_quad {
-            // 捨て牌を「鳴かれた」としてマーク
             if let Some(last_discard) = self.players[loser].discards.last_mut() {
                 last_discard.is_called = true;
             }
         }
 
         let scores = self.get_scores();
-        let winner_wind = self.players[winner].seat_wind;
         let loser_wind = self.players[loser].seat_wind;
 
-        // 役情報を構築
-        let yaku_list: Vec<(String, u32)> = score_result
-            .yaku_list
-            .iter()
-            .map(|(name, han)| (name.to_string(), *han))
-            .collect();
-        let rank_name = scoring::rank_to_string(&score_result.rank).to_string();
-        let player_hands = self.build_player_hands();
+        // 各和了者にRoundWonイベントを送信
+        for (idx, wd) in winner_data.iter().enumerate() {
+            let winner_wind = self.players[wd.winner].seat_wind;
+            let yaku_list: Vec<(String, u32)> = wd
+                .score_result
+                .yaku_list
+                .iter()
+                .map(|(name, han)| (name.to_string(), *han))
+                .collect();
+            let rank_name = scoring::rank_to_string(&wd.score_result.rank).to_string();
+            let event_riichi_sticks = if idx == 0 { riichi_sticks } else { 0 };
 
-        for i in 0..4 {
-            self.events.push((
-                i,
-                ServerEvent::RoundWon {
-                    winner: winner_wind,
-                    loser: Some(loser_wind),
-                    winning_tile,
-                    scores,
-                    yaku_list: yaku_list.clone(),
-                    han: score_result.han,
-                    fu: score_result.fu,
-                    score_points: deltas[winner] + (riichi_sticks as i32) * 1000,
-                    rank_name: rank_name.clone(),
-                    uradora_indicators: uradora_indicators.clone(),
-                    riichi_sticks,
-                    player_hands: player_hands.clone(),
-                },
-            ));
+            for i in 0..4 {
+                self.events.push((
+                    i,
+                    ServerEvent::RoundWon {
+                        winner: winner_wind,
+                        loser: Some(loser_wind),
+                        winning_tile,
+                        scores,
+                        yaku_list: yaku_list.clone(),
+                        han: wd.score_result.han,
+                        fu: wd.score_result.fu,
+                        score_points: wd.score_points,
+                        rank_name: rank_name.clone(),
+                        uradora_indicators: wd.uradora_indicators.clone(),
+                        riichi_sticks: event_riichi_sticks,
+                        player_hands: player_hands.clone(),
+                    },
+                ));
+            }
         }
 
         self.phase = TurnPhase::RoundOver;
         self.result = Some(RoundResult::Ron {
-            winner,
+            winners,
             loser,
             winning_tile,
         });
     }
 
     /// ポンを実行する
-    fn execute_pon(&mut self, caller: usize, discarder: usize, called_tile: Tile, hand_tile_types: [Tile; 2]) {
+    fn execute_pon(
+        &mut self,
+        caller: usize,
+        discarder: usize,
+        called_tile: Tile,
+        hand_tile_types: [Tile; 2],
+    ) {
         let from = Player::meld_from_relative(caller, discarder);
         self.players[caller].do_pon(called_tile, hand_tile_types, from);
 
@@ -955,7 +1036,16 @@ impl Round {
         }
 
         let caller_wind = self.players[caller].seat_wind;
-        let open = self.players[caller].hand.melds().iter().rev().find(|open| open.category == mahjong_core::hand_info::meld::MeldType::Kakan && open.tiles[0].get() == tile_type).unwrap();
+        let open = self.players[caller]
+            .hand
+            .melds()
+            .iter()
+            .rev()
+            .find(|open| {
+                open.category == mahjong_core::hand_info::meld::MeldType::Kakan
+                    && open.tiles[0].get() == tile_type
+            })
+            .unwrap();
         let mut tiles = open.tiles.clone();
         if tiles.len() == 3 {
             tiles.push(Tile::new(tile_type));
@@ -987,7 +1077,8 @@ impl Round {
     fn check_kakan_ron_and_resolve(&mut self, caller: usize, tile_type: TileType) {
         let called_tile = Tile::new(tile_type);
         let is_last_tile = self.wall.is_empty();
-        let mut available_calls: [Vec<AvailableCall>; 4] = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+        let mut available_calls: [Vec<AvailableCall>; 4] =
+            [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
         let mut responded = [true; 4];
 
         for i in 0..4 {
@@ -1060,9 +1151,15 @@ impl Round {
             return false;
         }
 
-        if self.players[player_idx].ankan_options().contains(&tile_type) {
+        if self.players[player_idx]
+            .ankan_options()
+            .contains(&tile_type)
+        {
             self.players[player_idx].do_ankan(tile_type);
-        } else if self.players[player_idx].kakan_options().contains(&tile_type) {
+        } else if self.players[player_idx]
+            .kakan_options()
+            .contains(&tile_type)
+        {
             self.check_kakan_ron_and_resolve(player_idx, tile_type);
             return true;
         } else {
@@ -1210,7 +1307,10 @@ impl Round {
 
         if player.is_riichi {
             if player_idx == 0 {
-                eprintln!("[riichi-reject] reason=already_riichi player={}", player_idx);
+                eprintln!(
+                    "[riichi-reject] reason=already_riichi player={}",
+                    player_idx
+                );
             }
             return false;
         }
@@ -1662,7 +1762,9 @@ impl Round {
             return false;
         }
 
-        self.players.iter().all(|p| p.discards[0].tile.get() == first_tile.get())
+        self.players
+            .iter()
+            .all(|p| p.discards[0].tile.get() == first_tile.get())
     }
 
     /// 四家立直を判定する
@@ -1889,7 +1991,15 @@ mod tests {
 
     #[test]
     fn test_round_scores() {
-        let round = Round::new(Wind::East, 0, [25000, 30000, 20000, 25000], 0, 0, 0, Settings::new());
+        let round = Round::new(
+            Wind::East,
+            0,
+            [25000, 30000, 20000, 25000],
+            0,
+            0,
+            0,
+            Settings::new(),
+        );
         let scores = round.get_scores();
         assert_eq!(scores, [25000, 30000, 20000, 25000]);
     }
@@ -1954,12 +2064,16 @@ mod tests {
         round.players[1] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
 
         let call_state = round.check_available_calls(Tile::new(Tile::Z5), 0);
-        assert!(call_state.available_calls[1]
-            .iter()
-            .any(|call| matches!(call, AvailableCall::Pon { .. })));
-        assert!(!call_state.available_calls[1]
-            .iter()
-            .any(|call| matches!(call, AvailableCall::Ron)));
+        assert!(
+            call_state.available_calls[1]
+                .iter()
+                .any(|call| matches!(call, AvailableCall::Pon { .. }))
+        );
+        assert!(
+            !call_state.available_calls[1]
+                .iter()
+                .any(|call| matches!(call, AvailableCall::Ron))
+        );
     }
 
     #[test]
@@ -1980,7 +2094,6 @@ mod tests {
         assert!(round.do_riichi(Some(Tile::new(Tile::Z4))));
         assert!(round.players[0].is_riichi);
     }
-
 
     #[test]
     fn test_do_riichi_deducts_score_and_adds_stick() {
@@ -2006,9 +2119,11 @@ mod tests {
         round.players[1] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
 
         let call_state = round.check_available_calls(Tile::new(Tile::M1), 0);
-        assert!(call_state.available_calls[1]
-            .iter()
-            .any(|call| matches!(call, AvailableCall::Daiminkan)));
+        assert!(
+            call_state.available_calls[1]
+                .iter()
+                .any(|call| matches!(call, AvailableCall::Daiminkan))
+        );
     }
 
     #[test]
@@ -2043,7 +2158,10 @@ mod tests {
         assert!(round.do_kan(Tile::M1));
         assert_eq!(round.phase, TurnPhase::WaitForDiscard);
         assert!(round.players[0].hand.drawn().is_some());
-        assert_eq!(round.players[0].hand.melds()[0].category, mahjong_core::hand_info::meld::MeldType::Kakan);
+        assert_eq!(
+            round.players[0].hand.melds()[0].category,
+            mahjong_core::hand_info::meld::MeldType::Kakan
+        );
         assert_eq!(round.wall.dora_indicators().len(), 2);
     }
 
@@ -2062,10 +2180,12 @@ mod tests {
         assert_eq!(round.phase, TurnPhase::WaitForDiscard);
         assert!(round.players[0].hand.drawn().is_some());
         assert_eq!(round.players[0].hand.tiles().len(), 10);
-        assert!(round.players[0]
-            .hand
-            .tiles()
-            .contains(&mahjong_core::tile::Tile::new(Tile::S9)));
+        assert!(
+            round.players[0]
+                .hand
+                .tiles()
+                .contains(&mahjong_core::tile::Tile::new(Tile::S9))
+        );
     }
 
     #[test]
@@ -2221,7 +2341,11 @@ mod tests {
         assert!(round.do_kan(Tile::M1));
         assert_eq!(round.phase, TurnPhase::WaitForCalls);
         let call_state = round.call_state.as_ref().unwrap();
-        assert!(call_state.available_calls[1].iter().any(|call| matches!(call, AvailableCall::Ron)));
+        assert!(
+            call_state.available_calls[1]
+                .iter()
+                .any(|call| matches!(call, AvailableCall::Ron))
+        );
 
         // ロンせずパス → フリテンが設定されること
         assert!(round.respond_to_call(1, CallResponse::Pass));
@@ -2277,13 +2401,21 @@ mod tests {
         assert!(round.do_kan(Tile::M1));
         assert_eq!(round.phase, TurnPhase::WaitForCalls);
         let call_state = round.call_state.as_ref().unwrap();
-        assert!(call_state.available_calls[1].iter().any(|call| matches!(call, AvailableCall::Ron)));
+        assert!(
+            call_state.available_calls[1]
+                .iter()
+                .any(|call| matches!(call, AvailableCall::Ron))
+        );
 
         assert!(round.respond_to_call(1, CallResponse::Ron));
         assert_eq!(round.phase, TurnPhase::RoundOver);
         match round.result {
-            Some(RoundResult::Ron { winner, loser, winning_tile }) => {
-                assert_eq!(winner, 1);
+            Some(RoundResult::Ron {
+                ref winners,
+                loser,
+                winning_tile,
+            }) => {
+                assert_eq!(winners, &vec![1]);
                 assert_eq!(loser, 0);
                 assert_eq!(winning_tile, Tile::new(Tile::M1));
             }
@@ -2356,7 +2488,13 @@ mod tests {
 
         let events = round.drain_events();
         let has_round_draw = events.iter().any(|(_idx, e)| {
-            matches!(e, ServerEvent::RoundDraw { reason: DrawReason::NineTerminals, .. })
+            matches!(
+                e,
+                ServerEvent::RoundDraw {
+                    reason: DrawReason::NineTerminals,
+                    ..
+                }
+            )
         });
         assert!(has_round_draw, "九種九牌流局イベントが生成されていない");
     }
@@ -2420,7 +2558,10 @@ mod tests {
         let has_available = events
             .iter()
             .any(|(_idx, e)| matches!(e, ServerEvent::NineTerminalsAvailable));
-        assert!(has_available, "NineTerminalsAvailableイベントが生成されていない");
+        assert!(
+            has_available,
+            "NineTerminalsAvailableイベントが生成されていない"
+        );
     }
 
     #[test]
@@ -2449,6 +2590,323 @@ mod tests {
         // 設定オフなら通常の打牌フェーズになる
         assert_eq!(round.phase, TurnPhase::WaitForDiscard);
     }
+
+    // ─── 三家和流局テスト ─────────────────────────────────────────────────────────
+
+    /// 3人がロン可能な状態を作るヘルパー
+    ///
+    /// - プレイヤー0: 打牌側（5sを捨てる）
+    /// - プレイヤー1,2,3: 5sでロン可能な手牌（タンヤオ形）
+    ///
+    /// 全員の手牌は同じ点数になる（非親・同一役・同一符）ため点数テストに使える。
+    fn setup_triple_ron(round: &mut Round) {
+        // プレイヤー0: 5sをツモ切り
+        let seat0 = round.players[0].seat_wind;
+        let mut p0 = Player::new(seat0, vec![], 25000);
+        // 12枚クローズ + ツモ牌5s
+        p0.hand = mahjong_core::hand::Hand::from("234m456m234p456p 5s");
+        round.players[0] = p0;
+
+        // プレイヤー1,2,3: 5sでロン可能な手牌（234m456m234p456p5s で 55s 待ち）
+        // 全員タンヤオ（2〜8のみ）で同一役・同一符
+        for i in 1..=3 {
+            let seat = round.players[i].seat_wind;
+            let mut p = Player::new(seat, vec![], 25000);
+            p.hand = mahjong_core::hand::Hand::from("234m456m234p456p5s");
+            round.players[i] = p;
+        }
+
+        round.current_player = 0;
+        round.phase = TurnPhase::WaitForDiscard;
+    }
+
+    #[test]
+    fn test_triple_ron_draw_enabled() {
+        let mut settings = Settings::new();
+        settings.triple_ron_draw = true;
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+        setup_triple_ron(&mut round);
+        round.drain_events();
+
+        // プレイヤー0が1mを捨てる
+        assert!(round.do_discard(None));
+        assert_eq!(round.phase, TurnPhase::WaitForCalls);
+
+        // 3人全員がロン宣言
+        assert!(round.respond_to_call(1, CallResponse::Ron));
+        assert!(round.respond_to_call(2, CallResponse::Ron));
+        assert!(round.respond_to_call(3, CallResponse::Ron));
+
+        // 三家和流局になること
+        assert_eq!(round.phase, TurnPhase::RoundOver);
+        assert!(matches!(round.result, Some(RoundResult::SpecialDraw)));
+
+        let events = round.drain_events();
+        let has_triple_ron = events.iter().any(|(_idx, e)| {
+            matches!(
+                e,
+                ServerEvent::RoundDraw {
+                    reason: DrawReason::TripleRon,
+                    ..
+                }
+            )
+        });
+        assert!(has_triple_ron, "三家和流局イベントが生成されていない");
+    }
+
+    #[test]
+    fn test_triple_ron_draw_takes_priority_over_multiple_ron() {
+        // triple_ron_draw=true かつ multiple_ron=true の両方が有効な場合、
+        // 三家和流局が優先されてトリロン（全員和了）にはならないことを明示的に確認する
+        let mut settings = Settings::new();
+        settings.triple_ron_draw = true;
+        settings.multiple_ron = true;
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+        setup_triple_ron(&mut round);
+        round.drain_events();
+
+        assert!(round.do_discard(None));
+        assert!(round.respond_to_call(1, CallResponse::Ron));
+        assert!(round.respond_to_call(2, CallResponse::Ron));
+        assert!(round.respond_to_call(3, CallResponse::Ron));
+
+        assert_eq!(round.phase, TurnPhase::RoundOver);
+        assert!(
+            matches!(round.result, Some(RoundResult::SpecialDraw)),
+            "triple_ron_draw が multiple_ron より優先されること"
+        );
+        let events = round.drain_events();
+        assert!(events.iter().any(|(_, e)| matches!(
+            e,
+            ServerEvent::RoundDraw {
+                reason: DrawReason::TripleRon,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn test_triple_ron_draw_disabled_multiple_ron_disabled_picks_winner() {
+        // triple_ron_draw=false, multiple_ron=false の場合は上家取り（頭ハネ）の1人ロン
+        let mut settings = Settings::new();
+        settings.triple_ron_draw = false;
+        settings.multiple_ron = false;
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+        setup_triple_ron(&mut round);
+        round.drain_events();
+
+        assert!(round.do_discard(None));
+        assert_eq!(round.phase, TurnPhase::WaitForCalls);
+
+        assert!(round.respond_to_call(1, CallResponse::Ron));
+        assert!(round.respond_to_call(2, CallResponse::Ron));
+        assert!(round.respond_to_call(3, CallResponse::Ron));
+
+        // multiple_ron=false → 上家（プレイヤー1）が優先してロン
+        assert_eq!(round.phase, TurnPhase::RoundOver);
+        match &round.result {
+            Some(RoundResult::Ron { winners, loser, .. }) => {
+                assert_eq!(winners, &vec![1]);
+                assert_eq!(*loser, 0);
+            }
+            _ => panic!("ロン結果が期待されたが別の結果: {:?}", round.result),
+        }
+    }
+
+    #[test]
+    fn test_two_ron_no_draw() {
+        // 2人ロンは三家和流局にならない（triple_ron_draw=true でも2人なら流局しない）
+        let mut settings = Settings::new();
+        settings.triple_ron_draw = true;
+        // multiple_ron=true（デフォルト）なので両方和了
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+        setup_triple_ron(&mut round);
+        round.drain_events();
+
+        assert!(round.do_discard(None));
+        assert_eq!(round.phase, TurnPhase::WaitForCalls);
+
+        assert!(round.respond_to_call(1, CallResponse::Ron));
+        assert!(round.respond_to_call(2, CallResponse::Ron));
+        assert!(round.respond_to_call(3, CallResponse::Pass));
+
+        // 2人ロンは流局でなくダブロン
+        assert_eq!(round.phase, TurnPhase::RoundOver);
+        match &round.result {
+            Some(RoundResult::Ron { winners, loser, .. }) => {
+                assert_eq!(winners, &vec![1, 2]);
+                assert_eq!(*loser, 0);
+            }
+            _ => panic!("Ron結果が期待されたが別の結果: {:?}", round.result),
+        }
+    }
+
+    #[test]
+    fn test_two_ron_disabled_picks_winner() {
+        // multiple_ron=false の場合は上家取り（頭ハネ）の1人ロン
+        let mut settings = Settings::new();
+        settings.multiple_ron = false;
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+        setup_triple_ron(&mut round);
+        round.drain_events();
+
+        assert!(round.do_discard(None));
+        assert_eq!(round.phase, TurnPhase::WaitForCalls);
+
+        assert!(round.respond_to_call(1, CallResponse::Ron));
+        assert!(round.respond_to_call(2, CallResponse::Ron));
+        assert!(round.respond_to_call(3, CallResponse::Pass));
+
+        // multiple_ron=false → 上家（プレイヤー1）のみロン
+        assert_eq!(round.phase, TurnPhase::RoundOver);
+        match &round.result {
+            Some(RoundResult::Ron { winners, loser, .. }) => {
+                assert_eq!(winners, &vec![1]);
+                assert_eq!(*loser, 0);
+            }
+            _ => panic!("Ron結果が期待されたが別の結果: {:?}", round.result),
+        }
+    }
+
+    #[test]
+    fn test_double_ron_both_win() {
+        // multiple_ron=true（デフォルト）: 2人ロンで両方和了
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        setup_triple_ron(&mut round);
+        round.drain_events();
+
+        assert!(round.do_discard(None));
+
+        assert!(round.respond_to_call(1, CallResponse::Ron));
+        assert!(round.respond_to_call(2, CallResponse::Ron));
+        assert!(round.respond_to_call(3, CallResponse::Pass));
+
+        assert_eq!(round.phase, TurnPhase::RoundOver);
+        match &round.result {
+            Some(RoundResult::Ron { winners, loser, .. }) => {
+                assert_eq!(winners, &vec![1, 2], "打順優先順で並んでいること");
+                assert_eq!(*loser, 0);
+            }
+            _ => panic!("Ron結果が期待されたが別の結果: {:?}", round.result),
+        }
+    }
+
+    #[test]
+    fn test_triple_ron_all_win() {
+        // multiple_ron=true かつ triple_ron_draw=false: 3人ロンで全員和了
+        let mut settings = Settings::new();
+        settings.multiple_ron = true;
+        settings.triple_ron_draw = false;
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+        setup_triple_ron(&mut round);
+        round.drain_events();
+
+        assert!(round.do_discard(None));
+
+        assert!(round.respond_to_call(1, CallResponse::Ron));
+        assert!(round.respond_to_call(2, CallResponse::Ron));
+        assert!(round.respond_to_call(3, CallResponse::Ron));
+
+        assert_eq!(round.phase, TurnPhase::RoundOver);
+        match &round.result {
+            Some(RoundResult::Ron { winners, loser, .. }) => {
+                assert_eq!(winners, &vec![1, 2, 3]);
+                assert_eq!(*loser, 0);
+            }
+            _ => panic!("Ron結果が期待されたが別の結果: {:?}", round.result),
+        }
+    }
+
+    #[test]
+    fn test_double_ron_scores() {
+        // ダブロン時のスコア: 各和了者が放銃者から独立して点数を受け取る
+        // 本場ボーナスは上家取りで最初の和了者（プレイヤー1）のみ
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 1, 0, 0, Settings::new()); // honba=1
+        setup_triple_ron(&mut round);
+        round.drain_events();
+
+        let initial_score_loser = round.players[0].score;
+        let initial_score_p1 = round.players[1].score;
+        let initial_score_p2 = round.players[2].score;
+
+        assert!(round.do_discard(None));
+        assert!(round.respond_to_call(1, CallResponse::Ron));
+        assert!(round.respond_to_call(2, CallResponse::Ron));
+        assert!(round.respond_to_call(3, CallResponse::Pass));
+
+        // プレイヤー1: 本場ボーナスあり (honba=1 → 300点加算)
+        // プレイヤー2: 本場ボーナスなし
+        let p1_gain = round.players[1].score - initial_score_p1;
+        let p2_gain = round.players[2].score - initial_score_p2;
+        assert!(
+            p1_gain > p2_gain,
+            "最初の和了者が本場ボーナスを得ること: p1={}, p2={}",
+            p1_gain,
+            p2_gain
+        );
+        assert_eq!(
+            p1_gain - p2_gain,
+            300,
+            "本場ボーナスの差は1本場=300点であること"
+        );
+
+        // 放銃者は両方の点数を払う
+        let loser_loss = initial_score_loser - round.players[0].score;
+        let total_gain = p1_gain + p2_gain;
+        assert_eq!(
+            loser_loss, total_gain,
+            "放銃者の支払いが全和了者の取得合計と一致すること"
+        );
+    }
+
+    #[test]
+    fn test_double_ron_events_generated() {
+        // ダブロン時に各和了者分のRoundWonイベントが生成されること
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        setup_triple_ron(&mut round);
+        round.drain_events();
+
+        assert!(round.do_discard(None));
+        assert!(round.respond_to_call(1, CallResponse::Ron));
+        assert!(round.respond_to_call(2, CallResponse::Ron));
+        assert!(round.respond_to_call(3, CallResponse::Pass));
+
+        let events = round.drain_events();
+        let won_events: Vec<_> = events
+            .iter()
+            .filter(|(idx, e)| *idx == 0 && matches!(e, ServerEvent::RoundWon { .. }))
+            .collect();
+        assert_eq!(
+            won_events.len(),
+            2,
+            "ダブロンで2件のRoundWonイベントが生成されること"
+        );
+    }
+
+    #[test]
+    fn test_multi_ron_riichi_sticks_first_winner_only() {
+        // 供託棒は最初の和了者（プレイヤー1）のみ取得
+        let settings = Settings::new();
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 2, 0, settings); // riichi_sticks=2
+        setup_triple_ron(&mut round);
+        round.drain_events();
+
+        let initial_p1 = round.players[1].score;
+        let initial_p2 = round.players[2].score;
+
+        assert!(round.do_discard(None));
+        assert!(round.respond_to_call(1, CallResponse::Ron));
+        assert!(round.respond_to_call(2, CallResponse::Ron));
+        assert!(round.respond_to_call(3, CallResponse::Pass));
+
+        let p1_gain = round.players[1].score - initial_p1;
+        let p2_gain = round.players[2].score - initial_p2;
+        // プレイヤー1は供託2本（2000点）分多く得点しているはず
+        assert_eq!(
+            p1_gain - p2_gain,
+            2000,
+            "供託2本はプレイヤー1のみ取得: 差は2000点"
+        );
+        assert_eq!(round.riichi_sticks, 0, "供託棒はすべて消費されること");
+    }
 }
-
-

--- a/crates/mahjong-server/src/table.rs
+++ b/crates/mahjong-server/src/table.rs
@@ -164,9 +164,7 @@ impl Table {
             }
 
             // === 九種九牌アクション ===
-            ClientAction::NineTerminals { declare } => {
-                round.do_nine_terminals(player_idx, declare)
-            }
+            ClientAction::NineTerminals { declare } => round.do_nine_terminals(player_idx, declare),
         }
     }
 
@@ -215,12 +213,20 @@ impl Table {
                 // 途中流局: 本場を増やし、局は進めない（連荘扱い）
                 self.honba += 1;
             }
-            Some(RoundResult::Tsumo { winner, .. }) | Some(RoundResult::Ron { winner, .. }) => {
+            Some(RoundResult::Tsumo { winner, .. }) => {
                 if winner == self.dealer {
-                    // 親が上がった場合は連荘（同じ局、本場+1）
                     self.honba += 1;
                 } else {
-                    // 親が上がっていなければ親交代、本場リセット
+                    self.honba = 0;
+                    self.dealer = (self.dealer + 1) % 4;
+                    self.advance_round_number();
+                }
+            }
+            Some(RoundResult::Ron { winners, .. }) => {
+                // 和了者の中に親がいれば連荘（1人ロンでも複数ロンでも共通）
+                if winners.iter().any(|&w| w == self.dealer) {
+                    self.honba += 1;
+                } else {
                     self.honba = 0;
                     self.dealer = (self.dealer + 1) % 4;
                     self.advance_round_number();
@@ -365,11 +371,14 @@ mod tests {
             ..Default::default()
         });
 
-        // 4局連続で流局させる
+        // 4局連続でノーテン流局（親交代あり）させてゲーム終了を確認する
         for _ in 0..4 {
             table.start_round();
             let round = table.current_round_mut().unwrap();
-            round.play_to_end();
+            round.phase = TurnPhase::RoundOver;
+            round.result = Some(RoundResult::ExhaustiveDraw {
+                dealer_tenpai: false,
+            });
             table.finish_round();
         }
 
@@ -385,7 +394,7 @@ mod tests {
         round.players[0].score = -100;
         round.phase = TurnPhase::RoundOver;
         round.result = Some(RoundResult::Ron {
-            winner: 1,
+            winners: vec![1],
             loser: 0,
             winning_tile: Tile::new(Tile::M1),
         });


### PR DESCRIPTION
Closes #83

## Summary

- Add `triple_ron_draw` setting (default: off): declares an abortive draw when all 3 non-dealer players ron the same discard; takes priority over `multiple_ron`
- Add `multiple_ron` setting (default: on): allows simultaneous 2 or 3-player ron; when off, only the highest turn-order player wins (kamicha rule)
- 本場ボーナス・供託棒は打順最優先の和了者のみ取得

## Changes

- **`mahjong-core/settings.rs`**: Add `triple_ron_draw` and `multiple_ron` fields
- **`mahjong-server/protocol.rs`**: Add `TripleRon` to `DrawReason`
- **`mahjong-server/round.rs`**: Unify `execute_ron`/`execute_multi_ron` into a single function taking `Vec<usize>`; unify `RoundResult::Ron`/`MultiRon` into `Ron { winners: Vec<usize> }`; add tests for triple ron draw, double/triple ron, score and event verification
- **`mahjong-server/table.rs`**: Update `finish_round` for `Ron { winners }` and stabilize flaky test
- **`mahjong-client/game.rs`**: Add `WinResult` pagination — each winner's result displayed on a separate page
- **`mahjong-client/main.rs`**: Fix empty if-branch in round result handler
- **`mahjong-client/renderer/mod.rs`**: Show "次の和了へ" vs "次の局へ" based on remaining winners

## Test plan

- [ ] `cargo test` passes (298 tests)
- [ ] `triple_ron_draw=true` → abortive draw on 3-player ron
- [ ] `triple_ron_draw=true` takes priority when `multiple_ron=true`
- [ ] `multiple_ron=true` → all simultaneous ron winners receive points
- [ ] `multiple_ron=false` → only kamicha-priority player wins
- [ ] 本場ボーナス difference of 300 per honba between first and second winner
- [ ] 供託棒 goes to first winner only
- [ ] Client result screen pages through each winner on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)