### PR TITLE
Add endgame and score-situation conventions (#142)

### DIFF
--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -307,6 +307,7 @@ impl GameState {
                 prevailing_wind,
                 dora_indicators,
                 round_number,
+                total_rounds: _,
                 honba,
                 riichi_sticks,
             } => {

--- a/crates/mahjong-server/src/cpu/client.rs
+++ b/crates/mahjong-server/src/cpu/client.rs
@@ -449,6 +449,12 @@ impl CpuClient {
             riichi_count
         };
 
+        // 終盤の遠い手は降りる（#183, 弱以上）:
+        // 残りツモが少ない2向聴以下の手は、脅威の有無や打点によらず押さない
+        if self.config.heuristics_enabled && self.state.remaining_tiles <= 12 && shanten >= 2 {
+            return false;
+        }
+
         // 押し引きの定石判定（#178, 中以上）:
         // 良形・高打点・親の聴牌は押し、愚形安手の聴牌は降りる
         let ctx = heuristics::CallContext {
@@ -745,6 +751,7 @@ mod tests {
             prevailing_wind: Wind::East,
             dora_indicators: vec![],
             round_number: 0,
+            total_rounds: 4,
             honba: 0,
             riichi_sticks: 0,
         }
@@ -1191,6 +1198,7 @@ mod tests {
             prevailing_wind: Wind::East,
             dora_indicators: vec![Tile::new(Tile::P8)], // ドラは P9
             round_number: 0,
+            total_rounds: 4,
             honba: 0,
             riichi_sticks: 0,
         });
@@ -1213,6 +1221,7 @@ mod tests {
             prevailing_wind: Wind::East,
             dora_indicators: vec![Tile::new(Tile::P8)],
             round_number: 0,
+            total_rounds: 4,
             honba: 0,
             riichi_sticks: 0,
         });
@@ -1386,6 +1395,7 @@ mod tests {
             prevailing_wind: Wind::East,
             dora_indicators: vec![Tile::new(Tile::S7), Tile::new(Tile::M3)], // ドラ S8×2 + M4
             round_number: 0,
+            total_rounds: 4,
             honba: 0,
             riichi_sticks: 0,
         };
@@ -1633,6 +1643,7 @@ mod tests {
             prevailing_wind: Wind::East,
             dora_indicators: vec![],
             round_number: 0,
+            total_rounds: 4,
             honba: 0,
             riichi_sticks: 0,
         });
@@ -2047,6 +2058,7 @@ mod tests {
             prevailing_wind: Wind::East,
             dora_indicators: vec![Tile::new(Tile::Z5)], // ドラ(發)は手牌にない
             round_number: 0,
+            total_rounds: 4,
             honba: 0,
             riichi_sticks: 0,
         });
@@ -2063,6 +2075,7 @@ mod tests {
             prevailing_wind: Wind::East,
             dora_indicators: vec![Tile::new(Tile::P6)], // ドラは P7（手牌に2枚...P7,P8のP7）
             round_number: 0,
+            total_rounds: 4,
             honba: 0,
             riichi_sticks: 0,
         });

--- a/crates/mahjong-server/src/cpu/heuristics.rs
+++ b/crates/mahjong-server/src/cpu/heuristics.rs
@@ -106,6 +106,12 @@ pub const DISCARD_HEURISTICS: &[DiscardHeuristic] = &[
         min_level: CpuLevel::Normal,
         apply: route_lock_bonus,
     },
+    // #186: 河底牌（最終打牌）で危険牌を切らない（中以上）
+    DiscardHeuristic {
+        name: "safe-last-discard",
+        min_level: CpuLevel::Normal,
+        apply: last_discard_safety_bonus,
+    },
 ];
 
 // ============================================================================
@@ -255,18 +261,57 @@ fn defense_safety_bonus(ctx: &DiscardContext, c: &DiscardCandidate) -> f64 {
     }
 
     let mut weight = 300.0;
