### PR TITLE
Reveal declarer's hand on nine terminals draw

### DIFF
--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -656,10 +656,11 @@ impl GameState {
                 tenpai,
                 riichi_sticks,
                 player_hands,
+                declarer,
             } => {
                 self.scores = scores;
                 self.riichi_sticks = riichi_sticks;
-                self.update_other_player_hands_on_draw(&player_hands, &tenpai);
+                self.update_other_player_hands_on_draw(&player_hands, &tenpai, declarer);
                 let reason_text = match reason {
                     DrawReason::Exhaustive => "荒牌流局",
                     DrawReason::FourWinds => "四風連打",
@@ -749,15 +750,14 @@ impl GameState {
         }
     }
 
-    /// 流局時に他プレイヤーの手牌を更新する（テンパイ者の手牌を公開）
-    fn update_other_player_hands_on_draw(&mut self, player_hands: &[PlayerHandInfo], tenpai: &[Wind]) {
+    /// 流局時に他プレイヤーの手牌を更新する（テンパイ者・九種九牌宣言者の手牌を公開）
+    fn update_other_player_hands_on_draw(&mut self, player_hands: &[PlayerHandInfo], tenpai: &[Wind], declarer: Option<Wind>) {
         for info in player_hands {
             let relative_idx = self.relative_player_index(info.wind);
             if relative_idx == 0 {
                 continue; // 自分はスキップ
             }
             let other = &mut self.other_players[relative_idx - 1];
-            // 副露を更新
             // 副露を更新（既存の from 情報を保持）
             if other.melds.is_empty() {
                 other.melds = info.melds.iter().map(|m| Meld {
@@ -767,8 +767,8 @@ impl GameState {
                     called_tile: None,
                 }).collect();
             }
-            // テンパイ者の手牌を公開
-            if tenpai.contains(&info.wind) {
+            // テンパイ者または九種九牌宣言者の手牌を公開
+            if tenpai.contains(&info.wind) || declarer == Some(info.wind) {
                 other.hand = info.hand.clone();
                 other.revealed = true;
             }

--- a/crates/mahjong-server/src/protocol.rs
+++ b/crates/mahjong-server/src/protocol.rs
@@ -215,6 +215,8 @@ pub enum ServerEvent {
         riichi_sticks: usize,
         /// 全プレイヤーの手牌情報
         player_hands: Vec<PlayerHandInfo>,
+        /// 九種九牌を宣言したプレイヤーの風（九種九牌流局の場合のみ）
+        declarer: Option<Wind>,
     },
 }
 

--- a/crates/mahjong-server/src/round/mod.rs
+++ b/crates/mahjong-server/src/round/mod.rs
@@ -581,7 +581,7 @@ impl Round {
 
             if ron_count >= 3 && self.settings.triple_ron_draw {
                 // 三家和流局（最優先）
-                self.declare_special_draw(DrawReason::TripleRon);
+                self.declare_special_draw(DrawReason::TripleRon, None);
                 return;
             }
 
@@ -1135,7 +1135,7 @@ impl Round {
     fn draw_after_kan(&mut self, player_idx: usize) {
         // 四槓散了チェック: 4回目のカン直後に判定（設定がありの場合のみ）
         if self.settings.four_kans_draw && self.check_four_kans_draw() {
-            self.declare_special_draw(DrawReason::FourKans);
+            self.declare_special_draw(DrawReason::FourKans, None);
             return;
         }
 
@@ -1581,6 +1581,7 @@ impl Round {
                     tenpai: tenpai_winds.clone(),
                     riichi_sticks: self.riichi_sticks,
                     player_hands: player_hands.clone(),
+                    declarer: None,
                 },
             ));
         }
@@ -1590,13 +1591,13 @@ impl Round {
     fn check_special_draws(&mut self) {
         // 四風連打チェック: 全員が1枚ずつ捨てて、全て同じ風牌
         if self.settings.four_winds_draw && self.check_four_winds_draw() {
-            self.declare_special_draw(DrawReason::FourWinds);
+            self.declare_special_draw(DrawReason::FourWinds, None);
             return;
         }
 
         // 四家立直チェック: 全員がリーチ宣言済み
         if self.settings.four_riichi_draw && self.check_four_riichi_draw() {
-            self.declare_special_draw(DrawReason::FourRiichi);
+            self.declare_special_draw(DrawReason::FourRiichi, None);
         }
     }
 
@@ -1670,7 +1671,8 @@ impl Round {
             return false;
         }
         if declare {
-            self.declare_special_draw(DrawReason::NineTerminals);
+            let declarer_wind = self.players[player_idx].seat_wind;
+            self.declare_special_draw(DrawReason::NineTerminals, Some(declarer_wind));
         } else {
             self.phase = TurnPhase::WaitForDiscard;
         }
@@ -1695,7 +1697,7 @@ impl Round {
     }
 
     /// 特殊流局を宣言する
-    fn declare_special_draw(&mut self, reason: DrawReason) {
+    fn declare_special_draw(&mut self, reason: DrawReason, declarer: Option<Wind>) {
         let scores = self.get_scores();
         let player_hands = self.build_player_hands();
         self.phase = TurnPhase::RoundOver;
@@ -1710,6 +1712,7 @@ impl Round {
                     tenpai: Vec::new(),
                     riichi_sticks: self.riichi_sticks,
                     player_hands: player_hands.clone(),
+                    declarer,
                 },
             ));
         }


### PR DESCRIPTION
## Summary

- `RoundDraw` イベントに `declarer: Option<Wind>` フィールドを追加し、九種九牌流局時に宣言者の風を通知する
- サーバー側で `do_nine_terminals` が宣言者の風を `declare_special_draw` に渡すよう変更
- クライアント側で九種九牌宣言者の手牌を、荒牌流局のテンパイ者と同様に表向きで表示するよう変更

Closes #94

## Test plan

- [ ] 自分が九種九牌を宣言した場合、自分の手牌は元々表示されているため変化なし
- [ ] CPUが九種九牌を宣言した場合、そのCPUの手牌が裏向きから表向きに切り替わること
- [ ] 他の特殊流局（四風連打・四家立直・四槓散了・三家和）では手牌が公開されないこと
- [ ] 荒牌流局のテンパイ手牌公開は引き続き正常に動作すること
- [ ] 全ユニットテストが通過すること（`cargo test`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)