### PR TITLE
Add kokushi musou route conventions (#142)

### DIFF
--- a/crates/mahjong-server/src/cpu/client.rs
+++ b/crates/mahjong-server/src/cpu/client.rs
@@ -481,8 +481,35 @@ impl CpuClient {
 
     /// 九種九牌を宣言すべきか判断する
     ///
-    /// 高打点型は国士無双を狙うため続行、それ以外は流局する。
+    /// 定石有効時は国士無双の見込みで判断する（#158/#159/#160）:
+    /// - 么九牌10種以上なら国士無双を狙って続行
+    /// - 9種でも高打点型、または大きく負けている場合は続行
+    /// - それ以外は流局を宣言する
+    ///
+    /// 定石無効時は従来どおり高打点型のみ続行する。
     fn decide_nine_terminals(&self) -> ClientAction {
+        if self.config.heuristics_enabled {
+            let mut counts = [0u8; 34];
+            for t in &self.state.my_hand {
+                counts[t.get() as usize] += 1;
+            }
+            if let Some(drawn) = self.state.my_drawn {
+                counts[drawn.get() as usize] += 1;
+            }
+            let kinds = super::defense::ORPHAN_TYPES
+                .iter()
+                .filter(|&&t| counts[t as usize] > 0)
+                .count();
+
+            let continue_kokushi = kinds >= 10
+                || (kinds >= 9
+                    && (self.config.personality == CpuPersonality::HighValue
+                        || heuristics::is_far_behind(&self.state)));
+            return ClientAction::NineTerminals {
+                declare: !continue_kokushi,
+            };
+        }
+
         let declare = self.config.personality != CpuPersonality::HighValue;
         ClientAction::NineTerminals { declare }
     }
@@ -1500,14 +1527,84 @@ mod tests {
         );
     }
 
+    /// 么九牌 n 種 + 中張牌で14枚の配牌を作る
+    fn orphan_rich_hand(kinds: usize) -> Vec<Tile> {
+        let orphan_types = [
+            Tile::M1,
+            Tile::M9,
+            Tile::P1,
+            Tile::P9,
+            Tile::S1,
+            Tile::S9,
+            Tile::Z1,
+            Tile::Z2,
+            Tile::Z3,
+            Tile::Z4,
+            Tile::Z5,
+            Tile::Z6,
+            Tile::Z7,
+        ];
+        let fillers = [Tile::M4, Tile::P5, Tile::S6, Tile::M6, Tile::P3];
+        let mut hand: Vec<Tile> = orphan_types
+            .iter()
+            .take(kinds)
+            .map(|&t| Tile::new(t))
+            .collect();
+        hand.extend(fillers.iter().take(13 - kinds).map(|&t| Tile::new(t)));
+        hand
+    }
+
+    fn nine_terminals_action(
+        config: CpuConfig,
+        hand: Vec<Tile>,
+        scores: [i32; 4],
+    ) -> Option<ClientAction> {
+        let mut client = CpuClient::new(config);
+        client.handle_event(&ServerEvent::GameStarted {
+            seat_wind: Wind::East,
+            hand,
+            scores,
+            prevailing_wind: Wind::East,
+            dora_indicators: vec![],
+            round_number: 0,
+            honba: 0,
+            riichi_sticks: 0,
+        });
+        client.handle_event(&ServerEvent::TileDrawn {
+            tile: Tile::new(Tile::S5),
+            remaining_tiles: 69,
+            can_tsumo: false,
+            can_riichi: false,
+            is_furiten: false,
+        });
+        client.handle_event(&ServerEvent::NineTerminalsAvailable)
+    }
+
     #[test]
-    fn test_nine_terminals_high_value_continues() {
-        // HighValue は国士狙いで続行（declare=false）
-        let config = CpuConfig::new(CpuLevel::Strong, CpuPersonality::HighValue);
+    fn test_kokushi_hand_keeps_orphans() {
+        // #160: 么九牌10種の手では么九牌を守り、中張牌から切る。
+        // ルートロックがないと一般形向聴数に引かれて么九牌を切ってしまう。
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
         let mut client = CpuClient::new(config);
 
-        let action = client.handle_event(&ServerEvent::NineTerminalsAvailable);
+        client.handle_event(&game_started_event(Wind::East, orphan_rich_hand(10)));
+        let action = client.handle_event(&draw_event(Tile::P6));
 
+        let tile = discarded_tile(&action);
+        // ツモ切り（P6）か手牌の中張牌切りなら正しい
+        if let Some(t) = tile {
+            assert!(
+                !t.is_1_9_honor(),
+                "国士無双ルートでは么九牌を切らない, got {t:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_nine_terminals_continues_with_ten_kinds() {
+        // #160: 么九牌10種以上は性格によらず国士無双を狙って続行
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let action = nine_terminals_action(config, orphan_rich_hand(10), [25000; 4]);
         assert!(matches!(
             action,
             Some(ClientAction::NineTerminals { declare: false })
@@ -1515,23 +1612,51 @@ mod tests {
     }
 
     #[test]
-    fn test_nine_terminals_non_high_value_declares() {
-        // HighValue 以外は流局宣言（declare=true）
-        for personality in [
-            CpuPersonality::Balanced,
-            CpuPersonality::Speedy,
-            CpuPersonality::Defensive,
-        ] {
-            let config = CpuConfig::new(CpuLevel::Normal, personality);
-            let mut client = CpuClient::new(config);
+    fn test_nine_terminals_nine_kinds_depends_on_situation() {
+        // 9種: 平場のバランス型は流局を選ぶ
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let action = nine_terminals_action(config, orphan_rich_hand(9), [25000; 4]);
+        assert!(matches!(
+            action,
+            Some(ClientAction::NineTerminals { declare: true })
+        ));
 
-            let action = client.handle_event(&ServerEvent::NineTerminalsAvailable);
+        // 9種: 高打点型は国士狙いで続行
+        let config = CpuConfig::new(CpuLevel::Strong, CpuPersonality::HighValue);
+        let action = nine_terminals_action(config, orphan_rich_hand(9), [25000; 4]);
+        assert!(matches!(
+            action,
+            Some(ClientAction::NineTerminals { declare: false })
+        ));
 
-            assert!(
-                matches!(action, Some(ClientAction::NineTerminals { declare: true })),
-                "personality {personality:?} should declare nine terminals"
-            );
-        }
+        // 9種: 大きく負けていれば（#159）バランス型でも続行
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let action =
+            nine_terminals_action(config, orphan_rich_hand(9), [8000, 42000, 25000, 25000]);
+        assert!(matches!(
+            action,
+            Some(ClientAction::NineTerminals { declare: false })
+        ));
+    }
+
+    #[test]
+    fn test_nine_terminals_without_heuristics_uses_personality() {
+        // 定石無効時は従来どおり: HighValue のみ続行
+        let config =
+            CpuConfig::new(CpuLevel::Strong, CpuPersonality::HighValue).without_heuristics();
+        let action = nine_terminals_action(config, orphan_rich_hand(9), [25000; 4]);
+        assert!(matches!(
+            action,
+            Some(ClientAction::NineTerminals { declare: false })
+        ));
+
+        let config =
+            CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced).without_heuristics();
+        let action = nine_terminals_action(config, orphan_rich_hand(10), [25000; 4]);
+        assert!(matches!(
+            action,
+            Some(ClientAction::NineTerminals { declare: true })
+        ));
     }
 
     #[test]

--- a/crates/mahjong-server/src/cpu/defense.rs
+++ b/crates/mahjong-server/src/cpu/defense.rs
@@ -9,7 +9,7 @@ use super::client::{CpuConfig, CpuLevel, is_yakuhai};
 use super::state::CpuGameState;
 
 /// 国士無双の構成牌（么九牌・字牌の全13種）
-const ORPHAN_TYPES: [TileType; 13] = [
+pub(crate) const ORPHAN_TYPES: [TileType; 13] = [
     Tile::M1,
     Tile::M9,
     Tile::P1,

--- a/crates/mahjong-server/src/cpu/heuristics.rs
+++ b/crates/mahjong-server/src/cpu/heuristics.rs
@@ -19,6 +19,7 @@ use mahjong_core::tile::{Tile, TileType, Wind, dora_indicator_to_dora};
 use mahjong_core::winning_hand::name::Form;
 
 use super::client::{CpuConfig, CpuLevel, is_yakuhai};
+use super::defense::ORPHAN_TYPES;
 use super::evaluator::{DiscardCandidate, get_yakuhai_types};
 use super::state::CpuGameState;
 
@@ -540,10 +541,12 @@ fn discard_adjustment_with(
         .sum()
 }
 
-/// 七対子と一般形のどちらを本線にするかを判定する（#154/#155/#156）
+/// 七対子・国士無双・一般形のどれを本線にするかを判定する
+/// （#154/#155/#156, #158/#159/#160/#161）
 ///
-/// - 副露がある、または対子が4つ未満なら一般形（#154: 4トイツ未満で
-///   七対子を本線にしない）
+/// - 副露があれば一般形（七対子・国士無双は門前限定）
+/// - 么九牌の種類数と点棒状況に応じて国士無双ルートを選ぶ（#158〜#161）
+/// - 対子が4つ未満なら一般形（#154: 4トイツ未満で七対子を本線にしない）
 /// - 対子が4つ以上でも、一般形の方が近い場合や、連続対子などの
 ///   複合形が多い場合は一般形を優先する（#155）
 /// - 字牌・么九牌・孤立した数牌対子（横に伸びにくい対子）が過半数なら
@@ -553,15 +556,21 @@ pub(crate) fn preferred_form(state: &CpuGameState) -> Form {
         return Form::Normal;
     }
 
+    let mut all_tiles = state.my_hand.clone();
+    if let Some(drawn) = state.my_drawn {
+        all_tiles.push(drawn);
+    }
+
+    // 国士無双ルート（#158〜#161）
+    if kokushi_route_viable(state, &all_tiles) {
+        return Form::ThirteenOrphans;
+    }
+
     let pairs = pair_types(state);
     if pairs.len() < 4 {
         return Form::Normal;
     }
 
-    let mut all_tiles = state.my_hand.clone();
-    if let Some(drawn) = state.my_drawn {
-        all_tiles.push(drawn);
-    }
     let hand = Hand::new(all_tiles.clone(), None);
     let seven_pairs = calc_shanten_number_by_form(&hand, Form::SevenPairs);
     let normal = calc_shanten_number_by_form(&hand, Form::Normal);
@@ -583,6 +592,84 @@ pub(crate) fn preferred_form(state: &CpuGameState) -> Form {
     } else {
         Form::Normal
     }
+}
+
+/// 国士無双を本線にすべきか（#158/#159/#160/#161）
+///
+/// - #160: 么九牌10種以上なら本線にする
+/// - #158: 8〜9種は他形と同等以上に近ければ採用、
+///   7種は通常手に見込みがない（5向聴以上）ときのみ候補に留める
+/// - #159: 大きく負けている場合は7種から、多少遠くても狙う
+///   （役満で逆転する価値がある）
+/// - #161: 未所持の必要牌が枯れている（4枚見え）なら成立不可能なので狙わない。
+///   中盤以降、未所持の必要牌が残り1枚以下の種類が2つ以上あれば見切る。
+///   この判定は自分の意思決定なので、自分の手牌を含む全ての見え情報を使う。
+fn kokushi_route_viable(state: &CpuGameState, all_tiles: &[Tile]) -> bool {
+    let mut counts = [0u8; 34];
+    for t in all_tiles {
+        counts[t.get() as usize] += 1;
+    }
+    let kinds = ORPHAN_TYPES
+        .iter()
+        .filter(|&&t| counts[t as usize] > 0)
+        .count();
+    if kinds < 7 {
+        return false;
+    }
+
+    // #161: 未所持の必要牌の枯れチェック
+    let visible = state.visible_tile_counts();
+    let missing_dead = ORPHAN_TYPES
+        .iter()
+        .any(|&t| counts[t as usize] == 0 && visible[t as usize] >= 4);
+    if missing_dead {
+        return false;
+    }
+    let thin_missing = ORPHAN_TYPES
+        .iter()
+        .filter(|&&t| counts[t as usize] == 0 && visible[t as usize] >= 3)
+        .count();
+    if state.turn() >= 7 && thin_missing >= 2 {
+        return false;
+    }
+
+    // #160: 10種以上は本線
+    if kinds >= 10 {
+        return true;
+    }
+
+    let hand = Hand::new(all_tiles.to_vec(), None);
+    let orphans = calc_shanten_number_by_form(&hand, Form::ThirteenOrphans);
+    let best_other = calc_shanten_number_by_form(&hand, Form::Normal)
+        .min(calc_shanten_number_by_form(&hand, Form::SevenPairs));
+
+    // #158: 8〜9種は他形と同等以上に近ければ採用（高く評価）
+    if kinds >= 8 && orphans <= best_other {
+        return true;
+    }
+
+    // #159: 大きく負けているなら7種から、多少遠くても役満を狙う
+    if is_far_behind(state) && orphans.as_i32() <= best_other.as_i32() + 1 {
+        return true;
+    }
+
+    // #158: 7種は通常手に見込みがない（5向聴以上）ときのみ候補に留める
+    orphans <= best_other && best_other.as_i32() >= 5
+}
+
+/// 大きく負けているか（#159: 役満狙いの価値が上がる点棒状況）
+///
+/// ラス目、またはトップとの点差が16000点以上ある場合。
+pub(crate) fn is_far_behind(state: &CpuGameState) -> bool {
+    let my_idx = CpuGameState::wind_to_index(state.my_seat_wind);
+    let my_score = state.scores[my_idx];
+    let top = *state.scores.iter().max().unwrap_or(&my_score);
+    let is_last = state
+        .scores
+        .iter()
+        .enumerate()
+        .all(|(i, &s)| i == my_idx || s >= my_score);
+    (top - my_score) >= 16000 || (is_last && top - my_score >= 8000)
 }
 
 /// 対子が「横に伸びにくい」か（#156）
@@ -2101,6 +2188,131 @@ mod tests {
             Tile::M7,
         ]);
         assert!(!is_cheap_distant_call(&state, &hand, &melds));
+    }
+
+    // --- 国士無双ルート（#158 #159 #160 #161）---
+
+    /// 么九牌 n 種 + 中張牌の埋め草で13枚の手牌を作る
+    fn orphan_hand(kinds: usize) -> Vec<Tile> {
+        let fillers = [Tile::M4, Tile::M5, Tile::P5, Tile::S5, Tile::S6, Tile::P3];
+        let mut hand: Vec<Tile> = ORPHAN_TYPES
+            .iter()
+            .take(kinds)
+            .map(|&t| Tile::new(t))
+            .collect();
+        hand.extend(fillers.iter().take(13 - kinds).map(|&t| Tile::new(t)));
+        hand
+    }
+
+    #[test]
+    fn test_preferred_form_kokushi_with_ten_kinds() {
+        // #160: 么九牌10種以上は国士無双を本線にする
+        let mut state = CpuGameState::new();
+        state.my_hand = orphan_hand(10);
+        assert_eq!(preferred_form(&state), Form::ThirteenOrphans);
+    }
+
+    #[test]
+    fn test_preferred_form_kokushi_nine_kinds_when_closer() {
+        // #158: 9種は他形より明確に近いとき国士無双を採用する
+        let mut state = CpuGameState::new();
+        state.my_hand = orphan_hand(9);
+        assert_eq!(preferred_form(&state), Form::ThirteenOrphans);
+    }
+
+    #[test]
+    fn test_preferred_form_normal_with_seven_kinds_and_decent_hand() {
+        // #158: 7種でも通常手に見込みがあるなら国士無双に向かわない
+        let mut state = CpuGameState::new();
+        let mut hand: Vec<Tile> = ORPHAN_TYPES.iter().take(7).map(|&t| Tile::new(t)).collect();
+        hand.extend(tiles(&[
+            Tile::M2,
+            Tile::M3,
+            Tile::M4,
+            Tile::P4,
+            Tile::P5,
+            Tile::P6,
+        ]));
+        state.my_hand = hand;
+        assert_eq!(preferred_form(&state), Form::Normal);
+    }
+
+    #[test]
+    fn test_kokushi_route_abandoned_when_missing_type_dead() {
+        // #161: 未所持の必要牌が4枚見えたら国士無双は成立しない
+        let mut state = CpuGameState::new();
+        state.my_hand = orphan_hand(10); // Z5/Z6/Z7 を持っていない
+        state.all_discards[1] = vec![Tile::new(Tile::Z5); 4];
+        assert_eq!(preferred_form(&state), Form::Normal);
+    }
+
+    #[test]
+    fn test_kokushi_route_abandoned_when_needed_tiles_thin_late() {
+        // #161: 中盤以降、未所持の必要牌が残り1枚以下の種類が2つ以上なら見切る
+        let mut state = CpuGameState::new();
+        state.my_hand = orphan_hand(10);
+        state.all_discards[1] = vec![
+            Tile::new(Tile::Z5),
+            Tile::new(Tile::Z5),
+            Tile::new(Tile::Z5),
+            Tile::new(Tile::Z6),
+            Tile::new(Tile::Z6),
+        ];
+        state.all_discards[2] = vec![Tile::new(Tile::Z6)];
+
+        // 序盤（1巡目）はまだ見切らない
+        assert_eq!(preferred_form(&state), Form::ThirteenOrphans);
+
+        // 7巡目以降は見切る
+        state.all_discards[0] = vec![Tile::new(Tile::P5); 6];
+        assert_eq!(preferred_form(&state), Form::Normal);
+    }
+
+    #[test]
+    fn test_is_far_behind() {
+        // トップと16000点差以上
+        let mut state = CpuGameState::new();
+        state.my_seat_wind = Wind::East;
+        state.scores = [8000, 42000, 25000, 25000];
+        assert!(is_far_behind(&state));
+
+        // 平場
+        state.scores = [25000; 4];
+        assert!(!is_far_behind(&state));
+
+        // ラス目でも僅差なら対象外
+        state.scores = [20000, 26000, 27000, 27000];
+        assert!(!is_far_behind(&state));
+
+        // ラス目で8000点以上離されている
+        state.scores = [17000, 27000, 28000, 28000];
+        assert!(is_far_behind(&state));
+    }
+
+    #[test]
+    fn test_preferred_form_kokushi_seven_kinds_when_far_behind() {
+        // #159: 大きく負けているなら7種から、多少遠くても国士無双を狙う。
+        // 通常形に見込みがある手で点棒状況だけを変えて比較する
+        let mut state = CpuGameState::new();
+        state.my_seat_wind = Wind::East;
+        let mut hand: Vec<Tile> = ORPHAN_TYPES.iter().take(7).map(|&t| Tile::new(t)).collect();
+        hand.extend(tiles(&[
+            Tile::M2,
+            Tile::M3,
+            Tile::M4,
+            Tile::P4,
+            Tile::P5,
+            Tile::S5,
+        ]));
+        state.my_hand = hand;
+
+        // 平場では狙わない（国士は通常形より遠い）
+        state.scores = [25000; 4];
+        assert_ne!(preferred_form(&state), Form::ThirteenOrphans);
+
+        // 大差のラス目なら狙う
+        state.scores = [5000, 45000, 25000, 25000];
+        assert_eq!(preferred_form(&state), Form::ThirteenOrphans);
     }
 
     // --- リーチ・ダマ判断（#168〜#172）---

--- a/crates/mahjong-server/src/round/mod.rs
+++ b/crates/mahjong-server/src/round/mod.rs
@@ -1747,6 +1747,26 @@ impl Round {
             self.declare_special_draw(DrawReason::NineTerminals, Some(declarer_wind));
         } else {
             self.phase = TurnPhase::WaitForDiscard;
+
+            // 続行を選んだプレイヤーに TileDrawn を再送して打牌を促す。
+            // 最初の TileDrawn への応答（打牌）は WaitForNineTerminals
+            // フェーズで拒否されているため、再送しないとクライアントが
+            // 打牌の機会を得られず局が進行しなくなる。
+            if let Some(drawn) = self.players[player_idx].hand.drawn() {
+                let can_tsumo = self.can_tsumo();
+                let can_riichi = self.can_player_riichi(player_idx);
+                let is_furiten = self.players[player_idx].is_furiten();
+                self.events.push((
+                    player_idx,
+                    ServerEvent::TileDrawn {
+                        tile: drawn,
+                        remaining_tiles: self.wall.remaining(),
+                        can_tsumo,
+                        can_riichi,
+                        is_furiten,
+                    },
+                ));
+            }
         }
         true
     }
@@ -2598,6 +2618,43 @@ mod tests {
             has_available,
             "NineTerminalsAvailableイベントが生成されていない"
         );
+    }
+
+    #[test]
+    fn test_nine_terminals_continue_resends_tile_drawn() {
+        // 続行を選んだプレイヤーには TileDrawn を再送して打牌を促す。
+        // （最初の TileDrawn への打牌は WaitForNineTerminals フェーズで
+        // 拒否されているため、再送がないと局が進行不能になる）
+        let mut wall_tiles: Vec<Tile> = vec![Tile::new(Tile::Z7)];
+        for _ in 0..(70 + 14) {
+            wall_tiles.push(Tile::new(Tile::M5));
+        }
+        let wall = Wall::from_tiles(wall_tiles);
+
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        round.wall = wall;
+        let seat = round.players[0].seat_wind;
+        let mut player = Player::new(seat, vec![], 25000);
+        player.hand = mahjong_core::hand::Hand::from("1m9m1p9p1s9s1z2z3z4z5z6z5m");
+        round.players[0] = player;
+        round.current_player = 0;
+        round.phase = TurnPhase::Draw;
+        round.drain_events();
+
+        round.do_draw();
+        round.drain_events();
+
+        assert!(round.do_nine_terminals(0, false));
+        assert_eq!(round.phase, TurnPhase::WaitForDiscard);
+
+        let events = round.drain_events();
+        let resent = events
+            .iter()
+            .any(|(idx, e)| *idx == 0 && matches!(e, ServerEvent::TileDrawn { .. }));
+        assert!(resent, "続行時に TileDrawn が再送されるべき");
+
+        // 再送されたツモ牌で打牌できる（局が進行する）
+        assert!(round.do_discard(None));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Kokushi musou route conventions for #142, closing #158, #159, #160 and #161. Also fixes a pre-existing game-freeze bug that this work exposed.

**Scope note**: the original plan had #161 bundled with push/fold (#178/#179), but cutting losses on kokushi only makes sense alongside the logic that pursues it — and since the route lock (#197) re-ranks discards by the preferred form, Normal+ CPUs had effectively stopped pursuing kokushi entirely (the lock only ever chose Normal or SevenPairs). This PR adds `ThirteenOrphans` as an explicit route; push/fold moves to the next PR.

## Conventions implemented

`kokushi_route_viable` feeds `preferred_form`, so the existing route-lock machinery handles the discard ranking unchanged:

- **#160**: 10+ orphan kinds → kokushi is the main line.
- **#158**: 8–9 kinds adopt it when at least as close as the other forms; 7 kinds only when the normal hand is hopeless (5+ shanten). (An 8-kind hand structurally cannot have a normal shanten below 5 — eight orphan singles are dead weight — so 8+ kinds adopting kokushi matches the issue's 「8〜9種以上ならより高く評価」.)
- **#159**: when far behind (16000+ from top, or last place by 8000+), pursue from 7 kinds even one shanten further back — yakuman value scales with the deficit.
- **#161**: the route is abandoned when a missing orphan type is fully dead (4 visible) — judged with **all** information including our own concealed tiles, since this models *our own* decision (the deliberate mirror of the #200 kokushi-threat rule, which uses public information only because it models the *opponent's* decision) — or, from turn 7 on, when two or more missing types have ≤1 copy left.

**Nine-terminals decisions** now follow the same logic: continue with 10+ kinds, or 9 kinds when HighValue or far behind; otherwise declare the draw. The personality-only rule remains for the no-heuristics baseline.

## Bug fix: game freeze on nine-terminals continue

The simulation immediately caught a pre-existing freeze: when a player chose to **continue** at the nine-terminals prompt, the round could never advance — the client's discard response to the original `TileDrawn` had been rejected during `WaitForNineTerminals`, and nothing prompted a new discard. Previously only HighValue CPUs ever continued (and the default simulation lineup is all-Balanced), so it went unnoticed; it would equally freeze the GUI game. `do_nine_terminals` now re-sends `TileDrawn` (with recomputed flags) to the continuing player. Separate commit with a regression test.

## Simulation results (100 east-only games)

Stable across both seeds — kokushi hands are rare, so aggregates barely move (Strong rank 2.19/2.14, deal-in 9.6%/9.1% vs baseline 2.50/2.53, 16.2%/16.8%). Nine-terminal special draws decrease (11 → 8 on seed 42) as CPUs now sometimes play those hands out. No stalls.

## Test plan

- 11 new tests: route selection per rule (10 kinds; 9 kinds; 7 kinds with decent normal hand → Normal; far-behind 7-kind adoption with score-only contrast), #161 abandonment (dead type; thin types with turn gating), `is_far_behind` boundaries, nine-terminals decisions (10 kinds / 9-kind situational / disabled baseline), kokushi-hand-keeps-orphans integration, and the server-side TileDrawn re-send regression test
- `cargo build` / `cargo test` ✓ (582 tests passing)
- `cargo fmt` / `cargo clippy` ✓ (no warnings)

Closes #158, closes #159, closes #160, closes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)