### PR TITLE
Fix riichi and tsumo buttons overlapping (#99)

### DIFF
--- a/crates/mahjong-client/src/renderer/overlay.rs
+++ b/crates/mahjong-client/src/renderer/overlay.rs
@@ -146,17 +146,17 @@ pub(super) fn draw_action_buttons(
     if state.can_riichi {
         const RIICHI_BTN_W: f32 = 80.0;
         const RIICHI_BTN_H: f32 = 40.0;
+        // ツモボタンと重ならないよう、ツモボタンがある場合は上にずらす
+        let riichi_y = if state.can_tsumo {
+            AGARI_BTN_Y - RIICHI_BTN_H - AGARI_BTN_GAP
+        } else {
+            AGARI_BTN_Y
+        };
         let riichi_bg = Color::new(0.8, 0.2, 0.2, 1.0);
-        draw_rectangle(
-            AGARI_BTN_X,
-            AGARI_BTN_Y,
-            RIICHI_BTN_W,
-            RIICHI_BTN_H,
-            riichi_bg,
-        );
+        draw_rectangle(AGARI_BTN_X, riichi_y, RIICHI_BTN_W, RIICHI_BTN_H, riichi_bg);
         draw_rectangle_lines(
             AGARI_BTN_X,
-            AGARI_BTN_Y,
+            riichi_y,
             RIICHI_BTN_W,
             RIICHI_BTN_H,
             2.0,
@@ -166,13 +166,13 @@ pub(super) fn draw_action_buttons(
             font,
             "リーチ",
             AGARI_BTN_X + 8.0,
-            AGARI_BTN_Y + RIICHI_BTN_H - 8.0,
+            riichi_y + RIICHI_BTN_H - 8.0,
             SMALL_FONT,
             WHITE,
         );
         if clicked
             && result.is_none()
-            && hit_rect(mx, my, AGARI_BTN_X, AGARI_BTN_Y, RIICHI_BTN_W, RIICHI_BTN_H)
+            && hit_rect(mx, my, AGARI_BTN_X, riichi_y, RIICHI_BTN_W, RIICHI_BTN_H)
         {
             result = Some(OverlayClick::ToggleRiichi);
         }


### PR DESCRIPTION
## Summary

- `can_tsumo` と `can_riichi` が同時に `true` の場合、リーチボタンと和了ボタンが同じ座標 `(AGARI_BTN_X, AGARI_BTN_Y)` に描画されて重なるバグを修正
- `can_tsumo` が `true` のときはリーチボタンを和了ボタンの上（`AGARI_BTN_GAP` 分の間隔を空けて）に配置するよう変更

## Test plan

- [ ] ツモ可能かつリーチ可能な状況を作り、両ボタンが重ならず表示されることを確認
- [ ] リーチのみ可能な場合、リーチボタンが従来通りの位置に表示されることを確認
- [ ] ツモのみ可能な場合、和了ボタンのみ表示されることを確認

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)