### PR TITLE
Add push/fold and mawashi conventions (#142)

### DIFF
--- a/crates/mahjong-server/src/cpu/client.rs
+++ b/crates/mahjong-server/src/cpu/client.rs
@@ -433,11 +433,6 @@ impl CpuClient {
         let hand = Hand::new(all_tiles, None);
         let shanten = calc_shanten_number(&hand);
 
-        // テンパイなら基本的に攻撃
-        if shanten.is_ready_or_won() {
-            return true;
-        }
-
         // 脅威の数: リーチ者 + 定石有効時は3副露以上の他家（#180: 聴牌濃厚）
         let riichi_count = self.state.player_riichi.iter().filter(|&&r| r).count();
         let threat_count = if self.config.heuristics_enabled {
@@ -453,6 +448,23 @@ impl CpuClient {
         } else {
             riichi_count
         };
+
+        // 押し引きの定石判定（#178, 中以上）:
+        // 良形・高打点・親の聴牌は押し、愚形安手の聴牌は降りる
+        let ctx = heuristics::CallContext {
+            state: &self.state,
+            config: &self.config,
+        };
+        match heuristics::judge_push(&ctx, threat_count) {
+            heuristics::PushJudgement::Push => return true,
+            heuristics::PushJudgement::Fold => return false,
+            heuristics::PushJudgement::Neutral => {}
+        }
+
+        // テンパイなら基本的に攻撃
+        if shanten.is_ready_or_won() {
+            return true;
+        }
 
         // 防御を使わないレベルなら常に攻撃
         // ただし定石有効時は弱レベルでも撤退判断を行う（#173: ベタオリは弱以上）
@@ -1402,6 +1414,60 @@ mod tests {
         client.handle_event(&start(hand));
         let action = client.handle_event(&draw);
         assert!(matches!(action, Some(ClientAction::Riichi { .. })));
+    }
+
+    #[test]
+    fn test_cheap_bad_shape_tenpai_folds_against_riichi() {
+        // #178: 愚形安手（タンヤオのみ・カンチャン待ち）の聴牌はリーチに押さず、
+        // 現物（対子の一部でも）から降りる。従来は聴牌なら無条件に押していた。
+        let hand = vec![
+            Tile::new(Tile::M2),
+            Tile::new(Tile::M3),
+            Tile::new(Tile::M4),
+            Tile::new(Tile::P4),
+            Tile::new(Tile::P5),
+            Tile::new(Tile::P6),
+            Tile::new(Tile::S4),
+            Tile::new(Tile::S5),
+            Tile::new(Tile::S6),
+            Tile::new(Tile::M6),
+            Tile::new(Tile::M8),
+            Tile::new(Tile::S2),
+            Tile::new(Tile::S2),
+        ];
+        let riichi_with_genbutsu = |client: &mut CpuClient| {
+            client.handle_event(&ServerEvent::TileDiscarded {
+                player: Wind::West,
+                tile: Tile::new(Tile::S2),
+                is_tsumogiri: false,
+            });
+            client.handle_event(&ServerEvent::PlayerRiichi {
+                player: Wind::West,
+                scores: [25000, 25000, 24000, 25000],
+                riichi_sticks: 1,
+            });
+        };
+
+        // 定石有効: 降りて現物(S2)を切る（聴牌は崩れる）
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let mut client = CpuClient::new(config);
+        client.handle_event(&game_started_event(Wind::South, hand.clone()));
+        riichi_with_genbutsu(&mut client);
+        let action = client.handle_event(&draw_event(Tile::Z4));
+        let tile = discarded_tile(&action).expect("expected a hand discard");
+        assert_eq!(tile.get(), Tile::S2, "愚形安手聴牌は現物から降りるべき");
+
+        // 定石無効: 従来どおり聴牌を維持して押す（ツモ切り）
+        let config =
+            CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced).without_heuristics();
+        let mut client = CpuClient::new(config);
+        client.handle_event(&game_started_event(Wind::South, hand));
+        riichi_with_genbutsu(&mut client);
+        let action = client.handle_event(&draw_event(Tile::Z4));
+        assert!(
+            matches!(action, Some(ClientAction::Discard { tile: None })),
+            "定石無効時は聴牌維持（ツモ切り）, got {action:?}"
+        );
     }
 
     #[test]

--- a/crates/mahjong-server/src/cpu/evaluator.rs
+++ b/crates/mahjong-server/src/cpu/evaluator.rs
@@ -123,7 +123,7 @@ fn count_acceptance(
 }
 
 /// 手牌の推定打点を簡易計算する
-fn estimate_hand_value(hand_tiles: &[Tile], state: &CpuGameState) -> f64 {
+pub(crate) fn estimate_hand_value(hand_tiles: &[Tile], state: &CpuGameState) -> f64 {
     let mut value = 0.0;
 
     // ドラ枚数

--- a/crates/mahjong-server/src/cpu/heuristics.rs
+++ b/crates/mahjong-server/src/cpu/heuristics.rs
@@ -20,7 +20,7 @@ use mahjong_core::winning_hand::name::Form;
 
 use super::client::{CpuConfig, CpuLevel, is_yakuhai};
 use super::defense::ORPHAN_TYPES;
-use super::evaluator::{DiscardCandidate, get_yakuhai_types};
+use super::evaluator::{DiscardCandidate, estimate_hand_value, get_yakuhai_types};
 use super::state::CpuGameState;
 
 /// 打牌補正を計算する際の局面コンテキスト
@@ -242,11 +242,31 @@ fn dora_protection_bonus(ctx: &DiscardContext, c: &DiscardCandidate) -> f64 {
 /// 安全度に大きな重みを掛けることで、現物 > スジ・字牌 > 無筋么九牌 >
 /// 無筋中張牌（456が最も危険）の順で打牌が選ばれる。
 /// 重み300は向聴数3段階分に相当し、聴牌を崩してでも現物を切る。
+///
+/// #179（強以上）: 聴牌・1向聴で降りる場合は重みを150に下げる。
+/// スジ程度の安全度差（0.25 → 37.5点）では向聴数1段階（100点）を
+/// 覆せなくなるため、現物で形を崩す代わりにスジ・字牌などの
+/// 安全寄りの牌で聴牌復帰を狙う「まわし打ち」になる。
+/// 無筋中張牌との差（0.85 → 127.5点）は依然として向聴数を上回るので、
+/// 危険牌を押してまで形は守らない。
 fn defense_safety_bonus(ctx: &DiscardContext, c: &DiscardCandidate) -> f64 {
     if ctx.attacking {
         return 0.0;
     }
-    c.safety * 300.0
+
+    let mut weight = 300.0;
+    if ctx.config.level >= CpuLevel::Strong {
+        let mut all_tiles = ctx.state.my_hand.clone();
+        if let Some(drawn) = ctx.state.my_drawn {
+            all_tiles.push(drawn);
+        }
+        let hand = Hand::new_with_melds(all_tiles, ctx.state.my_melds_for_analysis(), None);
+        if calc_shanten_number(&hand).as_i32() <= 1 {
+            weight = 150.0;
+        }
+    }
+
+    c.safety * weight
 }
 
 /// 手牌全体（ツモ込み・副露込み）のブロック数を数える
@@ -900,6 +920,94 @@ pub fn judge_ankan(ctx: &CallContext, tile_type: TileType) -> CallJudgement {
     }
 
     CallJudgement::Neutral
+}
+
+// ============================================================================
+// 押し引きの定石（#178）
+// ============================================================================
+
+/// 押し引きに対する定石の判定結果
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushJudgement {
+    /// 押すべき（攻撃続行）
+    Push,
+    /// 降りるべき
+    Fold,
+    /// 定石では決まらない（従来の判断に委ねる）
+    Neutral,
+}
+
+/// 脅威がいる局面で押すか降りるかの定石判定（#178, 中以上）
+///
+/// - 聴牌: 良形で「高打点・親・脅威1人」のいずれかなら押す。
+///   愚形かつ安手なら降りる（従来は聴牌なら無条件に押していた）。
+/// - 2向聴: 高打点（ドラ多数など）で脅威が1人なら押し続ける。
+/// - それ以外は従来の判断（性格・撤退閾値）に委ねる。
+pub fn judge_push(ctx: &CallContext, threat_count: usize) -> PushJudgement {
+    if !ctx.config.heuristics_enabled || ctx.config.level < CpuLevel::Normal || threat_count == 0 {
+        return PushJudgement::Neutral;
+    }
+
+    let mut all_tiles = ctx.state.my_hand.clone();
+    if let Some(drawn) = ctx.state.my_drawn {
+        all_tiles.push(drawn);
+    }
+    let melds = ctx.state.my_melds_for_analysis();
+    let hand = Hand::new_with_melds(all_tiles.clone(), melds.clone(), None);
+    let shanten = calc_shanten_number(&hand);
+
+    if shanten.is_ready_or_won() {
+        // 聴牌: 最も広い聴牌を取る打牌を選んだときの待ちの形と打点で判断する
+        let visible = ctx.state.visible_tile_counts();
+        let mut best_waits = 0u32;
+        let mut best_han = 0u32;
+        for i in 0..all_tiles.len() {
+            let mut remaining = all_tiles.clone();
+            remaining.remove(i);
+            let h = Hand::new_with_melds(remaining.clone(), melds.clone(), None);
+            if !calc_shanten_number(&h).is_ready() {
+                continue;
+            }
+            let waits = waiting_tiles(&remaining, &melds);
+            let count: u32 = waits
+                .iter()
+                .map(|&t| 4u32.saturating_sub(visible[t as usize] as u32))
+                .sum();
+            let han = waits
+                .iter()
+                .filter_map(|&w| estimate_ron_han(ctx.state, &remaining, &melds, w))
+                .max()
+                .unwrap_or(0);
+            if count > best_waits {
+                best_waits = count;
+                best_han = han;
+            }
+        }
+
+        let good_shape = best_waits >= 6;
+        // 門前ならリーチ・裏ドラなどの上積みを見込む
+        let value_han = best_han + u32::from(ctx.state.my_melds().is_empty());
+        let high_value = value_han >= 4;
+        let dealer = ctx.state.my_seat_wind == Wind::East;
+
+        if good_shape && (high_value || dealer || threat_count == 1) {
+            return PushJudgement::Push;
+        }
+        if !good_shape && !high_value {
+            return PushJudgement::Fold;
+        }
+        return PushJudgement::Neutral;
+    }
+
+    // 2向聴: 高打点（推定値が満貫級）で脅威が1人なら押し続ける
+    if shanten.as_i32() == 2
+        && threat_count == 1
+        && estimate_hand_value(&all_tiles, ctx.state) >= 6.0
+    {
+        return PushJudgement::Push;
+    }
+
+    PushJudgement::Neutral
 }
 
 // ============================================================================
@@ -2313,6 +2421,177 @@ mod tests {
         // 大差のラス目なら狙う
         state.scores = [5000, 45000, 25000, 25000];
         assert_eq!(preferred_form(&state), Form::ThirteenOrphans);
+    }
+
+    // --- 押し引き（#178）・まわし打ち（#179）---
+
+    #[test]
+    fn test_judge_push_folds_cheap_bad_shape_tenpai() {
+        // #178: 愚形安手の聴牌は脅威がいれば降りる
+        let mut state = riichi_state(&CHEAP_KANCHAN_TENPAI, Tile::Z4);
+        state.my_seat_wind = Wind::South; // 親の例外を避ける
+        state.player_riichi[2] = true;
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_push(&ctx, 1), PushJudgement::Fold);
+
+        // 弱レベルは対象外
+        let config = CpuConfig::new(CpuLevel::Weak, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_push(&ctx, 1), PushJudgement::Neutral);
+    }
+
+    #[test]
+    fn test_judge_push_pushes_good_shape_tenpai() {
+        // #178: 良形聴牌は安手でも1人リーチには押す
+        let mut state = riichi_state(&GOOD_SHAPE_TENPAI, Tile::Z3);
+        state.my_seat_wind = Wind::South;
+        state.player_riichi[2] = true;
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_push(&ctx, 1), PushJudgement::Push);
+    }
+
+    #[test]
+    fn test_judge_push_pushes_high_value_against_multiple_threats() {
+        // #178: 満貫級の良形聴牌は2人リーチでも押す
+        let mut state = riichi_state(&GOOD_SHAPE_TENPAI, Tile::Z3);
+        state.my_seat_wind = Wind::South;
+        state.dora_indicators = vec![Tile::new(Tile::S7), Tile::new(Tile::M3)]; // ドラ3
+        state.player_riichi[2] = true;
+        state.player_riichi[3] = true;
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_push(&ctx, 2), PushJudgement::Push);
+    }
+
+    #[test]
+    fn test_judge_push_dealer_pushes_good_shape() {
+        // #178: 親は良形聴牌なら2人リーチでも押す（連荘価値）
+        let mut state = riichi_state(&GOOD_SHAPE_TENPAI, Tile::Z3);
+        state.my_seat_wind = Wind::East;
+        state.player_riichi[2] = true;
+        state.player_riichi[3] = true;
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_push(&ctx, 2), PushJudgement::Push);
+    }
+
+    #[test]
+    fn test_judge_push_two_shanten_with_value() {
+        // #178: 2向聴でも満貫級（ドラ3相当）なら単独の脅威には押す
+        let mut state = CpuGameState::new();
+        state.my_seat_wind = Wind::South;
+        state.my_hand = tiles(&[
+            Tile::M3,
+            Tile::M4,
+            Tile::M5,
+            Tile::M5,
+            Tile::P4,
+            Tile::P5,
+            Tile::P6,
+            Tile::S6,
+            Tile::S7,
+            Tile::S2,
+            Tile::S2,
+            Tile::Z3,
+            Tile::Z4,
+        ]);
+        state.dora_indicators = vec![Tile::new(Tile::M4), Tile::new(Tile::M4)]; // ドラ M5×2重
+        state.player_riichi[2] = true;
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_push(&ctx, 1), PushJudgement::Push);
+
+        // ドラなしの安手2向聴は対象外（従来の撤退判断に委ねる）
+        state.dora_indicators = vec![];
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_push(&ctx, 1), PushJudgement::Neutral);
+    }
+
+    #[test]
+    fn test_judge_push_neutral_without_threats() {
+        let state = riichi_state(&CHEAP_KANCHAN_TENPAI, Tile::Z4);
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_push(&ctx, 0), PushJudgement::Neutral);
+    }
+
+    #[test]
+    fn test_mawashi_reduces_safety_weight_when_close() {
+        // #179: 強レベルは聴牌・1向聴で降りるとき安全度の重みを下げる
+        let mut candidate = make_candidate(Tile::M5);
+        candidate.safety = 1.0;
+
+        // 聴牌形の手牌
+        let state = riichi_state(&GOOD_SHAPE_TENPAI, Tile::Z3);
+
+        // 強レベル + 聴牌 → 重み150（まわし打ち）
+        let config = CpuConfig::new(CpuLevel::Strong, CpuPersonality::Balanced);
+        let defending = DiscardContext {
+            state: &state,
+            config: &config,
+            attacking: false,
+        };
+        assert_eq!(defense_safety_bonus(&defending, &candidate), 150.0);
+
+        // 中レベルは常にベタオリ（重み300）
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let defending = DiscardContext {
+            state: &state,
+            config: &config,
+            attacking: false,
+        };
+        assert_eq!(defense_safety_bonus(&defending, &candidate), 300.0);
+
+        // 強レベルでも手が遠ければベタオリ（重み300）
+        let mut far_state = CpuGameState::new();
+        far_state.my_hand = tiles(&[
+            Tile::M1,
+            Tile::M4,
+            Tile::M7,
+            Tile::P2,
+            Tile::P5,
+            Tile::P8,
+            Tile::S3,
+            Tile::S6,
+            Tile::S9,
+            Tile::Z1,
+            Tile::Z2,
+            Tile::Z3,
+            Tile::Z4,
+        ]);
+        let config = CpuConfig::new(CpuLevel::Strong, CpuPersonality::Balanced);
+        let defending = DiscardContext {
+            state: &far_state,
+            config: &config,
+            attacking: false,
+        };
+        assert_eq!(defense_safety_bonus(&defending, &candidate), 300.0);
     }
 
     // --- リーチ・ダマ判断（#168〜#172）---


