### PR TITLE
Add unit tests for mahjong-server/src/round/test_helpers.rs (#108)

### DIFF
--- a/crates/mahjong-server/src/round/mod.rs
+++ b/crates/mahjong-server/src/round/mod.rs
@@ -2932,4 +2932,68 @@ mod tests {
         );
         assert_eq!(round.riichi_sticks, 0, "供託棒はすべて消費されること");
     }
+
+    // ─── auto_pass_cpu テスト ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_auto_pass_cpu_no_op_when_wrong_phase() {
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        assert_eq!(round.phase, TurnPhase::Draw);
+        round.auto_pass_cpu(0);
+        assert_eq!(round.phase, TurnPhase::Draw);
+    }
+
+    #[test]
+    fn test_auto_pass_cpu_passes_cpu_players_and_resolves() {
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+
+        // プレイヤー1に5zポン可能な手牌をセット
+        let seat1 = round.players[1].seat_wind;
+        let hand1 = mahjong_core::hand::Hand::from("234678m56p567s55z");
+        round.players[1] = Player::new(seat1, hand1.tiles().to_vec(), 25000);
+
+        let call_state = round.check_available_calls(Tile::new(Tile::Z5), 0);
+        assert!(!call_state.responded[1], "player 1 should have pending pon");
+
+        round.phase = TurnPhase::WaitForCalls;
+        round.call_state = Some(call_state);
+
+        // human = 0 (捨て牌側), CPU のプレイヤー1 が自動パスされて鳴き解決される
+        round.auto_pass_cpu(0);
+
+        assert!(
+            round.call_state.is_none(),
+            "all CPUs passed → call should resolve"
+        );
+        assert_eq!(round.phase, TurnPhase::Draw);
+    }
+
+    #[test]
+    fn test_auto_pass_cpu_skips_human_player() {
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+
+        // プレイヤー1に5zポン可能な手牌をセット
+        let seat1 = round.players[1].seat_wind;
+        let hand1 = mahjong_core::hand::Hand::from("234678m56p567s55z");
+        round.players[1] = Player::new(seat1, hand1.tiles().to_vec(), 25000);
+
+        let call_state = round.check_available_calls(Tile::new(Tile::Z5), 0);
+        assert!(!call_state.responded[1], "player 1 should have pending pon");
+
+        round.phase = TurnPhase::WaitForCalls;
+        round.call_state = Some(call_state);
+
+        // human = 1 → プレイヤー1はスキップされるので応答が残る
+        round.auto_pass_cpu(1);
+
+        assert!(
+            round.call_state.is_some(),
+            "call should still be pending for human player"
+        );
+        assert!(
+            !round.call_state.as_ref().unwrap().responded[1],
+            "human player should not have been auto-passed"
+        );
+        assert_eq!(round.phase, TurnPhase::WaitForCalls);
+    }
 }


### PR DESCRIPTION
## Summary

- Add 3 unit tests for `auto_pass_cpu` in `mahjong-server/src/round/test_helpers.rs`, increasing coverage from 43.75%
- `test_auto_pass_cpu_no_op_when_wrong_phase`: verifies the early-return guard when phase ≠ `WaitForCalls`
- `test_auto_pass_cpu_passes_cpu_players_and_resolves`: verifies that CPU players are auto-passed and the call resolves when all have responded
- `test_auto_pass_cpu_skips_human_player`: verifies that the human player's pending call is not touched

## Test plan

- [x] `cargo test -p mahjong-server` — all 181 tests pass
- [x] `cargo fmt` — no formatting issues
- [x] `cargo clippy -p mahjong-server` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)