### PR TITLE
Add CPU heuristics framework foundation (#142)

### DIFF
--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -990,7 +990,7 @@ fn draw_game_over(state: &GameState, font: Option<&Font>) {
         .enumerate()
         .map(|(i, &s)| (i, s))
         .collect();
-    rankings.sort_by(|a, b| b.1.cmp(&a.1));
+    rankings.sort_by_key(|r| std::cmp::Reverse(r.1));
 
     for (rank, (player_idx, score)) in rankings.iter().enumerate() {
         let color = if *player_idx == 0 {

--- a/crates/mahjong-core/src/hand_info/hand_analyzer.rs
+++ b/crates/mahjong-core/src/hand_info/hand_analyzer.rs
@@ -272,6 +272,39 @@ pub fn calc_shanten_number(hand: &Hand) -> ShantenNumber {
     ShantenNumber(min(min(sp, to), nm))
 }
 
+/// 和了形を指定して向聴数のみを高速に計算する
+///
+/// `HandAnalyzer::new_by_form(hand, form)` の `shanten` と同じ結果を返すが、
+/// ブロック分解やVecへの格納を行わないため高速。
+/// CPU の路線判断（一般形・七対子・国士無双の比較）など、
+/// 形ごとの向聴数を大量に計算する箇所で使用する。
+///
+/// 副露がある場合、七対子・国士無双は該当なし（`i32::MAX` 相当）を返す。
+pub fn calc_shanten_number_by_form(hand: &Hand, form: Form) -> ShantenNumber {
+    let is_closed = hand.melds().is_empty();
+    match form {
+        Form::SevenPairs => {
+            if is_closed {
+                let t = hand.summarize_tiles();
+                ShantenNumber(calc_seven_pairs_shanten(&t).0)
+            } else {
+                ShantenNumber::UNAVAILABLE
+            }
+        }
+        Form::ThirteenOrphans => {
+            if is_closed {
+                let t = hand.summarize_tiles();
+                ShantenNumber(calc_thirteen_orphans_shanten(&t))
+            } else {
+                ShantenNumber::UNAVAILABLE
+            }
+        }
+        Form::Normal => calc_normal_shanten::<CountOnly>(hand)
+            .map(|(s, _)| ShantenNumber(s))
+            .unwrap_or(ShantenNumber::UNAVAILABLE),
+    }
+}
+
 /// 七対子のシャンテン数を計算する共通ロジック
 ///
 /// 戻り値: `(shanten, pair_count)`
@@ -916,6 +949,65 @@ mod tests {
                 .shanten
                 .is_ready()
         );
+    }
+
+    #[test]
+    /// calc_shanten_number_by_form は HandAnalyzer::new_by_form と同じ向聴数を返す
+    fn calc_shanten_number_by_form_matches_analyzer() {
+        let test_strs = [
+            "226699m99p228s66z 1z", // 七対子聴牌
+            "19m19p11s1234567z 5m", // 国士無双聴牌
+            "123456789m123p11z 2p", // 通常形聴牌
+            "1122m3344p5555s1z 1z", // 4枚使い七対子
+            "139m258p47s12345z 6z", // バラバラ
+            "111222333m44455p 5p",  // 和了形
+        ];
+        for test_str in test_strs {
+            let hand = Hand::from(test_str);
+            for form in [Form::Normal, Form::SevenPairs, Form::ThirteenOrphans] {
+                assert_eq!(
+                    calc_shanten_number_by_form(&hand, form),
+                    HandAnalyzer::new_by_form(&hand, form).unwrap().shanten,
+                    "form {form:?} mismatch for {test_str}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    /// 副露がある場合、七対子・国士無双は該当なしを返す
+    fn calc_shanten_number_by_form_melded_hand() {
+        use crate::hand_info::meld::{Meld, MeldFrom, MeldType};
+        let tiles = vec![
+            Tile::new(Tile::M1),
+            Tile::new(Tile::M2),
+            Tile::new(Tile::M3),
+            Tile::new(Tile::P4),
+            Tile::new(Tile::P5),
+            Tile::new(Tile::P6),
+            Tile::new(Tile::S7),
+            Tile::new(Tile::S8),
+            Tile::new(Tile::Z1),
+            Tile::new(Tile::Z1),
+        ];
+        let melds = vec![Meld {
+            tiles: vec![Tile::new(Tile::Z5); 3],
+            category: MeldType::Pon,
+            from: MeldFrom::Unknown,
+            called_tile: Some(Tile::new(Tile::Z5)),
+        }];
+        let hand = Hand::new_with_melds(tiles, melds, None);
+
+        assert_eq!(
+            calc_shanten_number_by_form(&hand, Form::SevenPairs),
+            ShantenNumber::UNAVAILABLE
+        );
+        assert_eq!(
+            calc_shanten_number_by_form(&hand, Form::ThirteenOrphans),
+            ShantenNumber::UNAVAILABLE
+        );
+        // 通常形は計算できる（S9 か S6 待ちの聴牌）
+        assert!(calc_shanten_number_by_form(&hand, Form::Normal).is_ready());
     }
 
     #[test]

--- a/crates/mahjong-core/src/winning_hand/name.rs
+++ b/crates/mahjong-core/src/winning_hand/name.rs
@@ -3,7 +3,7 @@ use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 use crate::settings::Lang;
 
 /// 和了時の手牌の形態
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Form {
     /// 七対子
     SevenPairs,

--- a/crates/mahjong-server/src/cpu/client.rs
+++ b/crates/mahjong-server/src/cpu/client.rs
@@ -14,7 +14,10 @@ use super::evaluator;
 use super::state::CpuGameState;
 
 /// CPUの強さレベル
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// `Weak < Normal < Strong` の順序を持つ。
+/// 定石（heuristics）の「弱以上」「中以上」などの有効化判定に使用する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CpuLevel {
     /// 初心者: 向聴数のみ考慮、防御なし、ミスあり
     Weak,
@@ -172,7 +175,9 @@ impl CpuClient {
         let candidates = evaluator::evaluate_discards(&self.state, &self.config);
 
         let attacking = self.should_attack();
-        if let Some(tile) = evaluator::select_best_discard(&candidates, &self.config, attacking) {
+        if let Some(tile) =
+            evaluator::select_best_discard(&candidates, &self.config, attacking, &self.state)
+        {
             // ツモ牌と同じならツモ切り
             if self.state.my_drawn == Some(tile) {
                 ClientAction::Discard { tile: None }
@@ -191,7 +196,9 @@ impl CpuClient {
         let candidates = evaluator::evaluate_discards(&self.state, &self.config);
         let attacking = self.should_attack();
 
-        if let Some(tile) = evaluator::select_best_discard(&candidates, &self.config, attacking) {
+        if let Some(tile) =
+            evaluator::select_best_discard(&candidates, &self.config, attacking, &self.state)
+        {
             ClientAction::Discard { tile: Some(tile) }
         } else if let Some(&tile) = self.state.my_hand.last() {
             ClientAction::Discard { tile: Some(tile) }
@@ -641,6 +648,13 @@ mod tests {
 
         assert!(CpuLevel::Weak.should_make_mistake());
         assert!(!CpuLevel::Normal.should_make_mistake());
+    }
+
+    #[test]
+    fn test_level_ordering() {
+        // 定石の「弱以上」「中以上」判定はこの順序に依存する
+        assert!(CpuLevel::Weak < CpuLevel::Normal);
+        assert!(CpuLevel::Normal < CpuLevel::Strong);
     }
 
     #[test]

--- a/crates/mahjong-server/src/cpu/evaluator.rs
+++ b/crates/mahjong-server/src/cpu/evaluator.rs
@@ -9,6 +9,7 @@ use mahjong_core::tile::{Tile, TileType, Wind, dora_indicator_to_dora};
 
 use super::client::CpuConfig;
 use super::defense;
+use super::heuristics::{self, DiscardContext};
 use super::state::CpuGameState;
 
 /// 牌1枚を捨てた場合の評価
@@ -193,10 +194,17 @@ pub fn select_best_discard(
     candidates: &[DiscardCandidate],
     config: &CpuConfig,
     attacking: bool,
+    state: &CpuGameState,
 ) -> Option<Tile> {
     if candidates.is_empty() {
         return None;
     }
+
+    let ctx = DiscardContext {
+        state,
+        config,
+        attacking,
+    };
 
     let params = &config.params;
     let mut scored: Vec<(usize, f64)> = candidates
@@ -218,6 +226,9 @@ pub fn select_best_discard(
             if !attacking {
                 score += c.safety * params.retreat_threshold * 50.0;
             }
+
+            // 定石による補正（レベルに応じて有効な定石のみ適用される）
+            score += heuristics::discard_adjustment(&ctx, c);
 
             (i, score)
         })
@@ -500,7 +511,8 @@ mod tests {
 
     #[test]
     fn test_select_best_discard_empty() {
-        assert!(select_best_discard(&[], &normal_config(), true).is_none());
+        let state = CpuGameState::new();
+        assert!(select_best_discard(&[], &normal_config(), true, &state).is_none());
     }
 
     fn make_candidate(tile_type: u32, shanten_val: i32, safety: f64) -> DiscardCandidate {
@@ -523,8 +535,9 @@ mod tests {
 
     #[test]
     fn test_select_best_discard_single_candidate() {
+        let state = CpuGameState::new();
         let c = make_candidate(Tile::Z1, 1, 0.5);
-        let result = select_best_discard(&[c], &normal_config(), true);
+        let result = select_best_discard(&[c], &normal_config(), true, &state);
         assert!(result.is_some());
         assert_eq!(result.unwrap().get(), Tile::Z1);
     }
@@ -552,7 +565,7 @@ mod tests {
         state.my_drawn = Some(Tile::new(Tile::Z2));
         let candidates = evaluate_discards(&state, &weak_config());
         // Z1 か Z2 を捨てたときがテンパイ（shanten=0）になるはず
-        let result = select_best_discard(&candidates, &normal_config(), true);
+        let result = select_best_discard(&candidates, &normal_config(), true, &state);
         assert!(result.is_some());
         let best = result.unwrap();
         // Z1 か Z2 を選ぶ（字牌を捨ててテンパイ）
@@ -597,7 +610,7 @@ mod tests {
             safety: 1.0,
         };
         // 守備モードでは安全な牌を選ぶ
-        let result = select_best_discard(&[dangerous, safe], &normal_config(), false);
+        let result = select_best_discard(&[dangerous, safe], &normal_config(), false, &state);
         assert_eq!(result.unwrap().get(), Tile::Z3);
     }
 }

--- a/crates/mahjong-server/src/cpu/heuristics.rs
+++ b/crates/mahjong-server/src/cpu/heuristics.rs
@@ -1,0 +1,194 @@
+//! 定石（heuristics）フレームワーク
+//!
+//! 人間らしい打牌判断の定石を「打牌候補へのスコア補正」として表現し、
+//! CPU の強さレベルに応じて有効な定石だけを適用する（issue #142）。
+//!
+//! 個々の定石は `DiscardHeuristic` として定義し、`DISCARD_HEURISTICS` に
+//! 登録する。定石をハードコードの分岐で書かないことで、
+//! レベルごとの有効/無効切り替えと定石単位のテストを可能にする。
+
+use super::client::{CpuConfig, CpuLevel};
+use super::evaluator::DiscardCandidate;
+use super::state::CpuGameState;
+
+/// 打牌補正を計算する際の局面コンテキスト
+pub struct DiscardContext<'a> {
+    /// CPU が観測しているゲーム状態
+    pub state: &'a CpuGameState,
+    /// CPU 設定
+    pub config: &'a CpuConfig,
+    /// 攻撃継続中か（false なら守備優先）
+    pub attacking: bool,
+}
+
+/// 定石1つの定義
+///
+/// `apply` は「この牌を捨てる」ことの良さに対する補正値を返す。
+/// 正の値はその牌を切りやすく、負の値は切りにくくする。
+/// スケールは `select_best_discard` の基本スコア（向聴数1段階 = 100.0）に合わせる。
+pub struct DiscardHeuristic {
+    /// 定石名（ログ・テスト用）
+    pub name: &'static str,
+    /// この定石が有効になる最低レベル
+    pub min_level: CpuLevel,
+    /// 補正関数
+    pub apply: fn(&DiscardContext, &DiscardCandidate) -> f64,
+}
+
+/// 打牌定石のレジストリ
+///
+/// issue #142 の定石を後続の変更でここに追加していく。
+/// 補正は合算されるため、登録順は結果に影響しない。
+pub const DISCARD_HEURISTICS: &[DiscardHeuristic] = &[];
+
+/// 打牌候補1つに対して、有効な全定石の補正値を合算する
+pub fn discard_adjustment(ctx: &DiscardContext, candidate: &DiscardCandidate) -> f64 {
+    discard_adjustment_with(DISCARD_HEURISTICS, ctx, candidate)
+}
+
+/// レジストリを指定して補正値を合算する
+///
+/// レベルが `min_level` 未満の定石は適用しない。
+fn discard_adjustment_with(
+    heuristics: &[DiscardHeuristic],
+    ctx: &DiscardContext,
+    candidate: &DiscardCandidate,
+) -> f64 {
+    heuristics
+        .iter()
+        .filter(|h| ctx.config.level >= h.min_level)
+        .map(|h| (h.apply)(ctx, candidate))
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mahjong_core::hand::Hand;
+    use mahjong_core::hand_info::hand_analyzer::calc_shanten_number;
+    use mahjong_core::tile::Tile;
+
+    use crate::cpu::client::CpuPersonality;
+
+    fn make_candidate(tile_type: u32) -> DiscardCandidate {
+        let hand = Hand::new(vec![Tile::new(tile_type)], None);
+        DiscardCandidate {
+            tile: Tile::new(tile_type),
+            shanten: calc_shanten_number(&hand),
+            acceptance_count: 0,
+            estimated_value: 0.0,
+            safety: 0.5,
+        }
+    }
+
+    fn fixed_bonus_heuristic(
+        name: &'static str,
+        min_level: CpuLevel,
+        apply: fn(&DiscardContext, &DiscardCandidate) -> f64,
+    ) -> DiscardHeuristic {
+        DiscardHeuristic {
+            name,
+            min_level,
+            apply,
+        }
+    }
+
+    #[test]
+    fn test_empty_registry_returns_zero() {
+        let state = CpuGameState::new();
+        let config = CpuConfig::new(CpuLevel::Strong, CpuPersonality::Balanced);
+        let ctx = DiscardContext {
+            state: &state,
+            config: &config,
+            attacking: true,
+        };
+        let candidate = make_candidate(Tile::M1);
+        assert_eq!(discard_adjustment(&ctx, &candidate), 0.0);
+    }
+
+    #[test]
+    fn test_level_gating() {
+        let heuristics = [
+            fixed_bonus_heuristic("weak-rule", CpuLevel::Weak, |_, _| 1.0),
+            fixed_bonus_heuristic("normal-rule", CpuLevel::Normal, |_, _| 10.0),
+            fixed_bonus_heuristic("strong-rule", CpuLevel::Strong, |_, _| 100.0),
+        ];
+        let state = CpuGameState::new();
+        let candidate = make_candidate(Tile::M1);
+
+        // Weak: 弱以上の定石のみ
+        let config = CpuConfig::new(CpuLevel::Weak, CpuPersonality::Balanced);
+        let ctx = DiscardContext {
+            state: &state,
+            config: &config,
+            attacking: true,
+        };
+        assert_eq!(discard_adjustment_with(&heuristics, &ctx, &candidate), 1.0);
+
+        // Normal: 弱以上 + 中以上
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = DiscardContext {
+            state: &state,
+            config: &config,
+            attacking: true,
+        };
+        assert_eq!(discard_adjustment_with(&heuristics, &ctx, &candidate), 11.0);
+
+        // Strong: 全て
+        let config = CpuConfig::new(CpuLevel::Strong, CpuPersonality::Balanced);
+        let ctx = DiscardContext {
+            state: &state,
+            config: &config,
+            attacking: true,
+        };
+        assert_eq!(
+            discard_adjustment_with(&heuristics, &ctx, &candidate),
+            111.0
+        );
+    }
+
+    #[test]
+    fn test_heuristic_can_reference_candidate_and_context() {
+        // 候補とコンテキストの両方を参照する定石が書けることを確認する
+        let heuristics = [fixed_bonus_heuristic(
+            "honor-in-defense",
+            CpuLevel::Weak,
+            |ctx, c| {
+                if !ctx.attacking && c.tile.get() >= 27 {
+                    50.0
+                } else {
+                    0.0
+                }
+            },
+        )];
+        let state = CpuGameState::new();
+        let config = CpuConfig::new(CpuLevel::Weak, CpuPersonality::Balanced);
+
+        let honor = make_candidate(Tile::Z1);
+        let number = make_candidate(Tile::M5);
+
+        let defending = DiscardContext {
+            state: &state,
+            config: &config,
+            attacking: false,
+        };
+        assert_eq!(
+            discard_adjustment_with(&heuristics, &defending, &honor),
+            50.0
+        );
+        assert_eq!(
+            discard_adjustment_with(&heuristics, &defending, &number),
+            0.0
+        );
+
+        let attacking = DiscardContext {
+            state: &state,
+            config: &config,
+            attacking: true,
+        };
+        assert_eq!(
+            discard_adjustment_with(&heuristics, &attacking, &honor),
+            0.0
+        );
+    }
+}

--- a/crates/mahjong-server/src/cpu/mod.rs
+++ b/crates/mahjong-server/src/cpu/mod.rs
@@ -6,5 +6,6 @@
 pub mod client;
 pub mod defense;
 pub mod evaluator;
+pub mod heuristics;
 pub mod personalities;
 pub mod state;

--- a/crates/mahjong-server/src/cpu/state.rs
+++ b/crates/mahjong-server/src/cpu/state.rs
@@ -46,6 +46,8 @@ pub struct CpuGameState {
     pub prevailing_wind: Wind,
     /// 山の残り枚数
     pub remaining_tiles: usize,
+    /// 局番号（東1局=0, 東2局=1, ...）
+    pub round_number: usize,
     /// 本場数
     pub honba: usize,
     /// 供託リーチ棒
@@ -83,6 +85,7 @@ impl CpuGameState {
             dora_indicators: Vec::new(),
             prevailing_wind: Wind::East,
             remaining_tiles: 0,
+            round_number: 0,
             honba: 0,
             riichi_sticks: 0,
             pending_calls: Vec::new(),
@@ -111,6 +114,7 @@ impl CpuGameState {
                 scores,
                 prevailing_wind,
                 dora_indicators,
+                round_number,
                 honba,
                 riichi_sticks,
                 ..
@@ -131,6 +135,7 @@ impl CpuGameState {
                 self.dora_indicators = dora_indicators.clone();
                 self.prevailing_wind = *prevailing_wind;
                 self.remaining_tiles = 70; // 136 - 14(王牌) - 13*4(配牌) = 70
+                self.round_number = *round_number;
                 self.honba = *honba;
                 self.riichi_sticks = *riichi_sticks;
                 self.pending_calls.clear();
@@ -296,6 +301,18 @@ impl CpuGameState {
         }
     }
 
+    /// 自分の捨て牌を返す
+    pub fn my_discards(&self) -> &[Tile] {
+        &self.all_discards[Self::wind_to_index(self.my_seat_wind)]
+    }
+
+    /// 現在の巡目（1始まり）を返す
+    ///
+    /// 自分の捨て牌の数から導出する。打牌前に呼べば「これから何巡目の打牌か」になる。
+    pub fn turn(&self) -> usize {
+        self.my_discards().len() + 1
+    }
+
     /// 場に見えている牌の枚数を種類ごとにカウントする
     /// （自分の手牌 + 全員の捨て牌 + 全員の副露）
     pub fn visible_tile_counts(&self) -> [u8; 34] {
@@ -391,6 +408,7 @@ mod tests {
         assert_eq!(state.scores, [25000; 4]);
         assert_eq!(state.prevailing_wind, Wind::East);
         assert_eq!(state.dora_indicators.len(), 1);
+        assert_eq!(state.round_number, 0);
     }
 
     #[test]
@@ -416,6 +434,7 @@ mod tests {
         state.dora_indicators = vec![Tile::new(Tile::P9)];
         state.prevailing_wind = Wind::South;
         state.remaining_tiles = 12;
+        state.round_number = 9;
         state.honba = 3;
         state.riichi_sticks = 2;
         state.pending_calls = vec![AvailableCall::Ron];
@@ -450,6 +469,7 @@ mod tests {
         assert_eq!(state.dora_indicators, vec![Tile::new(Tile::Z1)]);
         assert_eq!(state.prevailing_wind, Wind::East);
         assert_eq!(state.remaining_tiles, 70);
+        assert_eq!(state.round_number, 4);
         assert_eq!(state.honba, 1);
         assert_eq!(state.riichi_sticks, 1);
         assert!(state.pending_calls.is_empty());
@@ -768,6 +788,33 @@ mod tests {
         assert_eq!(state.scores, [25000, 26000, 24000, 25000]);
         assert_eq!(state.pending_calls.len(), 1);
         assert_eq!(state.pending_call_tile, Some(Tile::new(Tile::Z1)));
+    }
+
+    #[test]
+    fn test_turn_and_my_discards() {
+        let mut state = CpuGameState::new();
+        state.my_seat_wind = Wind::South;
+
+        // 配牌直後は1巡目
+        assert_eq!(state.turn(), 1);
+        assert!(state.my_discards().is_empty());
+
+        // 他家の捨て牌は巡目に影響しない
+        state.update(&ServerEvent::TileDiscarded {
+            player: Wind::East,
+            tile: Tile::new(Tile::M1),
+            is_tsumogiri: false,
+        });
+        assert_eq!(state.turn(), 1);
+
+        // 自分が捨てると巡目が進む
+        state.update(&ServerEvent::TileDiscarded {
+            player: Wind::South,
+            tile: Tile::new(Tile::P5),
+            is_tsumogiri: true,
+        });
+        assert_eq!(state.turn(), 2);
+        assert_eq!(state.my_discards(), &[Tile::new(Tile::P5)]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Foundation work for #142 (implementing human-like play conventions in the CPU AI). This PR introduces the framework only — **no behavior change**: the heuristics registry is empty, so all existing CPU decisions remain identical. Individual conventions will be added on top of this in follow-up PRs.

## Changes

### mahjong-core
- Add `calc_shanten_number_by_form()`: fast per-form shanten calculation (normal / seven pairs / thirteen orphans) without block decomposition. Needed for upcoming route-comparison heuristics (chiitoitsu vs. normal form, kokushi recognition).
- Derive `Clone, Copy` for `Form` (fieldless enum).

### mahjong-server
- New `cpu/heuristics.rs`: each convention is expressed as a `DiscardHeuristic` — a score adjustment applied to a discard candidate — registered in `DISCARD_HEURISTICS` and gated by a minimum CPU level. This follows the design note in #142 (evaluation adjustments rather than hardcoded branches, toggleable per CPU strength).
- `CpuLevel` now derives `PartialOrd`/`Ord` (`Weak < Normal < Strong`) for the "弱以上 / 中以上 / 強以上" gating.
- `evaluator::select_best_discard()` takes the game state and adds the summed heuristic adjustment to each candidate's score.
- `CpuGameState`: store `round_number` and expose `turn()` / `my_discards()` for upcoming turn- and standings-aware conventions.

Also includes a one-line fix for a pre-existing `clippy::unnecessary_sort_by` warning in `mahjong-client` (separate commit) so that `cargo clippy` is warning-free again.

## Planned follow-up PRs

1. Call (鳴き) conventions: no yaku-less calls, early yakuhai pon, avoid naked tanki, suppress meaningless kan (#162, #163, #166, #167)
2. Basic tile efficiency + basic defense (#147, #148, #152, #173, #174, #176)
3. Kokushi route recognition (#158, #159, #160)
4. Block theory (#149, #150, #151, #153)
5. Chiitoitsu / toitoi route comparison (#154–#157)
6. Advanced call decisions (#164, #165)
7. Riichi/dama judgment (#168–#172)
8. Threat model extension: melds, flush/yakuman signs (#175, #177, #180–#182)
9. Push/fold and sashikomi avoidance (#161, #178, #179)
10. Endgame + score/standings awareness (#183–#191)

## Test plan

- `cargo build` ✓
- `cargo test` ✓ (481 tests passing; new tests for `calc_shanten_number_by_form`, level gating, heuristic application, `turn()`/`my_discards()`)
- `cargo fmt` / `cargo clippy` ✓ (no warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)