-    if ctx.config.level >= CpuLevel::Strong {
-        let mut all_tiles = ctx.state.my_hand.clone();
-        if let Some(drawn) = ctx.state.my_drawn {
-            all_tiles.push(drawn);
-        }
-        let hand = Hand::new_with_melds(all_tiles, ctx.state.my_melds_for_analysis(), None);
-        if calc_shanten_number(&hand).as_i32() <= 1 {
+
+    let mut all_tiles = ctx.state.my_hand.clone();
+    if let Some(drawn) = ctx.state.my_drawn {
+        all_tiles.push(drawn);
+    }
+    let hand = Hand::new_with_melds(all_tiles, ctx.state.my_melds_for_analysis(), None);
+    let close = calc_shanten_number(&hand).as_i32() <= 1;
+
+    if close {
+        // #179（強以上）: まわし打ち
+        if ctx.config.level >= CpuLevel::Strong {
             weight = 150.0;
+        }
+        // #184（中以上）: 流局間際は安全牌を切りながら形式聴牌を狙う
+        if ctx.config.level >= CpuLevel::Normal && ctx.state.remaining_tiles <= 8 {
+            weight = 150.0;
+            // #185（強以上）: 親番・オーラスで順位が懸かる場面では
+            // 聴牌維持の価値をさらに上げる
+            if ctx.config.level >= CpuLevel::Strong
+                && (ctx.state.my_seat_wind == Wind::East
+                    || (ctx.state.is_final_round() && !ctx.state.is_top()))
+            {
+                weight = 120.0;
+            }
         }
     }
 
     c.safety * weight
+}
+
+/// #186: 河底牌（最終打牌）で危険牌を切らない
+///
+/// 山が空のときの打牌はこの局の最後の行動であり、手を進める意味がない。
+/// 攻撃中でも安全度に大きな重みを掛ける。形式聴牌の維持（約100点 =
+/// 向聴数1段階）はスジ程度の安全差なら優先されるが、無筋の危険牌を
+/// 押してまで維持はしない。
+fn last_discard_safety_bonus(ctx: &DiscardContext, c: &DiscardCandidate) -> f64 {
+    if ctx.state.remaining_tiles > 0 {
+        return 0.0;
+    }
+
+    // 脅威（リーチ者・3副露以上）がいなければ補正不要
+    let my_idx = CpuGameState::wind_to_index(ctx.state.my_seat_wind);
+    let any_threat = (0..4).any(|i| {
+        i != my_idx && (ctx.state.player_riichi[i] || ctx.state.player_melds[i].len() >= 3)
+    });
+    if !any_threat {
+        return 0.0;
+    }
+
+    c.safety * 200.0
 }
 
 /// 手牌全体（ツモ込み・副露込み）のブロック数を数える
@@ -804,7 +849,12 @@ pub fn judge_pon(ctx: &CallContext, called_tile: Tile) -> CallJudgement {
 
         // 安くて遠い仕掛けは控える（#165, 中以上）
         if ctx.config.level >= CpuLevel::Normal
-            && is_cheap_distant_call(ctx.state, &hand_after, &melds_after)
+            && is_cheap_distant_call(
+                ctx.state,
+                &hand_after,
+                &melds_after,
+                ctx.config.level >= CpuLevel::Strong,
+            )
         {
             return CallJudgement::Forbid;
         }
@@ -856,7 +906,12 @@ pub fn judge_chi(ctx: &CallContext, called_tile: Tile, hand_tiles: [Tile; 2]) ->
 
         // 安くて遠い仕掛けは控える（#165, 中以上）
         if ctx.config.level >= CpuLevel::Normal
-            && is_cheap_distant_call(ctx.state, &hand_after, &melds_after)
+            && is_cheap_distant_call(
+                ctx.state,
+                &hand_after,
+                &melds_after,
+                ctx.config.level >= CpuLevel::Strong,
+            )
         {
             return CallJudgement::Forbid;
         }
@@ -941,7 +996,11 @@ pub enum PushJudgement {
 ///
 /// - 聴牌: 良形で「高打点・親・脅威1人」のいずれかなら押す。
 ///   愚形かつ安手なら降りる（従来は聴牌なら無条件に押していた）。
-/// - 2向聴: 高打点（ドラ多数など）で脅威が1人なら押し続ける。
+///   親は連荘価値があるため愚形安手でも単独脅威には判断を保留する（#190）。
+///   供託・本場が多い局では安手聴牌の価値が上がる（#191, 強以上）。
+/// - 後半のトップ目は満貫級の良形聴牌以外は降りる（#188）。
+/// - 2向聴: 高打点で脅威が1人なら押し続ける。大きく負けている場合は
+///   打点の基準を下げて押す（#189: ラス目は打点寄り）。
 /// - それ以外は従来の判断（性格・撤退閾値）に委ねる。
 pub fn judge_push(ctx: &CallContext, threat_count: usize) -> PushJudgement {
     if !ctx.config.heuristics_enabled || ctx.config.level < CpuLevel::Normal || threat_count == 0 {
@@ -990,19 +1049,46 @@ pub fn judge_push(ctx: &CallContext, threat_count: usize) -> PushJudgement {
         let high_value = value_han >= 4;
         let dealer = ctx.state.my_seat_wind == Wind::East;
 
+        // #188: 後半のトップ目は放銃回避を最優先する。
+        // 満貫級の良形聴牌だけは押す
+        if ctx.state.is_top() && ctx.state.is_second_half() {
+            return if good_shape && high_value {
+                PushJudgement::Push
+            } else {
+                PushJudgement::Fold
+            };
+        }
+
         if good_shape && (high_value || dealer || threat_count == 1) {
             return PushJudgement::Push;
         }
         if !good_shape && !high_value {
+            // #190: 親は連荘価値があるため、単独脅威には判断を保留する
+            // （従来の判断 = 聴牌なら押す、に委ねる）
+            if dealer && threat_count == 1 {
+                return PushJudgement::Neutral;
+            }
+            // #191（強以上）: 供託・本場が大きければ安手聴牌でも降り推奨はしない
+            let stakes = ctx.state.riichi_sticks as i32 * 1000 + ctx.state.honba as i32 * 300;
+            if ctx.config.level >= CpuLevel::Strong && stakes >= 2000 {
+                return PushJudgement::Neutral;
+            }
             return PushJudgement::Fold;
         }
         return PushJudgement::Neutral;
     }
 
-    // 2向聴: 高打点（推定値が満貫級）で脅威が1人なら押し続ける
+    // #188: 後半のトップ目は聴牌以外では押さない
+    if ctx.state.is_top() && ctx.state.is_second_half() {
+        return PushJudgement::Fold;
+    }
+
+    // 2向聴: 高打点（推定値が満貫級）で脅威が1人なら押し続ける。
+    // 大きく負けている場合は基準を下げる（#189: 高打点ルートを取りに行く）
+    let value_threshold = if is_far_behind(ctx.state) { 4.0 } else { 6.0 };
     if shanten.as_i32() == 2
         && threat_count == 1
-        && estimate_hand_value(&all_tiles, ctx.state) >= 6.0
+        && estimate_hand_value(&all_tiles, ctx.state) >= value_threshold
     {
         return PushJudgement::Push;
     }
@@ -1078,8 +1164,11 @@ pub fn judge_riichi(ctx: &CallContext, riichi_discard: Option<Tile>) -> RiichiJu
     }
 
     // #170（中以上）: 全ての待ちでダマでも満貫以上 → リーチ棒・放銃リスクを
-    // 取らず出和了しやすさを優先する
+    // 取らず出和了しやすさを優先する。
+    // ただし大きく負けている場合は打点を伸ばす方が価値が高いので
+    // リーチに回す（#189: ラス目は打点寄り）
     if ctx.config.level >= CpuLevel::Normal
+        && !is_far_behind(ctx.state)
         && values.iter().all(|v| matches!(v, Some(han) if *han >= 5))
     {
         return RiichiJudgement::Damaten;
@@ -1243,16 +1332,40 @@ fn good_shape_upgrade_draws(remaining: &[Tile], visible: &[u8; 34]) -> u32 {
 /// 鳴いた後も2向聴以上で、打点要素（ドラ・赤ドラ・役牌・染め手）が
 /// 何もない仕掛けは、守備力低下のデメリットの方が大きいため控える。
 /// 親は連荘価値があるため例外とする。
-/// （オーラスの和了条件などの例外は点棒状況判断の導入時に拡張する）
-fn is_cheap_distant_call(state: &CpuGameState, hand_after: &[Tile], melds_after: &[Meld]) -> bool {
+///
+/// 点棒状況による例外・強化（#187/#191）:
+/// - オーラスで安手の和了でも順位が上がるなら速度優先（例外）
+/// - 供託・本場が大きい局は安手和了の価値が上がる（強以上、例外）
+/// - オーラスで満貫級が必要なら、近い仕掛けでも安手なら控える（強化）
+fn is_cheap_distant_call(
+    state: &CpuGameState,
+    hand_after: &[Tile],
+    melds_after: &[Meld],
+    consider_stakes: bool,
+) -> bool {
     // 親番は例外（連荘価値がある）
     if state.my_seat_wind == Wind::East {
         return false;
     }
 
+    // #187: オーラスで安手の和了でも順位が上がるなら速度を優先する
+    if state.is_final_round() && state.gap_to_next_rank().is_some_and(|gap| gap <= 3900) {
+        return false;
+    }
+
+    // #191（強以上）: 供託・本場が大きければ安手和了にも価値がある
+    let stakes = state.riichi_sticks as i32 * 1000 + state.honba as i32 * 300;
+    if consider_stakes && stakes >= 2000 {
+        return false;
+    }
+
+    // #187: オーラスで満貫級が必要な点差なら、安手は近い仕掛けでも控える
+    let needs_big_win =
+        state.is_final_round() && state.gap_to_next_rank().is_some_and(|gap| gap >= 8000);
+
     // 鳴いた後も2向聴以上か（遠い仕掛けか）
     let hand = Hand::new_with_melds(hand_after.to_vec(), melds_after.to_vec(), None);
-    if calc_shanten_number(&hand).as_i32() < 2 {
+    if !needs_big_win && calc_shanten_number(&hand).as_i32() < 2 {
         return false;
     }
 
@@ -2247,18 +2360,18 @@ mod tests {
             Tile::S4,
             Tile::M7,
         ]);
-        assert!(is_cheap_distant_call(&state, &hand, &melds));
+        assert!(is_cheap_distant_call(&state, &hand, &melds, false));
 
         // 親なら例外
         let mut dealer_state = CpuGameState::new();
         dealer_state.my_seat_wind = Wind::East;
-        assert!(!is_cheap_distant_call(&dealer_state, &hand, &melds));
+        assert!(!is_cheap_distant_call(&dealer_state, &hand, &melds, false));
 
         // ドラがあれば打点要素あり
         let mut dora_state = CpuGameState::new();
         dora_state.my_seat_wind = Wind::South;
         dora_state.dora_indicators = vec![Tile::new(Tile::M1)]; // ドラは M2（手牌にある）
-        assert!(!is_cheap_distant_call(&dora_state, &hand, &melds));
+        assert!(!is_cheap_distant_call(&dora_state, &hand, &melds, false));
 
         // 役牌対子があれば打点要素あり
         let hand_with_yakuhai = tiles(&[
@@ -2273,7 +2386,12 @@ mod tests {
             Tile::M6,
             Tile::P8,
         ]);
-        assert!(!is_cheap_distant_call(&state, &hand_with_yakuhai, &melds));
+        assert!(!is_cheap_distant_call(
+            &state,
+            &hand_with_yakuhai,
+            &melds,
+            false
+        ));
     }
 
     #[test]
@@ -2295,7 +2413,7 @@ mod tests {
             Tile::M6,
             Tile::M7,
         ]);
-        assert!(!is_cheap_distant_call(&state, &hand, &melds));
+        assert!(!is_cheap_distant_call(&state, &hand, &melds, false));
     }
 
     // --- 国士無双ルート（#158 #159 #160 #161）---
@@ -2547,8 +2665,9 @@ mod tests {
         let mut candidate = make_candidate(Tile::M5);
         candidate.safety = 1.0;
 
-        // 聴牌形の手牌
-        let state = riichi_state(&GOOD_SHAPE_TENPAI, Tile::Z3);
+        // 聴牌形の手牌（山はまだ十分残っている）
+        let mut state = riichi_state(&GOOD_SHAPE_TENPAI, Tile::Z3);
+        state.remaining_tiles = 40;
 
         // 強レベル + 聴牌 → 重み150（まわし打ち）
         let config = CpuConfig::new(CpuLevel::Strong, CpuPersonality::Balanced);
@@ -2570,6 +2689,7 @@ mod tests {
 
         // 強レベルでも手が遠ければベタオリ（重み300）
         let mut far_state = CpuGameState::new();
+        far_state.remaining_tiles = 40;
         far_state.my_hand = tiles(&[
             Tile::M1,
             Tile::M4,
@@ -2592,6 +2712,294 @@ mod tests {
             attacking: false,
         };
         assert_eq!(defense_safety_bonus(&defending, &candidate), 300.0);
+    }
+
+    #[test]
+    fn test_keishiki_tenpai_weights_at_endgame() {
+        // #184/#185: 流局間際の聴牌・1向聴は形式聴牌を狙って重みを下げる
+        let mut candidate = make_candidate(Tile::M5);
+        candidate.safety = 1.0;
+
+        let mut state = riichi_state(&GOOD_SHAPE_TENPAI, Tile::Z3);
+        state.my_seat_wind = Wind::South;
+        state.scores = [26000, 25000, 25000, 24000]; // 自分(南)は2着
+        state.remaining_tiles = 6;
+        state.round_number = 1;
+        state.total_rounds = 4;
+
+        // #184（中以上）: 流局間際 → 重み150
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let defending = DiscardContext {
+            state: &state,
+            config: &config,
+            attacking: false,
+        };
+        assert_eq!(defense_safety_bonus(&defending, &candidate), 150.0);
+
+        // #185（強以上）: オーラスでトップ目でない → さらに聴牌維持重視（重み120）
+        state.round_number = 3;
+        let config = CpuConfig::new(CpuLevel::Strong, CpuPersonality::Balanced);
+        let defending = DiscardContext {
+            state: &state,
+            config: &config,
+            attacking: false,
+        };
+        assert_eq!(defense_safety_bonus(&defending, &candidate), 120.0);
+
+        // #185: 親番でも聴牌維持重視
+        let mut dealer_state = riichi_state(&GOOD_SHAPE_TENPAI, Tile::Z3);
+        dealer_state.my_seat_wind = Wind::East;
+        dealer_state.remaining_tiles = 6;
+        let defending = DiscardContext {
+            state: &dealer_state,
+            config: &config,
+            attacking: false,
+        };
+        assert_eq!(defense_safety_bonus(&defending, &candidate), 120.0);
+    }
+
+    // --- 終盤処理・点棒状況（#183〜#191）---
+
+    #[test]
+    fn test_last_discard_safety_bonus() {
+        // #186: 山が空の最終打牌は、脅威がいれば攻撃中でも安全度を重視する
+        let mut candidate = make_candidate(Tile::M5);
+        candidate.safety = 1.0;
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+
+        // 山が残っていれば補正なし
+        let mut state = CpuGameState::new();
+        state.remaining_tiles = 10;
+        state.player_riichi[1] = true;
+        let ctx = attack_ctx(&state, &config);
+        assert_eq!(last_discard_safety_bonus(&ctx, &candidate), 0.0);
+
+        // 山が空 + リーチ者あり → 攻撃中でも補正
+        state.remaining_tiles = 0;
+        let ctx = attack_ctx(&state, &config);
+        assert_eq!(last_discard_safety_bonus(&ctx, &candidate), 200.0);
+
+        // 脅威がいなければ補正なし
+        let mut state = CpuGameState::new();
+        state.remaining_tiles = 0;
+        let ctx = attack_ctx(&state, &config);
+        assert_eq!(last_discard_safety_bonus(&ctx, &candidate), 0.0);
+    }
+
+    #[test]
+    fn test_cheap_call_allowed_when_final_round_speed_matters() {
+        // #187: オーラスで安手和了でも順位が上がるなら速度優先（抑制解除）
+        let mut state = CpuGameState::new();
+        state.my_seat_wind = Wind::South;
+        state.scores = [25000, 24000, 26000, 25000]; // 自分(南)は2000点差の3着
+        state.round_number = 3;
+        state.total_rounds = 4;
+        let melds = vec![chi_meld(Tile::S2)];
+        let hand = tiles(&[
+            Tile::M2,
+            Tile::M3,
+            Tile::P4,
+            Tile::P5,
+            Tile::S6,
+            Tile::S7,
+            Tile::M6,
+            Tile::P8,
+            Tile::S4,
+            Tile::M7,
+        ]);
+        // 通常なら安くて遠い仕掛けだが、オーラスの僅差なので許容
+        assert!(!is_cheap_distant_call(&state, &hand, &melds, false));
+
+        // オーラスでなければ抑制される
+        state.round_number = 1;
+        assert!(is_cheap_distant_call(&state, &hand, &melds, false));
+    }
+
+    #[test]
+    fn test_cheap_call_suppressed_when_mangan_needed() {
+        // #187: オーラスで満貫級が必要なら、近い（1向聴）仕掛けでも安手は控える
+        let mut state = CpuGameState::new();
+        state.my_seat_wind = Wind::South;
+        state.scores = [25000, 15000, 35000, 25000]; // 自分(南)はトップと2万点差
+        state.round_number = 3;
+        state.total_rounds = 4;
+        let melds = vec![chi_meld(Tile::S2)];
+        // チー後1向聴相当の手（2面子 + 対子 + ターツ）
+        let hand = tiles(&[
+            Tile::M2,
+            Tile::M3,
+            Tile::M4,
+            Tile::P4,
+            Tile::P5,
+            Tile::P6,
+            Tile::S6,
+            Tile::S6,
+            Tile::M6,
+            Tile::M7,
+        ]);
+        assert!(is_cheap_distant_call(&state, &hand, &melds, false));
+
+        // 平場なら1向聴の仕掛けは抑制されない
+        state.round_number = 1;
+        assert!(!is_cheap_distant_call(&state, &hand, &melds, false));
+    }
+
+    #[test]
+    fn test_cheap_call_allowed_with_large_stakes() {
+        // #191（強以上）: 供託・本場が大きければ安手仕掛けも許容
+        let mut state = CpuGameState::new();
+        state.my_seat_wind = Wind::South;
+        state.riichi_sticks = 2; // 供託2000点
+        let melds = vec![chi_meld(Tile::S2)];
+        let hand = tiles(&[
+            Tile::M2,
+            Tile::M3,
+            Tile::P4,
+            Tile::P5,
+            Tile::S6,
+            Tile::S7,
+            Tile::M6,
+            Tile::P8,
+            Tile::S4,
+            Tile::M7,
+        ]);
+        // 強（供託考慮あり）: 許容
+        assert!(!is_cheap_distant_call(&state, &hand, &melds, true));
+        // 中（供託考慮なし）: 従来どおり抑制
+        assert!(is_cheap_distant_call(&state, &hand, &melds, false));
+    }
+
+    #[test]
+    fn test_judge_push_top_in_second_half_folds() {
+        // #188: 後半のトップ目は安手の良形聴牌でも降りる
+        let mut state = riichi_state(&GOOD_SHAPE_TENPAI, Tile::Z3);
+        state.my_seat_wind = Wind::South;
+        state.scores = [25000, 40000, 20000, 15000]; // 自分(南)が大差トップ
+        state.round_number = 3;
+        state.total_rounds = 4;
+        state.player_riichi[2] = true;
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_push(&ctx, 1), PushJudgement::Fold);
+
+        // 満貫級の良形聴牌だけは押す
+        state.dora_indicators = vec![Tile::new(Tile::S7), Tile::new(Tile::M3)]; // ドラ3
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_push(&ctx, 1), PushJudgement::Push);
+
+        // 前半なら通常の判断（良形 + 脅威1人 → 押す）
+        let mut early = riichi_state(&GOOD_SHAPE_TENPAI, Tile::Z3);
+        early.my_seat_wind = Wind::South;
+        early.scores = [25000, 40000, 20000, 15000];
+        early.round_number = 0;
+        early.total_rounds = 4;
+        early.player_riichi[2] = true;
+        let ctx = CallContext {
+            state: &early,
+            config: &config,
+        };
+        assert_eq!(judge_push(&ctx, 1), PushJudgement::Push);
+    }
+
+    #[test]
+    fn test_judge_push_far_behind_lowers_value_threshold() {
+        // #189: 大きく負けているときは2向聴の押し基準を下げる
+        let mut state = CpuGameState::new();
+        state.my_seat_wind = Wind::South;
+        state.my_hand = tiles(&[
+            Tile::M3,
+            Tile::M4,
+            Tile::M5,
+            Tile::M5,
+            Tile::P4,
+            Tile::P5,
+            Tile::P6,
+            Tile::S6,
+            Tile::S7,
+            Tile::S2,
+            Tile::S2,
+            Tile::Z3,
+            Tile::Z4,
+        ]);
+        state.dora_indicators = vec![Tile::new(Tile::M4)]; // ドラ M5×2 = 推定4点相当
+        state.player_riichi[2] = true;
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+
+        // 平場: 基準（6.0）未満 → Neutral
+        state.scores = [25000; 4];
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_push(&ctx, 1), PushJudgement::Neutral);
+
+        // 大差のラス目: 基準が下がり押す
+        state.scores = [42000, 8000, 25000, 25000];
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_push(&ctx, 1), PushJudgement::Push);
+    }
+
+    #[test]
+    fn test_judge_push_dealer_keeps_pushing_cheap_tenpai() {
+        // #190: 親は愚形安手聴牌でも単独脅威には降り推奨しない（連荘価値）
+        let mut state = riichi_state(&CHEAP_KANCHAN_TENPAI, Tile::Z4);
+        state.my_seat_wind = Wind::East;
+        state.player_riichi[2] = true;
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        // 子なら Fold（既存テスト）、親なら Neutral（従来判断 = 押す）
+        assert_eq!(judge_push(&ctx, 1), PushJudgement::Neutral);
+    }
+
+    #[test]
+    fn test_judge_push_stakes_keep_cheap_tenpai_alive() {
+        // #191（強以上）: 供託・本場が大きければ愚形安手聴牌でも降り推奨しない
+        let mut state = riichi_state(&CHEAP_KANCHAN_TENPAI, Tile::Z4);
+        state.my_seat_wind = Wind::South;
+        state.riichi_sticks = 2;
+        state.player_riichi[2] = true;
+
+        let config = CpuConfig::new(CpuLevel::Strong, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_push(&ctx, 1), PushJudgement::Neutral);
+
+        // 中レベルは供託を考慮しない → Fold
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_push(&ctx, 1), PushJudgement::Fold);
+    }
+
+    #[test]
+    fn test_judge_riichi_far_behind_declares_over_damaten() {
+        // #189: 大きく負けているときは満貫確定でもダマにせずリーチで打点を伸ばす
+        let mut state = riichi_state(&GOOD_SHAPE_TENPAI, Tile::Z3);
+        state.my_seat_wind = Wind::South;
+        state.dora_indicators = vec![Tile::new(Tile::S7), Tile::new(Tile::M3)]; // ドラ3
+        state.scores = [42000, 8000, 25000, 25000]; // 自分(南)は大差ラス
+        let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+        let ctx = CallContext {
+            state: &state,
+            config: &config,
+        };
+        assert_eq!(judge_riichi(&ctx, None), RiichiJudgement::Declare);
     }
 
     // --- リーチ・ダマ判断（#168〜#172）---

--- a/crates/mahjong-server/src/cpu/state.rs
+++ b/crates/mahjong-server/src/cpu/state.rs
@@ -48,6 +48,8 @@ pub struct CpuGameState {
     pub remaining_tiles: usize,
     /// 局番号（東1局=0, 東2局=1, ...）
     pub round_number: usize,
+    /// ゲーム全体の局数（東風戦=4, 東南戦=8。0なら不明）
+    pub total_rounds: usize,
     /// 本場数
     pub honba: usize,
     /// 供託リーチ棒
@@ -86,6 +88,7 @@ impl CpuGameState {
             prevailing_wind: Wind::East,
             remaining_tiles: 0,
             round_number: 0,
+            total_rounds: 0,
             honba: 0,
             riichi_sticks: 0,
             pending_calls: Vec::new(),
@@ -115,6 +118,7 @@ impl CpuGameState {
                 prevailing_wind,
                 dora_indicators,
                 round_number,
+                total_rounds,
                 honba,
                 riichi_sticks,
                 ..
@@ -136,6 +140,7 @@ impl CpuGameState {
                 self.prevailing_wind = *prevailing_wind;
                 self.remaining_tiles = 70; // 136 - 14(王牌) - 13*4(配牌) = 70
                 self.round_number = *round_number;
+                self.total_rounds = *total_rounds;
                 self.honba = *honba;
                 self.riichi_sticks = *riichi_sticks;
                 self.pending_calls.clear();
@@ -306,6 +311,37 @@ impl CpuGameState {
         &self.all_discards[Self::wind_to_index(self.my_seat_wind)]
     }
 
+    /// オーラス（最終局）か。総局数が不明（0）なら false
+    pub fn is_final_round(&self) -> bool {
+        self.total_rounds > 0 && self.round_number + 1 >= self.total_rounds
+    }
+
+    /// ゲーム後半（東南戦の南場など）か。総局数が不明なら false
+    pub fn is_second_half(&self) -> bool {
+        self.total_rounds > 0 && self.round_number >= self.total_rounds / 2
+    }
+
+    /// 自分の得点
+    pub fn my_score(&self) -> i32 {
+        self.scores[Self::wind_to_index(self.my_seat_wind)]
+    }
+
+    /// 自分がトップ目か（同点トップを含む）
+    pub fn is_top(&self) -> bool {
+        let my = self.my_score();
+        self.scores.iter().all(|&s| s <= my)
+    }
+
+    /// 順位を1つ上げるのに必要な最小点差（トップなら None）
+    pub fn gap_to_next_rank(&self) -> Option<i32> {
+        let my = self.my_score();
+        self.scores
+            .iter()
+            .filter(|&&s| s > my)
+            .map(|&s| s - my)
+            .min()
+    }
+
     /// 自分の副露を返す
     pub fn my_melds(&self) -> &[Meld] {
         &self.player_melds[Self::wind_to_index(self.my_seat_wind)]
@@ -421,6 +457,7 @@ mod tests {
             prevailing_wind: Wind::East,
             dora_indicators: vec![Tile::new(Tile::M5)],
             round_number: 0,
+            total_rounds: 0,
             honba: 0,
             riichi_sticks: 0,
         });
@@ -472,6 +509,7 @@ mod tests {
             prevailing_wind: Wind::East,
             dora_indicators: vec![Tile::new(Tile::Z1)],
             round_number: 4,
+            total_rounds: 4,
             honba: 1,
             riichi_sticks: 1,
         });
@@ -810,6 +848,53 @@ mod tests {
         assert_eq!(state.scores, [25000, 26000, 24000, 25000]);
         assert_eq!(state.pending_calls.len(), 1);
         assert_eq!(state.pending_call_tile, Some(Tile::new(Tile::Z1)));
+    }
+
+    #[test]
+    fn test_round_position_helpers() {
+        let mut state = CpuGameState::new();
+        state.total_rounds = 4; // 東風戦
+
+        // 東1局: 前半・オーラスでない
+        state.round_number = 0;
+        assert!(!state.is_final_round());
+        assert!(!state.is_second_half());
+
+        // 東3局: 後半
+        state.round_number = 2;
+        assert!(!state.is_final_round());
+        assert!(state.is_second_half());
+
+        // 東4局: オーラス
+        state.round_number = 3;
+        assert!(state.is_final_round());
+
+        // 総局数が不明（0）なら常に false
+        state.total_rounds = 0;
+        assert!(!state.is_final_round());
+        assert!(!state.is_second_half());
+    }
+
+    #[test]
+    fn test_score_position_helpers() {
+        let mut state = CpuGameState::new();
+        state.my_seat_wind = Wind::South;
+        state.scores = [25000, 30000, 20000, 25000];
+
+        assert_eq!(state.my_score(), 30000);
+        assert!(state.is_top());
+        assert_eq!(state.gap_to_next_rank(), None);
+
+        // 3着のとき: 次の順位（東 25000）までの差
+        state.scores = [25000, 22000, 30000, 23000];
+        assert_eq!(state.my_score(), 22000);
+        assert!(!state.is_top());
+        assert_eq!(state.gap_to_next_rank(), Some(1000));
+
+        // 同点トップはトップ扱い
+        state.scores = [30000, 30000, 20000, 20000];
+        assert!(state.is_top());
+        assert_eq!(state.gap_to_next_rank(), None);
     }
 
     #[test]

--- a/crates/mahjong-server/src/protocol.rs
+++ b/crates/mahjong-server/src/protocol.rs
@@ -90,6 +90,8 @@ pub enum ServerEvent {
         dora_indicators: Vec<Tile>,
         /// 局番号（0-based: 東1局=0, 東2局=1, ...）
         round_number: usize,
+        /// ゲーム全体の局数（東風戦=4, 東南戦=8。オーラス判定に使用）
+        total_rounds: usize,
         /// 本場数
         honba: usize,
         /// 供託リーチ棒の本数

--- a/crates/mahjong-server/src/round/mod.rs
+++ b/crates/mahjong-server/src/round/mod.rs
@@ -129,6 +129,7 @@ impl Round {
     /// - `prevailing_wind`: 場風（東場なら East）
     /// - `dealer`: 親のプレイヤーインデックス（0-3）
     /// - `initial_scores`: 各プレイヤーの初期点数
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         prevailing_wind: Wind,
         dealer: usize,
@@ -136,6 +137,7 @@ impl Round {
         honba: usize,
         riichi_sticks: usize,
         round_number: usize,
+        total_rounds: usize,
         settings: Settings,
     ) -> Self {
         Self::with_wall(
@@ -146,6 +148,7 @@ impl Round {
             honba,
             riichi_sticks,
             round_number,
+            total_rounds,
             settings,
         )
     }
@@ -162,6 +165,7 @@ impl Round {
         honba: usize,
         riichi_sticks: usize,
         round_number: usize,
+        total_rounds: usize,
         settings: Settings,
     ) -> Self {
         Self::with_wall(
@@ -172,6 +176,7 @@ impl Round {
             honba,
             riichi_sticks,
             round_number,
+            total_rounds,
             settings,
         )
     }
@@ -186,6 +191,7 @@ impl Round {
         honba: usize,
         riichi_sticks: usize,
         round_number: usize,
+        total_rounds: usize,
         settings: Settings,
     ) -> Self {
         let dealt = wall.deal();
@@ -219,6 +225,7 @@ impl Round {
                     prevailing_wind,
                     dora_indicators: dora_indicators.clone(),
                     round_number,
+                    total_rounds,
                     honba,
                     riichi_sticks,
                 },
@@ -1832,7 +1839,7 @@ mod tests {
 
     #[test]
     fn test_round_new() {
-        let round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         assert_eq!(round.prevailing_wind, Wind::East);
         assert_eq!(round.current_player, 0);
         assert_eq!(round.phase, TurnPhase::Draw);
@@ -1851,7 +1858,7 @@ mod tests {
     fn test_round_draw() {
         // 固定シードで牌山を生成し、初回ツモが九種九牌にならないことを保証する
         let mut round =
-            Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+            Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         round.drain_events(); // 初期イベントをクリア
 
         assert!(round.do_draw());
@@ -1867,7 +1874,7 @@ mod tests {
     fn test_round_discard() {
         // 固定シードで牌山を生成し、初回ツモが九種九牌にならないことを保証する
         let mut round =
-            Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+            Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         round.drain_events();
         round.do_draw();
         round.drain_events();
@@ -1904,7 +1911,7 @@ mod tests {
     fn test_round_discard_rejects_tile_not_in_hand() {
         // 固定シードで牌山を生成し、初回ツモが九種九牌にならないことを保証する
         let mut round =
-            Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+            Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         round.drain_events();
         round.do_draw();
         round.drain_events();
@@ -1921,7 +1928,7 @@ mod tests {
     fn test_round_turn_flow() {
         // 固定シードで牌山を生成し、テストの再現性を確保する
         let mut round =
-            Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+            Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         round.drain_events();
 
         // 4人分のターンを回す
@@ -1971,7 +1978,7 @@ mod tests {
 
     #[test]
     fn test_round_play_to_end() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         round.play_to_end();
 
         assert!(round.is_over());
@@ -1987,6 +1994,7 @@ mod tests {
             0,
             0,
             0,
+            4,
             Settings::new(),
         );
         let scores = round.get_scores();
@@ -1995,7 +2003,7 @@ mod tests {
 
     #[test]
     fn test_round_events_on_start() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         let events = round.drain_events();
 
         // 4人分のGameStartedイベント
@@ -2025,7 +2033,7 @@ mod tests {
         // 打牌後に WaitForCalls になった場合、全員パスで Draw に進む
         // 固定シードで牌山を生成し、初回ツモが九種九牌にならないことを保証する
         let mut round =
-            Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+            Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         round.drain_events();
         round.do_draw();
         round.drain_events();
@@ -2049,7 +2057,7 @@ mod tests {
 
     #[test]
     fn test_check_available_calls_offers_pon_but_not_ron_for_5z() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         let seat_wind = round.players[1].seat_wind;
         let hand = mahjong_core::hand::Hand::from("234678m56p567s55z");
         round.players[1] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
@@ -2102,7 +2110,7 @@ mod tests {
     fn test_open_tanyao_disabled_blocks_tsumo() {
         let mut settings = Settings::new();
         settings.opened_all_simples = false;
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, settings);
 
         let seat_wind = round.players[0].seat_wind;
         round.players[0] = open_tanyao_player(seat_wind, true);
@@ -2118,7 +2126,7 @@ mod tests {
     fn test_open_tanyao_disabled_does_not_offer_ron() {
         let mut settings = Settings::new();
         settings.opened_all_simples = false;
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, settings);
 
         let seat_wind = round.players[1].seat_wind;
         round.players[1] = open_tanyao_player(seat_wind, false);
@@ -2134,7 +2142,7 @@ mod tests {
 
     #[test]
     fn test_do_riichi_requires_tenpai_after_discard() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         let seat_wind = round.players[0].seat_wind;
         let hand = mahjong_core::hand::Hand::from("123m123p123s45z67m 8m");
         round.players[0] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
@@ -2153,7 +2161,7 @@ mod tests {
 
     #[test]
     fn test_do_riichi_deducts_score_and_adds_stick() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         let seat_wind = round.players[0].seat_wind;
         let hand = mahjong_core::hand::Hand::from("123m123p123s45z67m 8m");
         round.players[0] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
@@ -2169,7 +2177,7 @@ mod tests {
 
     #[test]
     fn test_check_available_calls_offers_daiminkan() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         let seat_wind = round.players[1].seat_wind;
         let hand = mahjong_core::hand::Hand::from("111m234p567s789m");
         round.players[1] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
@@ -2184,7 +2192,7 @@ mod tests {
 
     #[test]
     fn test_do_ankan_draws_rinshan_and_reveals_dora() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         let seat_wind = round.players[0].seat_wind;
         let hand = mahjong_core::hand::Hand::from("111m234p567s789m 1m");
         round.players[0] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
@@ -2202,7 +2210,7 @@ mod tests {
 
     #[test]
     fn test_do_kakan_draws_rinshan_and_reveals_dora() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         let seat_wind = round.players[0].seat_wind;
         let mut player = Player::new(seat_wind, vec![], 25000);
         player.hand = mahjong_core::hand::Hand::from("234p567s789m1z 111m 1m");
@@ -2223,7 +2231,7 @@ mod tests {
 
     #[test]
     fn test_do_kakan_keeps_unrelated_drawn_tile_in_hand() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         let seat_wind = round.players[0].seat_wind;
         let mut player = Player::new(seat_wind, vec![], 25000);
         player.hand = mahjong_core::hand::Hand::from("127m234p567s1z 111m 9s");
@@ -2247,7 +2255,7 @@ mod tests {
     #[test]
     fn test_temporary_furiten_set_on_ron_pass() {
         // プレイヤー1がロン可能な状態で、パスすると同巡フリテンが設定される
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
 
         // プレイヤー1にテンパイ手を設定: 123m456p789s11z 待ち1z（場風東）
         let seat1 = round.players[1].seat_wind;
@@ -2286,7 +2294,7 @@ mod tests {
 
     #[test]
     fn test_temporary_furiten_cleared_on_draw() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         round.drain_events();
 
         // プレイヤー1に同巡フリテンを設定
@@ -2304,7 +2312,7 @@ mod tests {
     #[test]
     fn test_riichi_furiten_set_on_ron_pass() {
         // リーチ中のプレイヤーがロンを見逃すとリーチ後フリテンが設定される
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
 
         let seat1 = round.players[1].seat_wind;
         let hand1 = mahjong_core::hand::Hand::from("123m456p789s1122z");
@@ -2339,7 +2347,7 @@ mod tests {
 
     #[test]
     fn test_riichi_furiten_persists_after_draw() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         round.drain_events();
 
         // リーチ後フリテンを設定
@@ -2358,7 +2366,7 @@ mod tests {
     #[test]
     fn test_temporary_furiten_blocks_ron() {
         // 同巡フリテンのプレイヤーにはロンが提供されない
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
 
         let seat1 = round.players[1].seat_wind;
         let hand1 = mahjong_core::hand::Hand::from("123m456p789s1122z");
@@ -2379,7 +2387,7 @@ mod tests {
     #[test]
     fn test_kakan_ron_pass_sets_furiten() {
         // 加カンで搶槓可能だがパスした場合、フリテンが設定される
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
 
         let seat0 = round.players[0].seat_wind;
         let mut player0 = Player::new(seat0, vec![], 25000);
@@ -2413,7 +2421,7 @@ mod tests {
         // 再現テスト: 6m7m1p2p3p3p4p5p5p6p7s8s9s ツモ8m
         // shanten=0 で riichi_discards がある（3p,3p,5p,5p,6p）
         // → can_riichi = true であるべき
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
 
         let seat0 = round.players[0].seat_wind;
         let hand = mahjong_core::hand::Hand::from("67m12334556p789s");
@@ -2439,7 +2447,7 @@ mod tests {
 
     #[test]
     fn test_kakan_offers_rob_ron() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
 
         let seat0 = round.players[0].seat_wind;
         let mut player0 = Player::new(seat0, vec![], 25000);
@@ -2496,7 +2504,7 @@ mod tests {
 
     #[test]
     fn test_check_nine_terminals_qualifies() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         setup_nine_terminals_hand(&mut round, 0);
         // 初回ツモ（捨て牌0枚）かつヤオ九牌9種以上
         assert!(round.check_nine_terminals());
@@ -2504,7 +2512,7 @@ mod tests {
 
     #[test]
     fn test_check_nine_terminals_insufficient_types() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         let seat = round.players[0].seat_wind;
         let mut player = Player::new(seat, vec![], 25000);
         // ヤオ九牌が8種類のみ（6z・7zがなく中張牌が多い）
@@ -2518,7 +2526,7 @@ mod tests {
 
     #[test]
     fn test_check_nine_terminals_after_discard() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         setup_nine_terminals_hand(&mut round, 0);
         // 捨て牌を1枚追加（既に1巡した状態を再現）
         round.players[0].discards.push(crate::player::Discard {
@@ -2533,7 +2541,7 @@ mod tests {
 
     #[test]
     fn test_do_nine_terminals_declare() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         setup_nine_terminals_hand(&mut round, 0);
         round.phase = TurnPhase::WaitForNineTerminals;
         round.drain_events();
@@ -2557,7 +2565,7 @@ mod tests {
 
     #[test]
     fn test_do_nine_terminals_continue() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         setup_nine_terminals_hand(&mut round, 0);
         round.phase = TurnPhase::WaitForNineTerminals;
         round.drain_events();
@@ -2570,7 +2578,7 @@ mod tests {
 
     #[test]
     fn test_do_nine_terminals_wrong_player() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         setup_nine_terminals_hand(&mut round, 0);
         round.phase = TurnPhase::WaitForNineTerminals;
 
@@ -2590,7 +2598,7 @@ mod tests {
         }
         let wall = Wall::from_tiles(wall_tiles);
 
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         round.wall = wall;
 
         // 手牌をヤオ九牌12種に設定（ツモで7zが来て13種になる）
@@ -2631,7 +2639,7 @@ mod tests {
         }
         let wall = Wall::from_tiles(wall_tiles);
 
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         round.wall = wall;
         let seat = round.players[0].seat_wind;
         let mut player = Player::new(seat, vec![], 25000);
@@ -2667,7 +2675,7 @@ mod tests {
 
         let mut settings = Settings::new();
         settings.nine_terminals_draw = false;
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, settings);
         round.wall = wall;
 
         let seat = round.players[0].seat_wind;
@@ -2717,7 +2725,7 @@ mod tests {
     fn test_triple_ron_draw_enabled() {
         let mut settings = Settings::new();
         settings.triple_ron_draw = true;
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, settings);
         setup_triple_ron(&mut round);
         round.drain_events();
 
@@ -2754,7 +2762,7 @@ mod tests {
         let mut settings = Settings::new();
         settings.triple_ron_draw = true;
         settings.multiple_ron = true;
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, settings);
         setup_triple_ron(&mut round);
         round.drain_events();
 
@@ -2784,7 +2792,7 @@ mod tests {
         let mut settings = Settings::new();
         settings.triple_ron_draw = false;
         settings.multiple_ron = false;
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, settings);
         setup_triple_ron(&mut round);
         round.drain_events();
 
@@ -2812,7 +2820,7 @@ mod tests {
         let mut settings = Settings::new();
         settings.triple_ron_draw = true;
         // multiple_ron=true（デフォルト）なので両方和了
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, settings);
         setup_triple_ron(&mut round);
         round.drain_events();
 
@@ -2839,7 +2847,7 @@ mod tests {
         // multiple_ron=false の場合は上家取り（頭ハネ）の1人ロン
         let mut settings = Settings::new();
         settings.multiple_ron = false;
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, settings);
         setup_triple_ron(&mut round);
         round.drain_events();
 
@@ -2864,7 +2872,7 @@ mod tests {
     #[test]
     fn test_double_ron_both_win() {
         // multiple_ron=true（デフォルト）: 2人ロンで両方和了
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         setup_triple_ron(&mut round);
         round.drain_events();
 
@@ -2890,7 +2898,7 @@ mod tests {
         let mut settings = Settings::new();
         settings.multiple_ron = true;
         settings.triple_ron_draw = false;
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, settings);
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, settings);
         setup_triple_ron(&mut round);
         round.drain_events();
 
@@ -2914,7 +2922,7 @@ mod tests {
     fn test_double_ron_scores() {
         // ダブロン時のスコア: 各和了者が放銃者から独立して点数を受け取る
         // 本場ボーナスは上家取りで最初の和了者（プレイヤー1）のみ
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 1, 0, 0, Settings::new()); // honba=1
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 1, 0, 0, 4, Settings::new()); // honba=1
         setup_triple_ron(&mut round);
         round.drain_events();
 
@@ -2955,7 +2963,7 @@ mod tests {
     #[test]
     fn test_double_ron_events_generated() {
         // ダブロン時に各和了者分のRoundWonイベントが生成されること
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         setup_triple_ron(&mut round);
         round.drain_events();
 
@@ -2980,7 +2988,7 @@ mod tests {
     fn test_multi_ron_riichi_sticks_first_winner_only() {
         // 供託棒は最初の和了者（プレイヤー1）のみ取得
         let settings = Settings::new();
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 2, 0, settings); // riichi_sticks=2
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 2, 0, 4, settings); // riichi_sticks=2
         setup_triple_ron(&mut round);
         round.drain_events();
 
@@ -3007,7 +3015,7 @@ mod tests {
 
     #[test]
     fn test_auto_pass_cpu_no_op_when_wrong_phase() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
         assert_eq!(round.phase, TurnPhase::Draw);
         round.auto_pass_cpu(0);
         assert_eq!(round.phase, TurnPhase::Draw);
@@ -3015,7 +3023,7 @@ mod tests {
 
     #[test]
     fn test_auto_pass_cpu_passes_cpu_players_and_resolves() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
 
         // プレイヤー1に5zポン可能な手牌をセット
         let seat1 = round.players[1].seat_wind;
@@ -3040,7 +3048,7 @@ mod tests {
 
     #[test]
     fn test_auto_pass_cpu_skips_human_player() {
-        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, Settings::new());
+        let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
 
         // プレイヤー1に5zポン可能な手牌をセット
         let seat1 = round.players[1].seat_wind;

--- a/crates/mahjong-server/src/table.rs
+++ b/crates/mahjong-server/src/table.rs
@@ -69,6 +69,11 @@ impl Table {
         }
     }
 
+    /// ゲーム全体の局数（東風戦=4, 東南戦=8）を返す
+    fn total_rounds(&self) -> usize {
+        self.settings.round_count as usize * 4
+    }
+
     /// 新しい局を開始する
     pub fn start_round(&mut self) {
         let round = Round::new(
@@ -78,6 +83,7 @@ impl Table {
             self.honba,
             self.riichi_sticks,
             self.round_number,
+            self.total_rounds(),
             self.settings.rules.clone(),
         );
         self.round = Some(round);
@@ -95,6 +101,7 @@ impl Table {
             self.honba,
             self.riichi_sticks,
             self.round_number,
+            self.total_rounds(),
             self.settings.rules.clone(),
         );
         self.round = Some(round);


### PR DESCRIPTION
## Summary

The **final convention batch** for #142, closing #183, #184, #185, #186, #187, #188, #189, #190 and #191. With this PR, every convention listed in the issue is implemented.

## Protocol extension (separate commit)

`GameStarted` now carries **`total_rounds`** (4 for east-only, 8 for hanchan), threaded from `GameSettings.round_count` through the `Round` constructors. Clients previously had no way to tell whether the current round is the last — which #187/#188 require. `CpuGameState` stores it and gains position helpers: `is_final_round`, `is_second_half`, `my_score`, `is_top`, `gap_to_next_rank` (minimum score difference to climb one rank).

## Conventions implemented

**終盤処理:**

- **#183 終盤の遠い手は降りる** (Weak+): with ≤12 tiles left and a 2+ shanten hand, stop pushing regardless of threats or value — placed *before* the push/fold judgement so even a dora-heavy hand doesn't chase at that point.
- **#184 終盤の形式聴牌** (Normal+): when folding near exhaustion (≤8 tiles) with a close hand, the defense safety weight drops to 150 — the CPU takes keishiki tenpai with reasonably safe tiles instead of full betaori.
- **#185 聴牌維持の重要度** (Strong+): weight drops further to 120 when dealer (連荘) or in the final round while not top.
- **#186 河底牌で危険牌を切らない** (Normal+): the last discard of the round (empty wall) gets safety ×200 *even while attacking*, when any threat exists. The weight is tuned so suji-grade tiles still keep keishiki tenpai, but no-suji middles are not pushed — no future turn justifies it.

**点棒状況:**

- **#187 オーラスの必要打点** (Normal+): cheap-call suppression (#165) is lifted when a cheap win still climbs a rank (gap ≤ 3900 — speed wins), and extends to *close* (1-shanten) calls when only a mangan-class win helps (gap ≥ 8000).
- **#188 トップ目は放銃回避** (Normal+): a top CPU in the second half folds against threats unless holding a good-shape mangan-class tenpai.
- **#189 ラス目は打点寄り** (Normal+): far behind, the 2-shanten push threshold drops (6.0 → 4.0) and confirmed-mangan hands declare riichi instead of damaten (stacking value beats win availability when a big hand is needed).
- **#190 親は押し寄り** (Normal+): dealers keep pushing cheap bad-shape tenpai against a single threat instead of folding.
- **#191 供託・本場** (Strong+): with 2000+ points of sticks/honba on the table, cheap tenpai isn't folded and cheap calls are allowed — the pot subsidizes the hand.

## Simulation results (100 east-only games)

Aggregates hold at series-best levels (endgame/score situations are a minority of decisions): Strong avg rank **2.12 / 2.01**, win 27.1% / 30.0%, vs baseline 2.49 / 2.43. The east-only simulation does exercise オーラス (`total_rounds = 4` → 東4局). No stalls.

## Test plan

- 13 new tests: state position helpers (round/score), last-discard safety (wall/threat gating), final-round speed exemption and mangan-needed tightening, stakes exemptions with level gating (calls + tenpai), top-second-half fold with mangan exception and first-half contrast, far-behind threshold drop and riichi-over-damaten, dealer cheap-tenpai neutrality, keishiki weights (150/120 incl. dealer case)
- `cargo build` / `cargo test` ✓ (602 tests passing)
- `cargo fmt` / `cargo clippy` ✓ (no warnings)

Closes #183, closes #184, closes #185, closes #186, closes #187, closes #188, closes #189, closes #190, closes #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)