### PR DESCRIPTION
## Summary

Push/fold conventions for #142, closing #178 and #179. This is the PR designed to recover the win equity that the betaori and threat-model conventions traded away, by making the fold decision graded instead of binary.

## Conventions implemented

**#178 良形高打点聴牌なら一定程度押す** (`judge_push`, Normal+) — consulted by `should_attack` whenever threats exist (riichi or 3+ melds):

- Tenpai with a **good shape** (6+ live wait tiles) pushes when high value (4+ han including the menzen riichi upside, measured by real scoring over the widest-wait declaration), dealer (連荘 value), or facing a single threat.
- Tenpai with a **bad shape and low value folds** — previously tenpai *always* pushed, even a tanyao-only kanchan against two riichi. This was the inverse gap in the old logic.
- **2 shanten with mangan-class material** (≈dora 3+) keeps pushing against a single threat — exactly the equity the threat-model folds gave up.
- Everything else falls back to the personality retreat rules (`Neutral`).

**#179 まわし打ち** (Strong+): when folding with a close hand (tenpai / 1-shanten), the defense safety weight drops from 300 to 150. The arithmetic does the mawashi: suji-grade safety differences (0.25 × 150 = 37.5 pts) no longer override a shanten step (100 pts), so the CPU keeps its shape with reasonably safe tiles instead of breaking tenpai for genbutsu — while no-suji middle tiles (0.85 × 150 = 127.5 pts apart) still aren't pushed. Normal and far hands keep full betaori (300).

## Simulation results (100 east-only games)

Strong — the only level with both conventions — posts its best results of the series:

| CPU | seed 42 | seed 7 |
|---|---|---|
| Strong/Balanced | rank **2.04**, win 27.8%, deal-in 10.7% | rank **2.00**, win 30.3%, deal-in 9.9% |
| Normal/Balanced | rank 2.23, win 24.3% | rank 2.32, win 19.9% |
| Strong (no heuristics) | rank 2.55, win 16.9% | rank 2.48, win 18.8% |

The Strong-vs-baseline gap is now ~0.5 average rank with nearly double the win rate at two-thirds the deal-in rate. No stalls on either seed.

## Test plan

- 8 new tests: `judge_push` rules (cheap kanchan fold with Weak gating; good-shape push vs single threat; mangan push vs double riichi; dealer push; 2-shanten dora push with no-dora contrast; no-threat neutrality), mawashi weight switching (Strong-close 150 / Normal 300 / Strong-far 300), and a client-level A/B integration test (cheap bad-shape tenpai folds to genbutsu vs riichi; pushes tsumogiri when disabled)
- `cargo build` / `cargo test` ✓ (590 tests passing)
- `cargo fmt` / `cargo clippy` ✓ (no warnings)

Closes #178, closes #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)