### PR TITLE
Fix mahjong rules and kan state bugs

### DIFF
--- a/crates/mahjong-server/src/cpu/state.rs
+++ b/crates/mahjong-server/src/cpu/state.rs
@@ -34,6 +34,8 @@ pub struct CpuGameState {
     pub scores: [i32; 4],
     /// 各プレイヤーの捨て牌（風のインデックス順: 東=0, 南=1, 西=2, 北=3）
     pub all_discards: [Vec<Tile>; 4],
+    /// 鳴かれて副露側にも現れる捨て牌
+    called_discards: Vec<Tile>,
     /// 各プレイヤーのリーチ状態
     pub player_riichi: [bool; 4],
     /// 各プレイヤーの副露情報
@@ -75,6 +77,7 @@ impl CpuGameState {
             is_furiten: false,
             scores: [0; 4],
             all_discards: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+            called_discards: Vec::new(),
             player_riichi: [false; 4],
             player_melds: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             dora_indicators: Vec::new(),
@@ -122,6 +125,7 @@ impl CpuGameState {
                 self.is_furiten = false;
                 self.scores = *scores;
                 self.all_discards = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+                self.called_discards.clear();
                 self.player_riichi = [false; 4];
                 self.player_melds = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
                 self.dora_indicators = dora_indicators.clone();
@@ -183,9 +187,7 @@ impl CpuGameState {
                 }
             }
 
-            ServerEvent::CallAvailable {
-                tile, calls, ..
-            } => {
+            ServerEvent::CallAvailable { tile, calls, .. } => {
                 self.pending_calls = calls.clone();
                 self.pending_call_tile = Some(*tile);
             }
@@ -209,12 +211,37 @@ impl CpuGameState {
                     CallType::Ankan => MeldFrom::Myself,
                     _ => MeldFrom::Unknown,
                 };
-                self.player_melds[idx].push(Meld {
-                    tiles: tiles.clone(),
-                    category,
-                    from,
-                    called_tile: Some(*called_tile),
-                });
+                if matches!(
+                    call_type,
+                    CallType::Chi | CallType::Pon | CallType::Daiminkan
+                ) {
+                    self.called_discards.push(*called_tile);
+                }
+
+                if *call_type == CallType::Kakan {
+                    if let Some(meld) = self.player_melds[idx].iter_mut().find(|meld| {
+                        meld.category == MeldType::Pon
+                            && meld.tiles.first().map(|tile| tile.get()) == Some(called_tile.get())
+                    }) {
+                        meld.category = MeldType::Kakan;
+                        meld.tiles = tiles.clone();
+                        meld.called_tile = Some(*called_tile);
+                    } else {
+                        self.player_melds[idx].push(Meld {
+                            tiles: tiles.clone(),
+                            category,
+                            from,
+                            called_tile: Some(*called_tile),
+                        });
+                    }
+                } else {
+                    self.player_melds[idx].push(Meld {
+                        tiles: tiles.clone(),
+                        category,
+                        from,
+                        called_tile: Some(*called_tile),
+                    });
+                }
 
                 self.pending_calls.clear();
                 self.pending_call_tile = None;
@@ -303,6 +330,11 @@ impl CpuGameState {
             counts[tile.get() as usize] += 1;
         }
 
+        for tile in &self.called_discards {
+            let count = &mut counts[tile.get() as usize];
+            *count = count.saturating_sub(1);
+        }
+
         counts
     }
 }
@@ -311,6 +343,7 @@ impl CpuGameState {
 mod tests {
     use super::*;
     use crate::protocol::ServerEvent;
+    use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
     use mahjong_core::tile::{Tile, Wind};
 
     #[test]
@@ -397,6 +430,53 @@ mod tests {
 
         let counts = state.visible_tile_counts();
         assert_eq!(counts[Tile::M1 as usize], 3);
+    }
+
+    #[test]
+    fn test_called_tile_visible_count_not_double_counted() {
+        let mut state = CpuGameState::new();
+        state.update(&ServerEvent::TileDiscarded {
+            player: Wind::East,
+            tile: Tile::new(Tile::M1),
+            is_tsumogiri: false,
+        });
+        state.update(&ServerEvent::PlayerCalled {
+            player: Wind::South,
+            call_type: CallType::Pon,
+            called_tile: Tile::new(Tile::M1),
+            tiles: vec![Tile::new(Tile::M1); 3],
+        });
+
+        let counts = state.visible_tile_counts();
+        assert_eq!(counts[Tile::M1 as usize], 3);
+        assert_eq!(
+            state.all_discards[0].len(),
+            1,
+            "守備評価用の捨て牌は保持する"
+        );
+    }
+
+    #[test]
+    fn test_kakan_updates_existing_meld() {
+        let mut state = CpuGameState::new();
+        state.player_melds[0].push(Meld {
+            tiles: vec![Tile::new(Tile::M1); 3],
+            category: MeldType::Pon,
+            from: MeldFrom::Unknown,
+            called_tile: Some(Tile::new(Tile::M1)),
+        });
+
+        state.update(&ServerEvent::PlayerCalled {
+            player: Wind::East,
+            call_type: CallType::Kakan,
+            called_tile: Tile::new(Tile::M1),
+            tiles: vec![Tile::new(Tile::M1); 4],
+        });
+
+        assert_eq!(state.player_melds[0].len(), 1);
+        assert_eq!(state.player_melds[0][0].category, MeldType::Kakan);
+        assert_eq!(state.player_melds[0][0].tiles.len(), 4);
+        assert_eq!(state.visible_tile_counts()[Tile::M1 as usize], 4);
     }
 
     #[test]

--- a/crates/mahjong-server/src/player.rs
+++ b/crates/mahjong-server/src/player.rs
@@ -161,7 +161,12 @@ impl Player {
 
     /// ポン可能か判定する
     pub fn can_pon(&self, tile: Tile) -> bool {
-        let count = self.hand.tiles().iter().filter(|t| t.get() == tile.get()).count();
+        let count = self
+            .hand
+            .tiles()
+            .iter()
+            .filter(|t| t.get() == tile.get())
+            .count();
         count >= 2
     }
 
@@ -189,8 +194,7 @@ impl Player {
 
         for i in 0..tiles_of_type.len() {
             for j in (i + 1)..tiles_of_type.len() {
-                let includes_red =
-                    tiles_of_type[i].is_red_dora() || tiles_of_type[j].is_red_dora();
+                let includes_red = tiles_of_type[i].is_red_dora() || tiles_of_type[j].is_red_dora();
                 if includes_red && !has_with_red {
                     has_with_red = true;
                     options.push([tiles_of_type[i], tiles_of_type[j]]);
@@ -261,7 +265,12 @@ impl Player {
 
     /// 大明カン可能か判定する
     pub fn can_daiminkan(&self, tile: Tile) -> bool {
-        let count = self.hand.tiles().iter().filter(|t| t.get() == tile.get()).count();
+        let count = self
+            .hand
+            .tiles()
+            .iter()
+            .filter(|t| t.get() == tile.get())
+            .count();
         count >= 3
     }
 
@@ -301,6 +310,21 @@ impl Player {
                 (counts[tile_type as usize] >= 1).then_some(tile_type)
             })
             .collect()
+    }
+
+    /// 加カンで追加する実際の牌を返す（赤ドラも区別する）
+    pub fn kakan_added_tile(&self, tile_type: TileType) -> Option<Tile> {
+        if let Some(drawn) = self.hand.drawn() {
+            if drawn.get() == tile_type {
+                return Some(drawn);
+            }
+        }
+
+        self.hand
+            .tiles()
+            .iter()
+            .copied()
+            .find(|tile| tile.get() == tile_type)
     }
 
     /// フリテン状態か判定する
@@ -437,10 +461,7 @@ impl Player {
             "暗カンに必要な4枚が揃っていません"
         );
 
-        let mut kan_tiles: Vec<Tile> = indices
-            .iter()
-            .map(|&idx| self.hand.tiles()[idx])
-            .collect();
+        let mut kan_tiles: Vec<Tile> = indices.iter().map(|&idx| self.hand.tiles()[idx]).collect();
         if drawn_matches {
             kan_tiles.push(drawn.unwrap());
             self.hand.set_drawn(None);
@@ -451,9 +472,11 @@ impl Player {
             self.hand.set_drawn(None);
         }
 
+        let stored_tiles = Self::stored_kan_tiles(kan_tiles);
+
         self.hand.remove_tiles_by_indices(&mut indices);
         self.hand.add_meld(Meld {
-            tiles: vec![kan_tiles[0], kan_tiles[1], kan_tiles[2]],
+            tiles: stored_tiles,
             category: MeldType::Kan,
             from: MeldFrom::Myself,
             called_tile: None,
@@ -465,9 +488,15 @@ impl Player {
 
     /// 加カンを実行する
     pub fn do_kakan(&mut self, tile_type: TileType) {
-        let drawn_matches = self.hand.drawn().map(|t| t.get() == tile_type).unwrap_or(false);
-        if drawn_matches {
+        let drawn_matches = self
+            .hand
+            .drawn()
+            .map(|t| t.get() == tile_type)
+            .unwrap_or(false);
+        let added_tile = if drawn_matches {
+            let tile = self.hand.drawn().expect("加カンに必要なツモ牌がありません");
             self.hand.set_drawn(None);
+            tile
         } else {
             let idx = self
                 .hand
@@ -475,14 +504,15 @@ impl Player {
                 .iter()
                 .position(|t| t.get() == tile_type)
                 .expect("加カンに必要な牌が手牌にありません");
-            self.hand.tiles_mut().remove(idx);
+            let tile = self.hand.tiles_mut().remove(idx);
 
             if let Some(drawn_tile) = self.hand.drawn() {
                 self.hand.tiles_mut().push(drawn_tile);
                 self.hand.sort();
                 self.hand.set_drawn(None);
             }
-        }
+            tile
+        };
 
         let open = self
             .hand
@@ -491,9 +521,19 @@ impl Player {
             .find(|open| open.category == MeldType::Pon && open.tiles[0].get() == tile_type)
             .expect("加カン対象のポンがありません");
         open.category = MeldType::Kakan;
+        open.called_tile = Some(added_tile);
 
         self.is_first_turn = false;
         self.is_ippatsu = false;
+    }
+
+    fn stored_kan_tiles(mut kan_tiles: Vec<Tile>) -> Vec<Tile> {
+        let mut stored = Vec::with_capacity(3);
+        if let Some(red_pos) = kan_tiles.iter().position(|tile| tile.is_red_dora()) {
+            stored.push(kan_tiles.remove(red_pos));
+        }
+        stored.extend(kan_tiles.into_iter().take(3 - stored.len()));
+        stored
     }
 
     /// 手牌に含まれる槓子の数を返す
@@ -508,9 +548,9 @@ impl Player {
     /// 捨てたプレイヤーと自分の相対位置から MeldFrom を返す
     pub fn meld_from_relative(caller: usize, discarder: usize) -> MeldFrom {
         match (caller + 4 - discarder) % 4 {
-            1 => MeldFrom::Previous,   // 上家（カミチャ）
-            2 => MeldFrom::Opposite,   // 対面（トイメン）
-            3 => MeldFrom::Following,  // 下家（シモチャ）
+            1 => MeldFrom::Previous,  // 上家（カミチャ）
+            2 => MeldFrom::Opposite,  // 対面（トイメン）
+            3 => MeldFrom::Following, // 下家（シモチャ）
             _ => unreachable!(),
         }
     }
@@ -656,8 +696,12 @@ mod tests {
         // 4mでチー: [2m,3m] or [3m,5m]
         let options = player.chi_options(Tile::new(Tile::M4));
         assert_eq!(options.len(), 2);
-        assert!(options.iter().any(|o| o[0].get() == Tile::M2 && o[1].get() == Tile::M3));
-        assert!(options.iter().any(|o| o[0].get() == Tile::M3 && o[1].get() == Tile::M5));
+        assert!(options
+            .iter()
+            .any(|o| o[0].get() == Tile::M2 && o[1].get() == Tile::M3));
+        assert!(options
+            .iter()
+            .any(|o| o[0].get() == Tile::M3 && o[1].get() == Tile::M5));
 
         // 字牌はチー不可
         let options = player.chi_options(Tile::new(Tile::Z1));
@@ -690,7 +734,11 @@ mod tests {
         let mut player = Player::new(Wind::South, tiles, 25000);
         let called = Tile::new(Tile::M1);
 
-        player.do_pon(called, [Tile::new(Tile::M1), Tile::new(Tile::M1)], MeldFrom::Previous);
+        player.do_pon(
+            called,
+            [Tile::new(Tile::M1), Tile::new(Tile::M1)],
+            MeldFrom::Previous,
+        );
 
         // 手牌が11枚になること（13 - 2 = 11）
         assert_eq!(player.hand.tiles().len(), 11);
@@ -792,6 +840,37 @@ mod tests {
     }
 
     #[test]
+    fn test_do_ankan_preserves_red_drawn_tile_in_meld() {
+        let tiles = vec![
+            Tile::new(Tile::M5),
+            Tile::new(Tile::M5),
+            Tile::new(Tile::M5),
+            Tile::new(Tile::P2),
+            Tile::new(Tile::P3),
+            Tile::new(Tile::P4),
+            Tile::new(Tile::S2),
+            Tile::new(Tile::S3),
+            Tile::new(Tile::S4),
+            Tile::new(Tile::M2),
+            Tile::new(Tile::M3),
+            Tile::new(Tile::M4),
+            Tile::new(Tile::Z1),
+        ];
+        let mut player = Player::new(Wind::South, tiles, 25000);
+        player.draw(Tile::new_red(Tile::M5));
+
+        player.do_ankan(Tile::M5);
+
+        assert!(
+            player.hand.melds()[0]
+                .tiles
+                .iter()
+                .any(|tile| tile.is_red_dora()),
+            "暗カンの赤ドラ牌が副露情報に残ること"
+        );
+    }
+
+    #[test]
     fn test_do_kakan() {
         let mut player = Player::new(Wind::South, vec![], 25000);
         player.hand = Hand::from("234p567s789m1z 111m 1m");
@@ -817,6 +896,21 @@ mod tests {
         assert!(player.hand.tiles().contains(&Tile::new(Tile::S9)));
         assert_eq!(player.hand.melds().len(), 1);
         assert_eq!(player.hand.melds()[0].category, MeldType::Kakan);
+    }
+
+    #[test]
+    fn test_do_kakan_tracks_added_red_tile() {
+        let mut player = Player::new(Wind::South, vec![], 25000);
+        player.hand = Hand::from("234p567s789m1z 555m");
+        player.draw(Tile::new_red(Tile::M5));
+
+        player.do_kakan(Tile::M5);
+
+        assert_eq!(player.hand.melds()[0].category, MeldType::Kakan);
+        assert_eq!(
+            player.hand.melds()[0].called_tile,
+            Some(Tile::new_red(Tile::M5))
+        );
     }
 
     #[test]

--- a/crates/mahjong-server/src/round/diagnostics.rs
+++ b/crates/mahjong-server/src/round/diagnostics.rs
@@ -23,12 +23,13 @@ impl Round {
 
         let player = &self.players[player_idx];
         let analyzer = HandAnalyzer::new(&player.hand);
-        let win_result = scoring::check_win(
+        let win_result = scoring::check_win_with_settings(
             player,
             self.prevailing_wind,
             true,
             self.wall.is_empty(),
             self.last_draw_was_dead_wall,
+            &self.settings,
         );
         let riichi_discards: Vec<String> = player
             .hand

--- a/crates/mahjong-server/src/round/mod.rs
+++ b/crates/mahjong-server/src/round/mod.rs
@@ -9,6 +9,7 @@ mod diagnostics;
 mod test_helpers;
 
 use mahjong_core::hand_info::hand_analyzer;
+use mahjong_core::hand_info::meld::Meld;
 use mahjong_core::settings::Settings;
 use mahjong_core::tile::{Tile, TileType, Wind};
 
@@ -198,7 +199,7 @@ impl Round {
                     .melds()
                     .iter()
                     .map(|open| {
-                        let mut tiles: Vec<Tile> = open.tiles.clone();
+                        let tiles: Vec<Tile> = Self::expanded_meld_tiles(open);
                         let call_type = match open.category {
                             mahjong_core::hand_info::meld::MeldType::Chi => CallType::Chi,
                             mahjong_core::hand_info::meld::MeldType::Pon => CallType::Pon,
@@ -211,10 +212,6 @@ impl Round {
                             }
                             mahjong_core::hand_info::meld::MeldType::Kakan => CallType::Kakan,
                         };
-                        // カンの場合は4枚にする
-                        if open.category.is_kan() && tiles.len() == 3 {
-                            tiles.push(tiles[0]);
-                        }
                         MeldTiles { call_type, tiles }
                     })
                     .collect();
@@ -226,6 +223,26 @@ impl Round {
                 }
             })
             .collect()
+    }
+
+    fn expanded_meld_tiles(open: &Meld) -> Vec<Tile> {
+        let mut tiles = open.tiles.clone();
+        if open.category.is_kan() && tiles.len() == 3 {
+            tiles.push(Self::kan_fourth_tile(open));
+        }
+        tiles
+    }
+
+    fn kan_fourth_tile(open: &Meld) -> Tile {
+        if let Some(tile) = open.called_tile {
+            return tile;
+        }
+
+        open.tiles
+            .iter()
+            .copied()
+            .find(|tile| !tile.is_red_dora())
+            .unwrap_or(open.tiles[0])
     }
 
     pub fn get_scores(&self) -> [i32; 4] {
@@ -404,8 +421,13 @@ impl Round {
             // リーチ中は鳴き不可（ロンのみ可）
             // ロン判定: フリテンでなく、和了形であること
             if !player.is_furiten() {
-                let win_result =
-                    scoring::check_ron(player, discarded_tile, self.prevailing_wind, is_last_tile);
+                let win_result = scoring::check_ron_with_settings(
+                    player,
+                    discarded_tile,
+                    self.prevailing_wind,
+                    is_last_tile,
+                    &self.settings,
+                );
                 if win_result.is_win {
                     available_calls[i].push(AvailableCall::Ron);
                 }
@@ -668,12 +690,13 @@ impl Round {
         for (rank, &winner) in winners.iter().enumerate() {
             let honba_for_this = if rank == 0 { self.honba } else { 0 };
 
-            let win_result = scoring::check_ron_with_flags(
+            let win_result = scoring::check_ron_with_flags_and_settings(
                 &self.players[winner],
                 winning_tile,
                 self.prevailing_wind,
                 is_last_tile,
                 is_robbing_a_quad,
+                &self.settings,
             );
 
             if !win_result.is_win {
@@ -864,8 +887,7 @@ impl Round {
 
         let caller_wind = self.players[caller].seat_wind;
         let open = self.players[caller].hand.melds().last().unwrap();
-        let mut tiles = open.tiles.to_vec();
-        tiles.push(called_tile);
+        let tiles = Self::expanded_meld_tiles(open);
 
         for i in 0..4 {
             self.events.push((
@@ -965,10 +987,8 @@ impl Round {
                     && open.tiles[0].get() == tile_type
             })
             .unwrap();
-        let mut tiles = open.tiles.clone();
-        if tiles.len() == 3 {
-            tiles.push(Tile::new(tile_type));
-        }
+        let tiles = Self::expanded_meld_tiles(open);
+        let added_tile = Self::kan_fourth_tile(open);
 
         for i in 0..4 {
             self.events.push((
@@ -976,7 +996,7 @@ impl Round {
                 ServerEvent::PlayerCalled {
                     player: caller_wind,
                     call_type: CallType::Kakan,
-                    called_tile: Tile::new(tile_type),
+                    called_tile: added_tile,
                     tiles: tiles.clone(),
                 },
             ));
@@ -994,7 +1014,9 @@ impl Round {
     }
 
     fn check_kakan_ron_and_resolve(&mut self, caller: usize, tile_type: TileType) {
-        let called_tile = Tile::new(tile_type);
+        let called_tile = self.players[caller]
+            .kakan_added_tile(tile_type)
+            .unwrap_or_else(|| Tile::new(tile_type));
         let is_last_tile = self.wall.is_empty();
         let mut available_calls: [Vec<AvailableCall>; 4] =
             [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
@@ -1007,12 +1029,13 @@ impl Round {
 
             let player = &self.players[i];
             if !player.is_furiten() {
-                let win_result = scoring::check_ron_with_flags(
+                let win_result = scoring::check_ron_with_flags_and_settings(
                     player,
                     called_tile,
                     self.prevailing_wind,
                     is_last_tile,
                     true,
+                    &self.settings,
                 );
                 if win_result.is_win {
                     available_calls[i].push(AvailableCall::Ron);
@@ -1091,8 +1114,7 @@ impl Round {
 
         let caller_wind = self.players[player_idx].seat_wind;
         let open = self.players[player_idx].hand.melds().last().unwrap();
-        let mut tiles = open.tiles.to_vec();
-        tiles.push(open.tiles[0]);
+        let tiles = Self::expanded_meld_tiles(open);
         let called_tile = Tile::new(tile_type);
 
         for i in 0..4 {
@@ -1388,12 +1410,13 @@ impl Round {
         }
         let player = &self.players[self.current_player];
         let is_last_tile = self.wall.is_empty();
-        let result = scoring::check_win(
+        let result = scoring::check_win_with_settings(
             player,
             self.prevailing_wind,
             true,
             is_last_tile,
             self.last_draw_was_dead_wall,
+            &self.settings,
         );
         result.is_win
     }
@@ -1407,12 +1430,13 @@ impl Round {
 
         let player = &self.players[self.current_player];
         let is_last_tile = self.wall.is_empty();
-        let win_result = scoring::check_win(
+        let win_result = scoring::check_win_with_settings(
             player,
             self.prevailing_wind,
             true,
             is_last_tile,
             self.last_draw_was_dead_wall,
+            &self.settings,
         );
 
         if !win_result.is_win {
@@ -1927,15 +1951,76 @@ mod tests {
         round.players[1] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
 
         let call_state = round.check_available_calls(Tile::new(Tile::Z5), 0);
-        assert!(
-            call_state.available_calls[1]
-                .iter()
-                .any(|call| matches!(call, AvailableCall::Pon { .. }))
-        );
+        assert!(call_state.available_calls[1]
+            .iter()
+            .any(|call| matches!(call, AvailableCall::Pon { .. })));
+        assert!(!call_state.available_calls[1]
+            .iter()
+            .any(|call| matches!(call, AvailableCall::Ron)));
+    }
+
+    fn open_tanyao_player(seat_wind: Wind, with_drawn: bool) -> Player {
+        use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
+
+        let hand = mahjong_core::hand::Hand::from("56677m66s 5m");
+        let mut player = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
+        player.hand.add_meld(Meld {
+            tiles: vec![
+                Tile::new(Tile::P4),
+                Tile::new(Tile::P5),
+                Tile::new(Tile::P6),
+            ],
+            category: MeldType::Chi,
+            from: MeldFrom::Previous,
+            called_tile: None,
+        });
+        player.hand.add_meld(Meld {
+            tiles: vec![
+                Tile::new(Tile::M2),
+                Tile::new(Tile::M3),
+                Tile::new(Tile::M4),
+            ],
+            category: MeldType::Chi,
+            from: MeldFrom::Previous,
+            called_tile: None,
+        });
+        if with_drawn {
+            player.draw(hand.drawn().unwrap());
+        }
+        player
+    }
+
+    #[test]
+    fn test_open_tanyao_disabled_blocks_tsumo() {
+        let mut settings = Settings::new();
+        settings.opened_all_simples = false;
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+
+        let seat_wind = round.players[0].seat_wind;
+        round.players[0] = open_tanyao_player(seat_wind, true);
+        round.current_player = 0;
+        round.phase = TurnPhase::WaitForDiscard;
+
+        assert!(!round.can_tsumo());
+        assert!(!round.do_tsumo());
+        assert_eq!(round.phase, TurnPhase::WaitForDiscard);
+    }
+
+    #[test]
+    fn test_open_tanyao_disabled_does_not_offer_ron() {
+        let mut settings = Settings::new();
+        settings.opened_all_simples = false;
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+
+        let seat_wind = round.players[1].seat_wind;
+        round.players[1] = open_tanyao_player(seat_wind, false);
+
+        let call_state = round.check_available_calls(Tile::new(Tile::M5), 0);
         assert!(
             !call_state.available_calls[1]
                 .iter()
-                .any(|call| matches!(call, AvailableCall::Ron))
+                .any(|call| matches!(call, AvailableCall::Ron)),
+            "喰いタンなしではオープン断么九のみのロンを提示しない"
         );
     }
 
@@ -1982,11 +2067,9 @@ mod tests {
         round.players[1] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
 
         let call_state = round.check_available_calls(Tile::new(Tile::M1), 0);
-        assert!(
-            call_state.available_calls[1]
-                .iter()
-                .any(|call| matches!(call, AvailableCall::Daiminkan))
-        );
+        assert!(call_state.available_calls[1]
+            .iter()
+            .any(|call| matches!(call, AvailableCall::Daiminkan)));
     }
 
     #[test]
@@ -2043,12 +2126,10 @@ mod tests {
         assert_eq!(round.phase, TurnPhase::WaitForDiscard);
         assert!(round.players[0].hand.drawn().is_some());
         assert_eq!(round.players[0].hand.tiles().len(), 10);
-        assert!(
-            round.players[0]
-                .hand
-                .tiles()
-                .contains(&mahjong_core::tile::Tile::new(Tile::S9))
-        );
+        assert!(round.players[0]
+            .hand
+            .tiles()
+            .contains(&mahjong_core::tile::Tile::new(Tile::S9)));
     }
 
     #[test]
@@ -2204,11 +2285,9 @@ mod tests {
         assert!(round.do_kan(Tile::M1));
         assert_eq!(round.phase, TurnPhase::WaitForCalls);
         let call_state = round.call_state.as_ref().unwrap();
-        assert!(
-            call_state.available_calls[1]
-                .iter()
-                .any(|call| matches!(call, AvailableCall::Ron))
-        );
+        assert!(call_state.available_calls[1]
+            .iter()
+            .any(|call| matches!(call, AvailableCall::Ron)));
 
         // ロンせずパス → フリテンが設定されること
         assert!(round.respond_to_call(1, CallResponse::Pass));
@@ -2264,11 +2343,9 @@ mod tests {
         assert!(round.do_kan(Tile::M1));
         assert_eq!(round.phase, TurnPhase::WaitForCalls);
         let call_state = round.call_state.as_ref().unwrap();
-        assert!(
-            call_state.available_calls[1]
-                .iter()
-                .any(|call| matches!(call, AvailableCall::Ron))
-        );
+        assert!(call_state.available_calls[1]
+            .iter()
+            .any(|call| matches!(call, AvailableCall::Ron)));
 
         assert!(round.respond_to_call(1, CallResponse::Ron));
         assert_eq!(round.phase, TurnPhase::RoundOver);

--- a/crates/mahjong-server/src/scoring.rs
+++ b/crates/mahjong-server/src/scoring.rs
@@ -6,6 +6,7 @@
 
 use mahjong_core::hand::Hand;
 use mahjong_core::hand_info::hand_analyzer::{self, HandAnalyzer};
+use mahjong_core::hand_info::meld::Meld;
 use mahjong_core::hand_info::status::Status;
 use mahjong_core::scoring::score::{
     calculate_base_points, calculate_score, determine_rank, round_up_to_100, ScoreRank, ScoreResult,
@@ -34,6 +35,26 @@ pub fn check_win(
     is_tsumo: bool,
     is_last_tile: bool,
     is_dead_wall_draw: bool,
+) -> WinCheckResult {
+    let settings = Settings::new();
+    check_win_with_settings(
+        player,
+        prevailing_wind,
+        is_tsumo,
+        is_last_tile,
+        is_dead_wall_draw,
+        &settings,
+    )
+}
+
+/// プレイヤーの手牌が和了しているか、指定ルールで判定する
+pub fn check_win_with_settings(
+    player: &Player,
+    prevailing_wind: Wind,
+    is_tsumo: bool,
+    is_last_tile: bool,
+    is_dead_wall_draw: bool,
+    settings: &Settings,
 ) -> WinCheckResult {
     let hand = &player.hand;
 
@@ -72,9 +93,7 @@ pub fn check_win(
     status.is_dead_wall_draw = is_dead_wall_draw;
     status.kan_count = player.kan_count() as u32;
 
-    let settings = Settings::new();
-
-    match calculate_score(&analyzer, hand, &status, &settings) {
+    match calculate_score(&analyzer, hand, &status, settings) {
         Ok(Some(result)) => WinCheckResult {
             is_win: true,
             score_result: Some(result),
@@ -96,7 +115,33 @@ pub fn check_ron(
     prevailing_wind: Wind,
     is_last_tile: bool,
 ) -> WinCheckResult {
-    check_ron_with_flags(player, discarded_tile, prevailing_wind, is_last_tile, false)
+    let settings = Settings::new();
+    check_ron_with_flags_and_settings(
+        player,
+        discarded_tile,
+        prevailing_wind,
+        is_last_tile,
+        false,
+        &settings,
+    )
+}
+
+/// ロン和了が可能か指定ルールで判定する
+pub fn check_ron_with_settings(
+    player: &Player,
+    discarded_tile: Tile,
+    prevailing_wind: Wind,
+    is_last_tile: bool,
+    settings: &Settings,
+) -> WinCheckResult {
+    check_ron_with_flags_and_settings(
+        player,
+        discarded_tile,
+        prevailing_wind,
+        is_last_tile,
+        false,
+        settings,
+    )
 }
 
 /// ロン和了が可能か判定する（搶槓などの状態フラグ付き）
@@ -106,6 +151,26 @@ pub fn check_ron_with_flags(
     prevailing_wind: Wind,
     is_last_tile: bool,
     is_robbing_a_quad: bool,
+) -> WinCheckResult {
+    let settings = Settings::new();
+    check_ron_with_flags_and_settings(
+        player,
+        discarded_tile,
+        prevailing_wind,
+        is_last_tile,
+        is_robbing_a_quad,
+        &settings,
+    )
+}
+
+/// ロン和了が可能か指定ルールと状態フラグで判定する
+pub fn check_ron_with_flags_and_settings(
+    player: &Player,
+    discarded_tile: Tile,
+    prevailing_wind: Wind,
+    is_last_tile: bool,
+    is_robbing_a_quad: bool,
+    settings: &Settings,
 ) -> WinCheckResult {
     // 手牌をクローンして捨て牌をdrawnとしてセット
     let mut hand = player.hand.clone();
@@ -144,9 +209,7 @@ pub fn check_ron_with_flags(
     status.is_robbing_a_quad = is_robbing_a_quad;
     status.kan_count = player.kan_count() as u32;
 
-    let settings = Settings::new();
-
-    match calculate_score(&analyzer, &hand, &status, &settings) {
+    match calculate_score(&analyzer, &hand, &status, settings) {
         Ok(Some(result)) => WinCheckResult {
             is_win: true,
             score_result: Some(result),
@@ -275,7 +338,7 @@ pub fn add_dora_to_score(
             all_tiles.push(tile);
         }
         if open.category.is_kan() && open.tiles.len() == 3 {
-            all_tiles.push(open.tiles[0]);
+            all_tiles.push(kan_fourth_tile(open));
         }
     }
 
@@ -326,6 +389,18 @@ pub fn add_dora_to_score(
     }
 }
 
+fn kan_fourth_tile(open: &Meld) -> Tile {
+    if let Some(tile) = open.called_tile {
+        return tile;
+    }
+
+    open.tiles
+        .iter()
+        .copied()
+        .find(|tile| !tile.is_red_dora())
+        .unwrap_or(open.tiles[0])
+}
+
 /// プレイヤーがテンパイしているか判定する（13枚の手牌で）
 pub fn is_ready(player: &Player) -> bool {
     hand_analyzer::calc_shanten_number(&player.hand).is_ready()
@@ -366,6 +441,7 @@ pub fn calculate_ron_score_deltas(
 mod tests {
     use super::*;
     use mahjong_core::hand::Hand;
+    use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
     use mahjong_core::scoring::fu::{FuDetail, FuResult};
     use mahjong_core::scoring::score::ScoreRank;
     use mahjong_core::tile::Tile;
@@ -517,20 +593,26 @@ mod tests {
 
     #[test]
     fn test_check_win_open_tanyao_tsumo() {
-        use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
-
         let hand = Hand::from("56677m66s 5m");
         let tiles: Vec<Tile> = hand.tiles().to_vec();
         let drawn = hand.drawn();
         let mut player = Player::new(Wind::South, tiles, 25000);
         player.hand.add_meld(Meld {
-            tiles: vec![Tile::new(Tile::P4), Tile::new(Tile::P5), Tile::new(Tile::P6)],
+            tiles: vec![
+                Tile::new(Tile::P4),
+                Tile::new(Tile::P5),
+                Tile::new(Tile::P6),
+            ],
             category: MeldType::Chi,
             from: MeldFrom::Previous,
             called_tile: None,
         });
         player.hand.add_meld(Meld {
-            tiles: vec![Tile::new(Tile::M2), Tile::new(Tile::M3), Tile::new(Tile::M4)],
+            tiles: vec![
+                Tile::new(Tile::M2),
+                Tile::new(Tile::M3),
+                Tile::new(Tile::M4),
+            ],
             category: MeldType::Chi,
             from: MeldFrom::Previous,
             called_tile: None,
@@ -543,6 +625,43 @@ mod tests {
         assert!(result.is_win, "open tanyao tsumo should be a win");
         let score = result.score_result.unwrap();
         assert!(score.han >= 1, "expected at least tanyao");
+    }
+
+    #[test]
+    fn test_check_win_respects_open_tanyao_disabled() {
+        let hand = Hand::from("56677m66s 5m");
+        let tiles: Vec<Tile> = hand.tiles().to_vec();
+        let drawn = hand.drawn();
+        let mut player = Player::new(Wind::South, tiles, 25000);
+        player.hand.add_meld(Meld {
+            tiles: vec![
+                Tile::new(Tile::P4),
+                Tile::new(Tile::P5),
+                Tile::new(Tile::P6),
+            ],
+            category: MeldType::Chi,
+            from: MeldFrom::Previous,
+            called_tile: None,
+        });
+        player.hand.add_meld(Meld {
+            tiles: vec![
+                Tile::new(Tile::M2),
+                Tile::new(Tile::M3),
+                Tile::new(Tile::M4),
+            ],
+            category: MeldType::Chi,
+            from: MeldFrom::Previous,
+            called_tile: None,
+        });
+        if let Some(d) = drawn {
+            player.draw(d);
+        }
+
+        let mut settings = Settings::new();
+        settings.opened_all_simples = false;
+
+        let result = check_win_with_settings(&player, Wind::East, true, false, false, &settings);
+        assert!(!result.is_win, "open tanyao must be rejected when disabled");
     }
 
     #[test]
@@ -573,7 +692,10 @@ mod tests {
 
         let fu_result = FuResult {
             total: 30,
-            details: vec![FuDetail { name: "副底", fu: 20 }],
+            details: vec![FuDetail {
+                name: "副底",
+                fu: 20,
+            }],
         };
         let mut score = ScoreResult {
             han: 1,
@@ -590,10 +712,18 @@ mod tests {
 
         // 手牌にM2（ドラ）・赤M5（赤ドラ）・S7（裏ドラ対象）を含む
         let tiles = vec![
-            Tile::new(Tile::M2), Tile::new(Tile::M3), Tile::new(Tile::M4),
-            Tile::new(Tile::P2), Tile::new(Tile::P3), Tile::new(Tile::P4),
-            Tile::new(Tile::S2), Tile::new(Tile::S3), Tile::new(Tile::S4),
-            Tile::new(Tile::M6), Tile::new(Tile::M7), Tile::new(Tile::M8),
+            Tile::new(Tile::M2),
+            Tile::new(Tile::M3),
+            Tile::new(Tile::M4),
+            Tile::new(Tile::P2),
+            Tile::new(Tile::P3),
+            Tile::new(Tile::P4),
+            Tile::new(Tile::S2),
+            Tile::new(Tile::S3),
+            Tile::new(Tile::S4),
+            Tile::new(Tile::M6),
+            Tile::new(Tile::M7),
+            Tile::new(Tile::M8),
             Tile::new(Tile::S7),
         ];
         let mut player = Player::new(Wind::South, tiles, 25000);
@@ -605,7 +735,13 @@ mod tests {
         let dora_indicators = vec![Tile::new(Tile::M1)];
         let uradora_indicators = vec![Tile::new(Tile::S6)];
 
-        add_dora_to_score(&mut score, &player.hand, None, &dora_indicators, &uradora_indicators);
+        add_dora_to_score(
+            &mut score,
+            &player.hand,
+            None,
+            &dora_indicators,
+            &uradora_indicators,
+        );
 
         assert_eq!(score.yaku_list.len(), 4);
         assert_eq!(score.yaku_list[0], ("断么九", 1));
@@ -613,7 +749,84 @@ mod tests {
         assert_eq!(score.yaku_list[2], ("赤ドラ", 1));
         assert_eq!(score.yaku_list[3], ("裏ドラ", 1));
     }
+
+    #[test]
+    fn test_add_dora_counts_red_called_kan_tile() {
+        let fu_result = FuResult {
+            total: 30,
+            details: vec![FuDetail {
+                name: "副底",
+                fu: 20,
+            }],
+        };
+        let mut score = ScoreResult {
+            han: 1,
+            fu: 30,
+            rank: ScoreRank::Normal,
+            dealer_ron: 1500,
+            dealer_tsumo_all: 500,
+            non_dealer_ron: 1000,
+            non_dealer_tsumo_dealer: 500,
+            non_dealer_tsumo_non_dealer: 300,
+            yaku_list: vec![("立直", 1)],
+            fu_result,
+        };
+        let hand = Hand::new_with_melds(
+            vec![],
+            vec![Meld {
+                tiles: vec![Tile::new(Tile::M5); 3],
+                category: MeldType::Kan,
+                from: MeldFrom::Previous,
+                called_tile: Some(Tile::new_red(Tile::M5)),
+            }],
+            None,
+        );
+
+        add_dora_to_score(&mut score, &hand, None, &[], &[]);
+
+        assert_eq!(score.yaku_list.last(), Some(&("赤ドラ", 1)));
+        assert_eq!(score.han, 2);
+    }
+
+    #[test]
+    fn test_add_dora_counts_red_closed_kan_once() {
+        let fu_result = FuResult {
+            total: 30,
+            details: vec![FuDetail {
+                name: "副底",
+                fu: 20,
+            }],
+        };
+        let mut score = ScoreResult {
+            han: 1,
+            fu: 30,
+            rank: ScoreRank::Normal,
+            dealer_ron: 1500,
+            dealer_tsumo_all: 500,
+            non_dealer_ron: 1000,
+            non_dealer_tsumo_dealer: 500,
+            non_dealer_tsumo_non_dealer: 300,
+            yaku_list: vec![("立直", 1)],
+            fu_result,
+        };
+        let hand = Hand::new_with_melds(
+            vec![],
+            vec![Meld {
+                tiles: vec![
+                    Tile::new_red(Tile::M5),
+                    Tile::new(Tile::M5),
+                    Tile::new(Tile::M5),
+                ],
+                category: MeldType::Kan,
+                from: MeldFrom::Myself,
+                called_tile: None,
+            }],
+            None,
+        );
+
+        add_dora_to_score(&mut score, &hand, None, &[], &[]);
+
+        assert_eq!(score.yaku_list.last(), Some(&("赤ドラ", 1)));
+        assert_eq!(score.han, 2);
+    }
 }
-
-
-


### PR DESCRIPTION
## Summary
- pass table settings into win checks so rule toggles like open tanyao are respected
- preserve red dora identity for closed, added, and open kan melds
- prevent CPU visible tile counts from double-counting called discards and update existing pon melds on kakan

## Tests
- cargo test