### PR TITLE
Add CPU call conventions: no yaku-less calls, yakuhai pon, kan suppression (#142)

### DIFF
--- a/crates/mahjong-server/src/cpu/client.rs
+++ b/crates/mahjong-server/src/cpu/client.rs
@@ -11,6 +11,7 @@ use mahjong_core::tile::Tile;
 use crate::protocol::{AvailableCall, ClientAction, ServerEvent};
 
 use super::evaluator;
+use super::heuristics;
 use super::state::CpuGameState;
 
 /// CPUの強さレベル
@@ -310,7 +311,7 @@ impl CpuClient {
         }
 
         // 暗カンがある場合も正しく判定できるよう、副露を含めて向聴数を計算する
-        let melds = self.build_existing_melds();
+        let melds = self.state.my_melds_for_analysis();
         let mut best: Option<(Tile, f64)> = None;
 
         for (i, &tile) in all_tiles.iter().enumerate() {
@@ -357,12 +358,22 @@ impl CpuClient {
             counts[tile.get() as usize] += 1;
         }
 
+        let ctx = heuristics::CallContext {
+            state: &self.state,
+            config: &self.config,
+        };
+
         for (tile_type, &count) in counts.iter().enumerate() {
             if count == 4 {
-                // 暗カンしてもテンパイが崩れないか確認
-                // （簡易的に: Strong以外は常にカン、Strongは向聴数を確認）
-                if self.config.level == CpuLevel::Strong {
-                    // 暗カン後の手牌で向聴数を確認（簡易チェック）
+                // 定石判定（中以上）: 手を壊すカン・他家リーチ後のカンを抑制
+                if heuristics::judge_ankan(&ctx, tile_type as u32)
+                    == heuristics::CallJudgement::Forbid
+                {
+                    continue;
+                }
+
+                // 定石無効時の従来動作: Strongのみテンパイ維持を確認
+                if !self.config.heuristics_enabled && self.config.level == CpuLevel::Strong {
                     let remaining: Vec<Tile> = all_tiles
                         .iter()
                         .filter(|t| t.get() != tile_type as u32)
@@ -373,6 +384,7 @@ impl CpuClient {
                         continue; // テンパイが崩れるのでカンしない
                     }
                 }
+
                 return Some(ClientAction::Kan {
                     tile_index: tile_type,
                 });
@@ -442,18 +454,30 @@ impl CpuClient {
             None => return false,
         };
 
-        // Weakレベル: 向聴数が下がるなら常に鳴く
+        // 向聴数が下がらないポンはしない（全レベル共通）
+        if !self.call_reduces_shanten_pon(called_tile) {
+            return false;
+        }
+
+        // 定石判定: 役なし鳴き禁止・裸単騎回避・役牌早ポン
+        // （定石無効時は Neutral が返り、従来の判断に進む）
+        let ctx = heuristics::CallContext {
+            state: &self.state,
+            config: &self.config,
+        };
+        match heuristics::judge_pon(&ctx, called_tile) {
+            heuristics::CallJudgement::Forbid => return false,
+            heuristics::CallJudgement::Encourage => return true,
+            heuristics::CallJudgement::Neutral => {}
+        }
+
+        // Weakレベル: 向聴数が下がるなら鳴く
         if self.config.level == CpuLevel::Weak {
-            return self.call_reduces_shanten_pon(called_tile);
+            return true;
         }
 
         // 鳴き積極度が低ければパス
         if params.call_aggressiveness < 0.3 {
-            return false;
-        }
-
-        // 向聴数が下がるか
-        if !self.call_reduces_shanten_pon(called_tile) {
             return false;
         }
 
@@ -493,10 +517,21 @@ impl CpuClient {
         }
 
         let called_tile = self.state.pending_call_tile?;
+        let ctx = heuristics::CallContext {
+            state: &self.state,
+            config: &self.config,
+        };
 
         // 各選択肢で向聴数が下がるか確認
         for &opt in options {
             if self.call_reduces_shanten_chi(called_tile, opt) {
+                // 定石判定: 役なし鳴き禁止・裸単騎回避
+                match heuristics::judge_chi(&ctx, called_tile, opt) {
+                    heuristics::CallJudgement::Forbid => continue,
+                    heuristics::CallJudgement::Encourage => return Some(opt),
+                    heuristics::CallJudgement::Neutral => {}
+                }
+
                 // Speedy型は積極的にチー
                 if self.config.personality == CpuPersonality::Speedy {
                     return Some(opt);
@@ -509,22 +544,6 @@ impl CpuClient {
         }
 
         None
-    }
-
-    /// 既存の副露を取得する
-    fn build_existing_melds(&self) -> Vec<Meld> {
-        let my_idx = super::state::CpuGameState::wind_to_index(self.state.my_seat_wind);
-        self.state.player_melds[my_idx]
-            .iter()
-            .map(|open| {
-                // 手分析用に3枚に切り詰め
-                let mut o = open.clone();
-                if o.tiles.len() > 3 {
-                    o.tiles.truncate(3);
-                }
-                o
-            })
-            .collect()
     }
 
     /// ポンした場合に向聴数が下がるか
@@ -551,7 +570,7 @@ impl CpuClient {
         }
 
         // 既存の副露 + 今回のポンを含めた Hand を作成
-        let mut melds = self.build_existing_melds();
+        let mut melds = self.state.my_melds_for_analysis();
         melds.push(Meld {
             tiles: vec![called_tile, called_tile, called_tile],
             category: MeldType::Pon,
@@ -580,7 +599,7 @@ impl CpuClient {
         }
 
         // 既存の副露 + 今回のチーを含めた Hand を作成
-        let mut melds = self.build_existing_melds();
+        let mut melds = self.state.my_melds_for_analysis();
         melds.push(Meld {
             tiles: vec![called_tile, chi_tiles_for_meld[0], chi_tiles_for_meld[1]],
             category: MeldType::Chi,
@@ -594,7 +613,7 @@ impl CpuClient {
 }
 
 /// 役牌かどうか判定
-fn is_yakuhai(
+pub(crate) fn is_yakuhai(
     tile_type: u32,
     seat_wind: mahjong_core::tile::Wind,
     prevailing_wind: mahjong_core::tile::Wind,
@@ -1159,6 +1178,256 @@ mod tests {
         });
 
         assert!(matches!(action, Some(ClientAction::Pass)));
+    }
+
+    /// 役なしになる鳴きの機会を作る共通手牌（M9ポンで向聴数は下がるが役がない）
+    ///
+    /// 浮き牌は客風牌（南家にとって役牌でない Z3/Z4）にして、
+    /// 数牌の再分解による意図しない聴牌を防ぐ。
+    fn yakuless_pon_hand() -> Vec<Tile> {
+        vec![
+            Tile::new(Tile::M2),
+            Tile::new(Tile::M3),
+            Tile::new(Tile::M4),
+            Tile::new(Tile::P3),
+            Tile::new(Tile::P4),
+            Tile::new(Tile::P5),
+            Tile::new(Tile::S4),
+            Tile::new(Tile::S5),
+            Tile::new(Tile::S6),
+            Tile::new(Tile::M9),
+            Tile::new(Tile::M9),
+            Tile::new(Tile::Z3),
+            Tile::new(Tile::Z4),
+        ]
+    }
+
+    fn pon_call_event(tile_type: u32) -> ServerEvent {
+        ServerEvent::CallAvailable {
+            tile: Tile::new(tile_type),
+            discarder: Wind::East,
+            calls: vec![AvailableCall::Pon {
+                options: vec![[Tile::new(tile_type), Tile::new(tile_type)]],
+            }],
+        }
+    }
+
+    #[test]
+    fn test_pass_on_yakuless_pon() {
+        // #162: 向聴数が下がっても役の見込みがない鳴きはしない
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let mut client = CpuClient::new(config);
+
+        client.handle_event(&game_started_event(Wind::South, yakuless_pon_hand()));
+        let action = client.handle_event(&pon_call_event(Tile::M9));
+
+        assert!(matches!(action, Some(ClientAction::Pass)));
+    }
+
+    #[test]
+    fn test_yakuless_pon_called_without_heuristics() {
+        // 定石無効時は従来どおり鳴く（A/B比較のベースライン維持）
+        let config =
+            CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced).without_heuristics();
+        let mut client = CpuClient::new(config);
+
+        client.handle_event(&game_started_event(Wind::South, yakuless_pon_hand()));
+        let action = client.handle_event(&pon_call_event(Tile::M9));
+
+        assert!(matches!(action, Some(ClientAction::Pon { .. })));
+    }
+
+    #[test]
+    fn test_weak_level_also_avoids_yakuless_pon() {
+        // #162 は弱以上: Weakレベルでも役なし鳴きはしない
+        let config = CpuConfig::new(CpuLevel::Weak, CpuPersonality::Balanced);
+        let mut client = CpuClient::new(config);
+
+        client.handle_event(&game_started_event(Wind::South, yakuless_pon_hand()));
+        let action = client.handle_event(&pon_call_event(Tile::M9));
+
+        assert!(matches!(action, Some(ClientAction::Pass)));
+    }
+
+    #[test]
+    fn test_high_value_pons_yakuhai() {
+        // #163: 役牌対子のポンは性格（鳴き積極度）によらず行う
+        let hand = vec![
+            Tile::new(Tile::Z5),
+            Tile::new(Tile::Z5),
+            Tile::new(Tile::M2),
+            Tile::new(Tile::M3),
+            Tile::new(Tile::M4),
+            Tile::new(Tile::P4),
+            Tile::new(Tile::P5),
+            Tile::new(Tile::P6),
+            Tile::new(Tile::S2),
+            Tile::new(Tile::S2),
+            Tile::new(Tile::M7),
+            Tile::new(Tile::M8),
+            Tile::new(Tile::S9),
+        ];
+
+        // HighValue は鳴き積極度 0.2 で、従来は役牌すら鳴かなかった
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::HighValue);
+        let mut client = CpuClient::new(config);
+        client.handle_event(&game_started_event(Wind::South, hand.clone()));
+        let action = client.handle_event(&pon_call_event(Tile::Z5));
+        assert!(matches!(action, Some(ClientAction::Pon { .. })));
+
+        // 定石無効時は従来どおりパス
+        let config =
+            CpuConfig::new(CpuLevel::Normal, CpuPersonality::HighValue).without_heuristics();
+        let mut client = CpuClient::new(config);
+        client.handle_event(&game_started_event(Wind::South, hand));
+        let action = client.handle_event(&pon_call_event(Tile::Z5));
+        assert!(matches!(action, Some(ClientAction::Pass)));
+    }
+
+    #[test]
+    fn test_pass_on_pon_leading_to_naked_tanki() {
+        // #166: 4副露目（裸単騎）になるポンはしない
+        let hand = vec![
+            Tile::new(Tile::S3),
+            Tile::new(Tile::S3),
+            Tile::new(Tile::M5),
+            Tile::new(Tile::M9),
+        ];
+        let melds = vec![
+            Meld {
+                tiles: vec![
+                    Tile::new(Tile::M1),
+                    Tile::new(Tile::M2),
+                    Tile::new(Tile::M3),
+                ],
+                category: MeldType::Chi,
+                from: MeldFrom::Previous,
+                called_tile: Some(Tile::new(Tile::M1)),
+            },
+            Meld {
+                tiles: vec![Tile::new(Tile::P5); 3],
+                category: MeldType::Pon,
+                from: MeldFrom::Unknown,
+                called_tile: Some(Tile::new(Tile::P5)),
+            },
+            Meld {
+                tiles: vec![Tile::new(Tile::S9); 3],
+                category: MeldType::Pon,
+                from: MeldFrom::Unknown,
+                called_tile: Some(Tile::new(Tile::S9)),
+            },
+        ];
+
+        // 定石有効: パス
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let mut client = CpuClient::new(config);
+        client.handle_event(&game_started_event(Wind::East, hand.clone()));
+        client.state.player_melds[0] = melds.clone();
+        let action = client.handle_event(&pon_call_event(Tile::S3));
+        assert!(matches!(action, Some(ClientAction::Pass)));
+
+        // 定石無効: 従来どおり鳴く
+        let config =
+            CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced).without_heuristics();
+        let mut client = CpuClient::new(config);
+        client.handle_event(&game_started_event(Wind::East, hand));
+        client.state.player_melds[0] = melds;
+        let action = client.handle_event(&pon_call_event(Tile::S3));
+        assert!(matches!(action, Some(ClientAction::Pon { .. })));
+    }
+
+    #[test]
+    fn test_normal_level_avoids_hand_breaking_ankan() {
+        // #167: 手を壊すカン（向聴数が悪化）は中レベル以上では行わない
+        let hand = vec![
+            Tile::new(Tile::M2),
+            Tile::new(Tile::M3),
+            Tile::new(Tile::M4),
+            Tile::new(Tile::P2),
+            Tile::new(Tile::P3),
+            Tile::new(Tile::P4),
+            Tile::new(Tile::S4),
+            Tile::new(Tile::S5),
+            Tile::new(Tile::S5),
+            Tile::new(Tile::S5),
+            Tile::new(Tile::S6),
+            Tile::new(Tile::Z1),
+            Tile::new(Tile::Z3),
+        ];
+        let draw_event = ServerEvent::TileDrawn {
+            tile: Tile::new(Tile::S5),
+            remaining_tiles: 40,
+            can_tsumo: false,
+            can_riichi: false,
+            is_furiten: false,
+        };
+
+        // 定石有効: S5×4 は S456+S555 に使われているのでカンせず打牌
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let mut client = CpuClient::new(config);
+        client.handle_event(&game_started_event(Wind::East, hand.clone()));
+        let action = client.handle_event(&draw_event);
+        assert!(
+            matches!(action, Some(ClientAction::Discard { .. })),
+            "expected discard instead of hand-breaking kan, got {action:?}"
+        );
+
+        // 定石無効: 従来の Normal はカンしてしまう
+        let config =
+            CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced).without_heuristics();
+        let mut client = CpuClient::new(config);
+        client.handle_event(&game_started_event(Wind::East, hand));
+        let action = client.handle_event(&draw_event);
+        assert!(matches!(action, Some(ClientAction::Kan { .. })));
+    }
+
+    #[test]
+    fn test_ankan_suppressed_during_opponent_riichi() {
+        // #167: 他家リーチ中、聴牌維持にならないカンはしない
+        let hand = vec![
+            Tile::new(Tile::M2),
+            Tile::new(Tile::M3),
+            Tile::new(Tile::M4),
+            Tile::new(Tile::M6),
+            Tile::new(Tile::M7),
+            Tile::new(Tile::S3),
+            Tile::new(Tile::S3),
+            Tile::new(Tile::P2),
+            Tile::new(Tile::P2),
+            Tile::new(Tile::P2),
+            Tile::new(Tile::P2),
+            Tile::new(Tile::Z1),
+            Tile::new(Tile::Z2),
+        ];
+        let draw_event = ServerEvent::TileDrawn {
+            tile: Tile::new(Tile::M5),
+            remaining_tiles: 40,
+            can_tsumo: false,
+            can_riichi: false,
+            is_furiten: false,
+        };
+
+        // リーチなし: 向聴数を保つカンなので実行する
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let mut client = CpuClient::new(config);
+        client.handle_event(&game_started_event(Wind::East, hand.clone()));
+        let action = client.handle_event(&draw_event);
+        assert!(matches!(action, Some(ClientAction::Kan { .. })));
+
+        // 他家リーチあり: カン後も聴牌しないのでカンしない
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let mut client = CpuClient::new(config);
+        client.handle_event(&game_started_event(Wind::East, hand));
+        client.handle_event(&ServerEvent::PlayerRiichi {
+            player: Wind::West,
+            scores: [25000, 25000, 24000, 25000],
+            riichi_sticks: 1,
+        });
+        let action = client.handle_event(&draw_event);
+        assert!(
+            matches!(action, Some(ClientAction::Discard { .. })),
+            "expected discard instead of kan during opponent riichi, got {action:?}"
+        );
     }
 
     #[test]

--- a/crates/mahjong-server/src/cpu/evaluator.rs
+++ b/crates/mahjong-server/src/cpu/evaluator.rs
@@ -162,7 +162,7 @@ fn count_dora_in_hand(hand_tiles: &[Tile], dora_indicators: &[Tile]) -> u32 {
 }
 
 /// 役牌となる牌種のリストを返す
-fn get_yakuhai_types(seat_wind: Wind, prevailing_wind: Wind) -> Vec<TileType> {
+pub(crate) fn get_yakuhai_types(seat_wind: Wind, prevailing_wind: Wind) -> Vec<TileType> {
     use mahjong_core::tile::Tile as T;
     let mut types = vec![T::Z5, T::Z6, T::Z7]; // 白發中
 

--- a/crates/mahjong-server/src/cpu/heuristics.rs
+++ b/crates/mahjong-server/src/cpu/heuristics.rs
@@ -7,8 +7,13 @@
 //! 登録する。定石をハードコードの分岐で書かないことで、
 //! レベルごとの有効/無効切り替えと定石単位のテストを可能にする。
 
-use super::client::{CpuConfig, CpuLevel};
-use super::evaluator::DiscardCandidate;
+use mahjong_core::hand::Hand;
+use mahjong_core::hand_info::hand_analyzer::calc_shanten_number;
+use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
+use mahjong_core::tile::{Tile, TileType, Wind};
+
+use super::client::{CpuConfig, CpuLevel, is_yakuhai};
+use super::evaluator::{DiscardCandidate, get_yakuhai_types};
 use super::state::CpuGameState;
 
 /// 打牌補正を計算する際の局面コンテキスト
@@ -63,6 +68,293 @@ fn discard_adjustment_with(
         .filter(|h| ctx.config.level >= h.min_level)
         .map(|h| (h.apply)(ctx, candidate))
         .sum()
+}
+
+// ============================================================================
+// 鳴き判断の定石
+//
+// 打牌定石（スコア補正の合算）と異なり、鳴きは個別の意思決定なので
+// 「禁止 / 推奨 / 中立」の三値判定で表現する。禁止は推奨より優先される。
+// ============================================================================
+
+/// 鳴き判断の文脈
+pub struct CallContext<'a> {
+    /// CPU が観測しているゲーム状態
+    pub state: &'a CpuGameState,
+    /// CPU 設定
+    pub config: &'a CpuConfig,
+}
+
+/// 鳴き・カンに対する定石の判定結果
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallJudgement {
+    /// 定石上、鳴くべきでない
+    Forbid,
+    /// 定石上、積極的に鳴くべき（性格・積極度の判断を上書きする）
+    Encourage,
+    /// 定石は関与しない（既存の性格・積極度判断に委ねる）
+    Neutral,
+}
+
+/// ポンに対する定石判定
+///
+/// 適用される定石:
+/// - 裸単騎回避（#166, 弱以上）: 4副露目になる鳴きはしない
+/// - 役なし鳴き禁止（#162, 弱以上）: 鳴いた後に役の見込みがなければ鳴かない
+/// - 役牌対子は早めにポン（#163, 弱以上）: 役牌のポンは性格によらず推奨
+///
+/// 呼び出し元で「向聴数が下がること」は確認済みである前提。
+pub fn judge_pon(ctx: &CallContext, called_tile: Tile) -> CallJudgement {
+    if !ctx.config.heuristics_enabled {
+        return CallJudgement::Neutral;
+    }
+
+    // 裸単騎回避（弱以上）
+    if ctx.state.my_melds().len() >= 3 {
+        return CallJudgement::Forbid;
+    }
+
+    // 役なし鳴き禁止（弱以上）
+    if let Some((hand_after, melds_after)) = hand_after_pon(ctx.state, called_tile)
+        && !has_yaku_prospect(
+            &hand_after,
+            &melds_after,
+            ctx.state.my_seat_wind,
+            ctx.state.prevailing_wind,
+        )
+    {
+        return CallJudgement::Forbid;
+    }
+
+    // 役牌対子は早めにポン（弱以上）
+    if is_yakuhai(
+        called_tile.get(),
+        ctx.state.my_seat_wind,
+        ctx.state.prevailing_wind,
+    ) {
+        return CallJudgement::Encourage;
+    }
+
+    CallJudgement::Neutral
+}
+
+/// チーに対する定石判定
+///
+/// 適用される定石:
+/// - 裸単騎回避（#166, 弱以上）
+/// - 役なし鳴き禁止（#162, 弱以上）
+///
+/// 呼び出し元で「向聴数が下がること」は確認済みである前提。
+pub fn judge_chi(ctx: &CallContext, called_tile: Tile, hand_tiles: [Tile; 2]) -> CallJudgement {
+    if !ctx.config.heuristics_enabled {
+        return CallJudgement::Neutral;
+    }
+
+    // 裸単騎回避（弱以上）
+    if ctx.state.my_melds().len() >= 3 {
+        return CallJudgement::Forbid;
+    }
+
+    // 役なし鳴き禁止（弱以上）
+    if let Some((hand_after, melds_after)) = hand_after_chi(ctx.state, called_tile, hand_tiles)
+        && !has_yaku_prospect(
+            &hand_after,
+            &melds_after,
+            ctx.state.my_seat_wind,
+            ctx.state.prevailing_wind,
+        )
+    {
+        return CallJudgement::Forbid;
+    }
+
+    CallJudgement::Neutral
+}
+
+/// 暗カンに対する定石判定（#167, 中以上）
+///
+/// - 向聴数が悪化するカン（手を壊すカン）はしない
+/// - 他家リーチ中は、カン後も聴牌している場合を除きカンしない
+///   （新ドラで相手の打点を上げるリスクを評価する）
+pub fn judge_ankan(ctx: &CallContext, tile_type: TileType) -> CallJudgement {
+    if !ctx.config.heuristics_enabled || ctx.config.level < CpuLevel::Normal {
+        return CallJudgement::Neutral;
+    }
+
+    let mut all_tiles = ctx.state.my_hand.clone();
+    if let Some(drawn) = ctx.state.my_drawn {
+        all_tiles.push(drawn);
+    }
+
+    let melds = ctx.state.my_melds_for_analysis();
+
+    // カン前の向聴数
+    let before_hand = Hand::new_with_melds(all_tiles.clone(), melds.clone(), None);
+    let before = calc_shanten_number(&before_hand);
+
+    // カン後の向聴数（対象の4枚を除き、カンを面子として加える）
+    let remaining: Vec<Tile> = all_tiles
+        .iter()
+        .filter(|t| t.get() != tile_type)
+        .copied()
+        .collect();
+    let mut melds_after = melds;
+    melds_after.push(Meld {
+        tiles: vec![Tile::new(tile_type); 3],
+        category: MeldType::Kan,
+        from: MeldFrom::Myself,
+        called_tile: None,
+    });
+    let after_hand = Hand::new_with_melds(remaining, melds_after, None);
+    let after = calc_shanten_number(&after_hand);
+
+    // 手を壊すカンはしない
+    if after > before {
+        return CallJudgement::Forbid;
+    }
+
+    // 他家リーチ中は聴牌維持できる場合のみカンする
+    let my_idx = CpuGameState::wind_to_index(ctx.state.my_seat_wind);
+    let opponent_riichi = ctx
+        .state
+        .player_riichi
+        .iter()
+        .enumerate()
+        .any(|(i, &r)| i != my_idx && r);
+    if opponent_riichi && !after.is_ready_or_won() {
+        return CallJudgement::Forbid;
+    }
+
+    CallJudgement::Neutral
+}
+
+/// ポンした後の手牌と副露を構築する
+///
+/// 手牌に同種の牌が2枚なければ `None`。
+fn hand_after_pon(state: &CpuGameState, called_tile: Tile) -> Option<(Vec<Tile>, Vec<Meld>)> {
+    let tt = called_tile.get();
+    let mut remaining = state.my_hand.clone();
+    let mut removed = 0;
+    remaining.retain(|t| {
+        if t.get() == tt && removed < 2 {
+            removed += 1;
+            false
+        } else {
+            true
+        }
+    });
+    if removed < 2 {
+        return None;
+    }
+
+    let mut melds = state.my_melds_for_analysis();
+    melds.push(Meld {
+        tiles: vec![called_tile, called_tile, called_tile],
+        category: MeldType::Pon,
+        from: MeldFrom::Unknown,
+        called_tile: Some(called_tile),
+    });
+    Some((remaining, melds))
+}
+
+/// チーした後の手牌と副露を構築する
+///
+/// 指定の2枚が手牌になければ `None`。
+fn hand_after_chi(
+    state: &CpuGameState,
+    called_tile: Tile,
+    hand_tiles: [Tile; 2],
+) -> Option<(Vec<Tile>, Vec<Meld>)> {
+    let mut remaining = state.my_hand.clone();
+    let mut chi_tiles = Vec::new();
+    for &target in &hand_tiles {
+        let pos = remaining.iter().position(|t| *t == target)?;
+        chi_tiles.push(remaining.remove(pos));
+    }
+
+    let mut melds = state.my_melds_for_analysis();
+    melds.push(Meld {
+        tiles: vec![called_tile, chi_tiles[0], chi_tiles[1]],
+        category: MeldType::Chi,
+        from: MeldFrom::Previous,
+        called_tile: Some(called_tile),
+    });
+    Some((remaining, melds))
+}
+
+/// 鳴いた後の手に和了役の見込みがあるか（簡易判定）
+///
+/// 副露した手で成立しうる代表的な役の見込みを判定する（#162）:
+/// - 役牌: 手牌+副露に役牌が2枚以上ある
+/// - 断么九: 副露が全て中張牌で、手牌の么九牌が3枚以下（切って移行できる）
+/// - 混一色/清一色: 数牌が1色に収まっている
+/// - 対々和: 副露が全て刻子系で、手牌の浮き牌が2種以下
+///
+/// チャンタ系などの稀な役は考慮しない（見込みなしと誤判定しても
+/// 「鳴かない」側に倒れるだけで安全）。
+pub fn has_yaku_prospect(
+    hand_tiles: &[Tile],
+    melds: &[Meld],
+    seat_wind: Wind,
+    prevailing_wind: Wind,
+) -> bool {
+    // 手牌 + 副露の牌種ごとの枚数
+    let mut counts = [0u8; 34];
+    for t in hand_tiles {
+        counts[t.get() as usize] += 1;
+    }
+    for meld in melds {
+        for t in &meld.tiles {
+            counts[t.get() as usize] += 1;
+        }
+    }
+
+    // 役牌: 対子以上があれば刻子にできる見込みがある
+    for yh in get_yakuhai_types(seat_wind, prevailing_wind) {
+        if counts[yh as usize] >= 2 {
+            return true;
+        }
+    }
+
+    // 断么九: 副露が全て中張牌で、手牌の么九牌が少ない
+    let melds_all_simple = melds
+        .iter()
+        .all(|m| m.tiles.iter().all(|t| !t.is_1_9_honor()));
+    if melds_all_simple {
+        let terminal_honor_count = hand_tiles.iter().filter(|t| t.is_1_9_honor()).count();
+        if terminal_honor_count <= 3 {
+            return true;
+        }
+    }
+
+    // 混一色/清一色/字一色: 数牌が1色以下に収まっている
+    let mut suits_used = [false; 3];
+    for (tile_type, &count) in counts.iter().enumerate().take(27) {
+        if count > 0 {
+            suits_used[tile_type / 9] = true;
+        }
+    }
+    if suits_used.iter().filter(|&&u| u).count() <= 1 {
+        return true;
+    }
+
+    // 対々和: 副露が全て刻子系で、手牌が対子・刻子中心
+    let melds_all_triplets = melds
+        .iter()
+        .all(|m| matches!(m.category, MeldType::Pon | MeldType::Kan | MeldType::Kakan));
+    if melds_all_triplets && !melds.is_empty() {
+        let hand_singles = {
+            let mut hand_counts = [0u8; 34];
+            for t in hand_tiles {
+                hand_counts[t.get() as usize] += 1;
+            }
+            hand_counts.iter().filter(|&&c| c == 1).count()
+        };
+        if hand_singles <= 2 {
+            return true;
+        }
+    }
+
+    false
 }
 
 #[cfg(test)]
@@ -169,6 +461,360 @@ mod tests {
         };
         let candidate = make_candidate(Tile::M1);
         assert_eq!(discard_adjustment_with(&heuristics, &ctx, &candidate), 0.0);
+    }
+
+    // --- has_yaku_prospect ---
+
+    fn tiles(types: &[u32]) -> Vec<Tile> {
+        types.iter().map(|&t| Tile::new(t)).collect()
+    }
+
+    fn pon_meld(tile_type: u32) -> Meld {
+        Meld {
+            tiles: vec![Tile::new(tile_type); 3],
+            category: MeldType::Pon,
+            from: MeldFrom::Unknown,
+            called_tile: Some(Tile::new(tile_type)),
+        }
+    }
+
+    fn chi_meld(start: u32) -> Meld {
+        Meld {
+            tiles: vec![Tile::new(start), Tile::new(start + 1), Tile::new(start + 2)],
+            category: MeldType::Chi,
+            from: MeldFrom::Previous,
+            called_tile: Some(Tile::new(start)),
+        }
+    }
+
+    #[test]
+    fn test_yaku_prospect_yakuhai_pair() {
+        // 白の対子があれば役牌の見込みあり
+        let hand = tiles(&[Tile::Z5, Tile::Z5, Tile::M1, Tile::M9, Tile::P1, Tile::S9]);
+        let melds = vec![chi_meld(Tile::P2)];
+        assert!(has_yaku_prospect(&hand, &melds, Wind::East, Wind::East));
+    }
+
+    #[test]
+    fn test_yaku_prospect_tanyao() {
+        // 副露も手牌も中張牌中心なら断么九の見込みあり
+        let hand = tiles(&[Tile::M2, Tile::M3, Tile::P4, Tile::P5, Tile::S6, Tile::M9]);
+        let melds = vec![chi_meld(Tile::S2)];
+        assert!(has_yaku_prospect(&hand, &melds, Wind::East, Wind::East));
+    }
+
+    #[test]
+    fn test_yaku_prospect_honitsu() {
+        // 萬子+字牌のみなら混一色の見込みあり
+        let hand = tiles(&[Tile::M1, Tile::M2, Tile::M3, Tile::M7, Tile::Z2, Tile::Z3]);
+        let melds = vec![chi_meld(Tile::M4)];
+        assert!(has_yaku_prospect(&hand, &melds, Wind::East, Wind::East));
+    }
+
+    #[test]
+    fn test_yaku_prospect_toitoi() {
+        // 副露が全て刻子で手牌が対子中心なら対々和の見込みあり
+        let hand = tiles(&[Tile::M9, Tile::M9, Tile::P1, Tile::P1, Tile::S9]);
+        let melds = vec![pon_meld(Tile::M1), pon_meld(Tile::S1)];
+        assert!(has_yaku_prospect(&hand, &melds, Wind::East, Wind::East));
+    }
+
+    #[test]
+    fn test_yaku_prospect_none_for_junk_hand() {
+        // 3色バラバラ + 么九牌副露 + 役牌なし → 見込みなし
+        let hand = tiles(&[
+            Tile::M2,
+            Tile::M3,
+            Tile::M4,
+            Tile::P3,
+            Tile::P4,
+            Tile::P5,
+            Tile::S4,
+            Tile::S5,
+            Tile::S6,
+            Tile::S2,
+            Tile::S7,
+        ]);
+        let melds = vec![pon_meld(Tile::M9)];
+        assert!(!has_yaku_prospect(&hand, &melds, Wind::East, Wind::East));
+    }
+
+    // --- judge_pon ---
+
+    fn call_state_with_hand(hand: Vec<Tile>) -> CpuGameState {
+        let mut state = CpuGameState::new();
+        state.my_hand = hand;
+        state
+    }
+
+    #[test]
+    fn test_judge_pon_forbids_yakuless_call() {
+        // 3面子完成 + M9対子: M9ポンは向聴数を下げるが役の見込みがない
+        let state = call_state_with_hand(tiles(&[
+            Tile::M2,
+            Tile::M3,
+            Tile::M4,
+            Tile::P3,
+            Tile::P4,
+            Tile::P5,
+            Tile::S4,
+            Tile::S5,
+            Tile::S6,
+            Tile::M9,
+            Tile::M9,
+            Tile::S2,
+            Tile::S7,
+        ]));
+        let config = CpuConfig::new(CpuLevel::Weak, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_pon(&ctx, Tile::new(Tile::M9)), CallJudgement::Forbid);
+    }
+
+    #[test]
+    fn test_judge_pon_forbids_fourth_meld() {
+        // 既に3副露 → 裸単騎になるポンは禁止
+        let mut state = call_state_with_hand(tiles(&[Tile::S3, Tile::S3, Tile::M5, Tile::M9]));
+        state.player_melds[0] = vec![chi_meld(Tile::M1), pon_meld(Tile::P5), pon_meld(Tile::S9)];
+        let config = CpuConfig::new(CpuLevel::Weak, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_pon(&ctx, Tile::new(Tile::S3)), CallJudgement::Forbid);
+    }
+
+    #[test]
+    fn test_judge_pon_encourages_yakuhai() {
+        // 白対子のポンは推奨
+        let state = call_state_with_hand(tiles(&[
+            Tile::Z5,
+            Tile::Z5,
+            Tile::M2,
+            Tile::M3,
+            Tile::M4,
+            Tile::P4,
+            Tile::P5,
+            Tile::P6,
+            Tile::S2,
+            Tile::S2,
+            Tile::M7,
+            Tile::M8,
+            Tile::S9,
+        ]));
+        let config = CpuConfig::new(CpuLevel::Weak, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(
+            judge_pon(&ctx, Tile::new(Tile::Z5)),
+            CallJudgement::Encourage
+        );
+    }
+
+    #[test]
+    fn test_judge_pon_neutral_for_tanyao_call() {
+        // 中張牌中心の手の中張牌ポンは中立（性格判断に委ねる）
+        let state = call_state_with_hand(tiles(&[
+            Tile::M2,
+            Tile::M3,
+            Tile::M4,
+            Tile::P3,
+            Tile::P4,
+            Tile::P5,
+            Tile::S4,
+            Tile::S5,
+            Tile::S6,
+            Tile::S3,
+            Tile::S3,
+            Tile::M5,
+            Tile::M6,
+        ]));
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_pon(&ctx, Tile::new(Tile::S3)), CallJudgement::Neutral);
+    }
+
+    #[test]
+    fn test_judge_pon_neutral_when_heuristics_disabled() {
+        // 定石無効なら3副露でも Neutral（従来挙動の維持）
+        let mut state = call_state_with_hand(tiles(&[Tile::S3, Tile::S3, Tile::M5, Tile::M9]));
+        state.player_melds[0] = vec![chi_meld(Tile::M1), pon_meld(Tile::P5), pon_meld(Tile::S9)];
+        let config =
+            CpuConfig::new(CpuLevel::Strong, CpuPersonality::Balanced).without_heuristics();
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_pon(&ctx, Tile::new(Tile::S3)), CallJudgement::Neutral);
+    }
+
+    // --- judge_chi ---
+
+    #[test]
+    fn test_judge_chi_forbids_yakuless_call() {
+        // バラバラの3色手で么九牌絡みのチーは役の見込みがない
+        // 手牌: M789 + P345 + S456 + M9M9 + S2 S7 → M7M8 で M9 をチー
+        let state = call_state_with_hand(tiles(&[
+            Tile::M7,
+            Tile::M8,
+            Tile::P3,
+            Tile::P4,
+            Tile::P5,
+            Tile::S4,
+            Tile::S5,
+            Tile::S6,
+            Tile::M1,
+            Tile::M1,
+            Tile::S2,
+            Tile::S7,
+            Tile::Z2,
+        ]));
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Speedy);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        // M9チー（M7M8使用）: 副露に么九牌 → タンヤオ消滅、役牌なし、3色 → Forbid
+        assert_eq!(
+            judge_chi(
+                &ctx,
+                Tile::new(Tile::M9),
+                [Tile::new(Tile::M7), Tile::new(Tile::M8)]
+            ),
+            CallJudgement::Forbid
+        );
+    }
+
+    #[test]
+    fn test_judge_chi_neutral_for_tanyao_call() {
+        // 中張牌のみのチーで断么九の見込みが残る → Neutral
+        let state = call_state_with_hand(tiles(&[
+            Tile::M3,
+            Tile::M4,
+            Tile::P3,
+            Tile::P4,
+            Tile::P5,
+            Tile::S4,
+            Tile::S5,
+            Tile::S6,
+            Tile::S3,
+            Tile::S3,
+            Tile::M5,
+            Tile::M6,
+            Tile::M7,
+        ]));
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(
+            judge_chi(
+                &ctx,
+                Tile::new(Tile::M5),
+                [Tile::new(Tile::M3), Tile::new(Tile::M4)]
+            ),
+            CallJudgement::Neutral
+        );
+    }
+
+    // --- judge_ankan ---
+
+    /// 暗カンすると手が壊れる手牌（S5×4を順子+刻子に使っている聴牌形）
+    fn hand_breaking_kan_state() -> CpuGameState {
+        let mut state = call_state_with_hand(tiles(&[
+            Tile::M2,
+            Tile::M3,
+            Tile::M4,
+            Tile::P2,
+            Tile::P3,
+            Tile::P4,
+            Tile::S4,
+            Tile::S5,
+            Tile::S5,
+            Tile::S5,
+            Tile::S6,
+            Tile::Z1,
+            Tile::Z3,
+        ]));
+        state.my_drawn = Some(Tile::new(Tile::S5));
+        state
+    }
+
+    #[test]
+    fn test_judge_ankan_forbids_hand_breaking_kan() {
+        // S5×4 を S456 + S555 に使っている聴牌形: カンすると1向聴に落ちる
+        let state = hand_breaking_kan_state();
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_ankan(&ctx, Tile::S5), CallJudgement::Forbid);
+    }
+
+    #[test]
+    fn test_judge_ankan_neutral_for_weak_level() {
+        // 弱レベルは対象外（初心者らしい雑なカンを許容）
+        let state = hand_breaking_kan_state();
+        let config = CpuConfig::new(CpuLevel::Weak, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_ankan(&ctx, Tile::S5), CallJudgement::Neutral);
+    }
+
+    /// カンしても向聴数が変わらない1向聴の手牌（P2×4が浮き刻子+1枚）
+    fn shanten_keeping_kan_state() -> CpuGameState {
+        let mut state = call_state_with_hand(tiles(&[
+            Tile::M2,
+            Tile::M3,
+            Tile::M4,
+            Tile::M6,
+            Tile::M7,
+            Tile::S3,
+            Tile::S3,
+            Tile::P2,
+            Tile::P2,
+            Tile::P2,
+            Tile::P2,
+            Tile::Z1,
+            Tile::Z2,
+        ]));
+        state.my_drawn = Some(Tile::new(Tile::M5));
+        state
+    }
+
+    #[test]
+    fn test_judge_ankan_neutral_when_shanten_kept_and_no_riichi() {
+        let state = shanten_keeping_kan_state();
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_ankan(&ctx, Tile::P2), CallJudgement::Neutral);
+    }
+
+    #[test]
+    fn test_judge_ankan_forbids_kan_during_opponent_riichi_without_tenpai() {
+        // 他家リーチ中、カン後も聴牌でない → 新ドラリスクを取らない
+        let mut state = shanten_keeping_kan_state();
+        state.player_riichi[2] = true; // 西家がリーチ（自分は東家）
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_ankan(&ctx, Tile::P2), CallJudgement::Forbid);
     }
 
     #[test]

--- a/crates/mahjong-server/src/cpu/state.rs
+++ b/crates/mahjong-server/src/cpu/state.rs
@@ -306,6 +306,28 @@ impl CpuGameState {
         &self.all_discards[Self::wind_to_index(self.my_seat_wind)]
     }
 
+    /// 自分の副露を返す
+    pub fn my_melds(&self) -> &[Meld] {
+        &self.player_melds[Self::wind_to_index(self.my_seat_wind)]
+    }
+
+    /// 自分の副露を手牌分析用に取得する（カンは3枚に切り詰める）
+    ///
+    /// `HandAnalyzer` は副露を3枚の面子として扱うため、
+    /// 向聴数計算に渡す際はこちらを使用する。
+    pub fn my_melds_for_analysis(&self) -> Vec<Meld> {
+        self.my_melds()
+            .iter()
+            .map(|open| {
+                let mut o = open.clone();
+                if o.tiles.len() > 3 {
+                    o.tiles.truncate(3);
+                }
+                o
+            })
+            .collect()
+    }
+
     /// 現在の巡目（1始まり）を返す
     ///
     /// 自分の捨て牌の数から導出する。打牌前に呼べば「これから何巡目の打牌か」になる。


### PR DESCRIPTION
## Summary

Phase 1 call (鳴き) conventions for #142, closing #162, #163, #166 and #167. This is the first PR that actually changes CPU behavior on top of the heuristics foundation (#192) and simulation harness (#193).

Calls are individual accept/reject decisions rather than score sums, so they are expressed as a tri-state judgement layer (`Forbid` / `Encourage` / `Neutral`) in `cpu/heuristics.rs`, consulted from `should_pon`, `select_chi_option` and `consider_ankan`. `Forbid` takes precedence; `Neutral` falls through to the existing personality/aggressiveness logic. Everything respects `heuristics_enabled`, so the no-heuristics baseline reproduces the previous behavior for A/B comparison.

## Conventions implemented

- **#162 役なし鳴き禁止** (Weak+): calls that leave no yaku prospect are forbidden. The prospect check (`has_yaku_prospect`) covers yakuhai pairs/triplets, kuitan (all-simple melds + few terminals/honors in hand), honitsu/chinitsu (single suit + honors), and toitoi (all-triplet melds + pair-heavy hand). Rare yaku (chanta etc.) are intentionally ignored — a false negative only means passing on a call.
- **#163 役牌対子は早めにポン** (Weak+): yakuhai pon is `Encourage`d, overriding personality gates. Previously the HighValue personality (call aggressiveness 0.2) would pass even on yakuhai pon.
- **#166 裸単騎回避** (Weak+): pon/chi that would create a fourth meld is forbidden.
- **#167 無意味なカン抑制** (Normal+): ankan that worsens shanten (hand-breaking kan, e.g. four S5 used as S456+S555) is forbidden; during an opponent's riichi, ankan is forbidden unless the hand remains tenpai (new-dora risk). Weak keeps its naive kan on purpose — beginner-like behavior. Daiminkan was already never called, which satisfies the daiminkan half of #167 as the status quo.

Refactor: meld-list construction for hand analysis moved from `CpuClient::build_existing_melds` to `CpuGameState::my_melds_for_analysis()` so heuristics and client share one implementation.

## Simulation results (seed 42, 100 east-only games)

The A/B gap between Strong with and without heuristics is now substantial:

| CPU | win% | deal-in% | riichi | melds | avg rank | avg score |
|---|---|---|---|---|---|---|
| Weak/Balanced | 2.8% | 19.8% | 20 | 471 | 3.37 | 15540 |
| Normal/Balanced | 28.3% | 11.9% | 156 | 728 | **2.07** | 29388 |
| Strong/Balanced | 27.2% | 11.4% | 141 | 714 | **2.10** | 29602 |
| Strong/Balanced (no heuristics) | 19.3% | 15.1% | 83 | 1215 | 2.46 | 25400 |

Junk calls cut roughly in half; staying closed more leads to ~70% more riichi, +8pt win rate and −3.7pt deal-in rate versus the no-heuristics baseline.

## Test plan

- 18 new tests: unit tests for `has_yaku_prospect` / `judge_pon` / `judge_chi` / `judge_ankan` (incl. level gating and disabled-heuristics neutrality) and client-level A/B integration tests for each convention
- `cargo build` / `cargo test` ✓ (513 tests passing)
- `cargo fmt` / `cargo clippy` ✓ (no warnings)
- 100-game simulation completes without stalls ✓

Closes #162, closes #163, closes #166, closes #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)