### PR TITLE
Sort yaku list by han ascending, dora last (ドラ→赤ドラ→裏ドラ)

### DIFF
--- a/crates/mahjong-core/src/scoring/score.rs
+++ b/crates/mahjong-core/src/scoring/score.rs
@@ -119,7 +119,7 @@ pub fn calculate_score(
 fn extract_yaku_list(
     yaku_result: &HashMap<Kind, (&'static str, bool, u32)>,
 ) -> Vec<(&'static str, u32)> {
-    let mut list: Vec<(&'static str, u32)> = Vec::new();
+    let mut list: Vec<(&Kind, &'static str, u32)> = Vec::new();
     let mut has_yakuman = false;
 
     // まず役満があるか確認
@@ -130,19 +130,19 @@ fn extract_yaku_list(
         }
     }
 
-    for (_, (name, is_valid, han)) in yaku_result {
+    for (kind, (name, is_valid, han)) in yaku_result {
         if *is_valid && *han > 0 {
             // 役満がある場合は通常役を除外
             if has_yakuman && *han < 13 {
                 continue;
             }
-            list.push((name, *han));
+            list.push((kind, name, *han));
         }
     }
 
-    // 翻数の降順でソートし、同じ翻数の場合は名前でソート
-    list.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
-    list
+    // 翻数の昇順でソートし、同じ翻数の場合はKind列挙型の定義順でソート
+    list.sort_by(|a, b| a.2.cmp(&b.2).then(a.0.cmp(b.0)));
+    list.into_iter().map(|(_, name, han)| (name, han)).collect()
 }
 
 /// 等級を決定する
@@ -477,5 +477,45 @@ mod tests {
         assert_eq!(round_up_to_100(base * 2), 500);
         // 子: 240 * 1 = 240 -> 300
         assert_eq!(round_up_to_100(base), 300);
+    }
+
+    /// 役リストは翻数昇順に並ぶ: 断么九(1翻)が七対子(2翻)より先
+    #[test]
+    fn test_yaku_list_order_han_ascending() {
+        // 2244668m224466p + ロン8m = 七対子(2翻) + 断么九(1翻)
+        let hand = Hand::from("2244668m224466p 8m");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.is_self_picked = false;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let settings = Settings::new();
+        let result = calculate_score(&analyzer, &hand, &status, &settings)
+            .unwrap()
+            .unwrap();
+        // 翻数昇順: 断么九(1翻) → 七対子(2翻)
+        assert_eq!(result.yaku_list[0], ("断么九", 1));
+        assert_eq!(result.yaku_list[1], ("七対子", 2));
+    }
+
+    /// 同翻の役はKind列挙型の定義順に並ぶ: 立直(ReadyHand)が平和(NoPointsHand)より先
+    #[test]
+    fn test_yaku_list_order_same_han_uses_kind_order() {
+        // 立直(1翻) + 平和(1翻): Kind定義順でReadyHand < NoPointsHand
+        let hand = Hand::from("123456m234p6799s 5s");
+        let analyzer = HandAnalyzer::new(&hand).unwrap();
+        let mut status = Status::new();
+        status.has_claimed_ready = true;
+        status.is_self_picked = false;
+        status.player_wind = Wind::South;
+        status.prevailing_wind = Wind::East;
+        let settings = Settings::new();
+        let result = calculate_score(&analyzer, &hand, &status, &settings)
+            .unwrap()
+            .unwrap();
+        let names: Vec<&str> = result.yaku_list.iter().map(|(n, _)| *n).collect();
+        let riichi_pos = names.iter().position(|&n| n == "立直").unwrap();
+        let pinfu_pos = names.iter().position(|&n| n == "平和").unwrap();
+        assert!(riichi_pos < pinfu_pos, "立直はKind定義順で平和より先に来る");
     }
 }

--- a/crates/mahjong-core/src/winning_hand/name.rs
+++ b/crates/mahjong-core/src/winning_hand/name.rs
@@ -16,18 +16,21 @@ pub enum Form {
 /// 和了役を表す列挙型
 ///
 /// <https://en.wikipedia.org/wiki/Japanese_Mahjong_yaku>による英語名
-#[derive(Debug, PartialEq, Eq, Hash, EnumCountMacro, EnumIter)]
+/// ここでの定義順で同翻役のリザルト画面の役の表示順も決定する
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, EnumCountMacro, EnumIter)]
 pub enum Kind {
     /// 立直
     ReadyHand,
+    /// ダブル立直
+    DoubleReady,
+    /// 一発
+    OneShot,
+    /// 門前清自摸和
+    SelfPick,
     /// 七対子
     SevenPairs,
     /// 流し満貫
     NagashiMangan,
-    /// 門前清自摸和
-    SelfPick,
-    /// 一発
-    OneShot,
     /// 海底撈月
     LastTileFromTheWall,
     /// 河底撈魚
@@ -36,8 +39,6 @@ pub enum Kind {
     DeadWallDraw,
     /// 搶槓
     RobbingAQuad,
-    /// ダブル立直
-    DoubleReady,
     /// 平和
     NoPointsHand,
     /// 一盃口
@@ -349,4 +350,3 @@ fn get_ja(hand_kind: Kind, has_openned: bool) -> &'static str {
         Kind::HandOfEarth => "地和",
     }
 }
-

--- a/crates/mahjong-server/src/scoring.rs
+++ b/crates/mahjong-server/src/scoring.rs
@@ -296,17 +296,6 @@ pub fn add_dora_to_score(
     // 赤ドラをカウント
     let red_dora_count = all_tiles.iter().filter(|t| t.is_red_dora()).count() as u32;
 
-    // 翻を追加
-    if dora_count > 0 {
-        score_result.yaku_list.push(("ドラ", dora_count));
-    }
-    if uradora_count > 0 {
-        score_result.yaku_list.push(("裏ドラ", uradora_count));
-    }
-    if red_dora_count > 0 {
-        score_result.yaku_list.push(("赤ドラ", red_dora_count));
-    }
-
     let extra_han = dora_count + uradora_count + red_dora_count;
     if extra_han == 0 {
         return;
@@ -325,10 +314,16 @@ pub fn add_dora_to_score(
     score_result.non_dealer_tsumo_dealer = round_up_to_100(base_points * 2);
     score_result.non_dealer_tsumo_non_dealer = round_up_to_100(base_points);
 
-    // ソートし直す（翻数降順、同翻なら名前昇順）
-    score_result
-        .yaku_list
-        .sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    // ドラ・赤ドラ・裏ドラをこの順で末尾に追加
+    if dora_count > 0 {
+        score_result.yaku_list.push(("ドラ", dora_count));
+    }
+    if red_dora_count > 0 {
+        score_result.yaku_list.push(("赤ドラ", red_dora_count));
+    }
+    if uradora_count > 0 {
+        score_result.yaku_list.push(("裏ドラ", uradora_count));
+    }
 }
 
 /// プレイヤーがテンパイしているか判定する（13枚の手牌で）
@@ -569,6 +564,54 @@ mod tests {
 
         let waiting = get_waiting_tiles(&player);
         assert_eq!(waiting, vec![Tile::P4, Tile::P7]);
+    }
+
+    /// 通常役の後にドラ→赤ドラ→裏ドラの順で並ぶことを確認する
+    #[test]
+    fn test_dora_order_in_yaku_list() {
+        use mahjong_core::tile::Wind;
+
+        let fu_result = FuResult {
+            total: 30,
+            details: vec![FuDetail { name: "副底", fu: 20 }],
+        };
+        let mut score = ScoreResult {
+            han: 1,
+            fu: 30,
+            rank: ScoreRank::Normal,
+            dealer_ron: 1500,
+            dealer_tsumo_all: 500,
+            non_dealer_ron: 1000,
+            non_dealer_tsumo_dealer: 500,
+            non_dealer_tsumo_non_dealer: 300,
+            yaku_list: vec![("断么九", 1)],
+            fu_result,
+        };
+
+        // 手牌にM2（ドラ）・赤M5（赤ドラ）・S7（裏ドラ対象）を含む
+        let tiles = vec![
+            Tile::new(Tile::M2), Tile::new(Tile::M3), Tile::new(Tile::M4),
+            Tile::new(Tile::P2), Tile::new(Tile::P3), Tile::new(Tile::P4),
+            Tile::new(Tile::S2), Tile::new(Tile::S3), Tile::new(Tile::S4),
+            Tile::new(Tile::M6), Tile::new(Tile::M7), Tile::new(Tile::M8),
+            Tile::new(Tile::S7),
+        ];
+        let mut player = Player::new(Wind::South, tiles, 25000);
+        player.draw(Tile::new_red(Tile::M5)); // 赤ドラ
+
+        // ドラ表示牌M1 → ドラはM2（1枚）
+        // 裏ドラ表示牌S6 → 裏ドラはS7（1枚）
+        // 赤ドラ: 赤M5（1枚）
+        let dora_indicators = vec![Tile::new(Tile::M1)];
+        let uradora_indicators = vec![Tile::new(Tile::S6)];
+
+        add_dora_to_score(&mut score, &player.hand, None, &dora_indicators, &uradora_indicators);
+
+        assert_eq!(score.yaku_list.len(), 4);
+        assert_eq!(score.yaku_list[0], ("断么九", 1));
+        assert_eq!(score.yaku_list[1], ("ドラ", 1));
+        assert_eq!(score.yaku_list[2], ("赤ドラ", 1));
+        assert_eq!(score.yaku_list[3], ("裏ドラ", 1));
     }
 }
 


### PR DESCRIPTION
## Summary

- Sort regular yaku by han ascending (lowest han first), matching traditional Japanese mahjong convention
- For equal-han yaku, display order follows the declaration order in the `Kind` enum — reorder `Kind` variants to control display priority
- Dora entries are always appended last in fixed order: ドラ → 赤ドラ → 裏ドラ

## Changes

- `mahjong-core/src/winning_hand/name.rs`: Add `PartialOrd, Ord` to `Kind` derive; reorder variants to define same-han display priority (with doc comment explaining this)
- `mahjong-core/src/scoring/score.rs`: `extract_yaku_list` now sorts han ascending + `Kind` enum order for ties; add two unit tests
- `mahjong-server/src/scoring.rs`: Push ドラ → 赤ドラ → 裏ドラ in that fixed order after regular yaku (no re-sort); add one unit test

Closes #96

## Test plan

- [ ] `cargo test -p mahjong-core` — `test_yaku_list_order_han_ascending`, `test_yaku_list_order_same_han_uses_kind_order` pass
- [ ] `cargo test -p mahjong-server` — `test_dora_order_in_yaku_list` passes
- [ ] Play a hand in-game and verify the win result screen shows yaku in the new order

🤖 Generated with [Claude Code](https://claude.com/claude-code)