### PR TITLE
Add content-hash cache busting for web assets

### DIFF
--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -18,4 +18,14 @@ cargo build --release --target wasm32-unknown-unknown -p mahjong-client
 curl -L https://not-fl3.github.io/miniquad-samples/mq_js_bundle.js -o public/mq_js_bundle.js
 cp target/wasm32-unknown-unknown/release/mahjong-client.wasm public/mahjong-client.wasm
 cp index.html public/index.html
-sed -i 's|target/wasm32-unknown-unknown/release/mahjong-client.wasm|mahjong-client.wasm|' public/index.html
+
+# Rename assets with a content hash so browsers can cache them immutably
+# (see the Cache-Control headers in vercel.json) without ever serving a
+# stale version after a new deployment.
+wasm_hash=$(sha1sum public/mahjong-client.wasm | cut -c1-8)
+js_hash=$(sha1sum public/mq_js_bundle.js | cut -c1-8)
+mv public/mahjong-client.wasm "public/mahjong-client.${wasm_hash}.wasm"
+mv public/mq_js_bundle.js "public/mq_js_bundle.${js_hash}.js"
+
+sed -i "s|target/wasm32-unknown-unknown/release/mahjong-client.wasm|mahjong-client.${wasm_hash}.wasm|" public/index.html
+sed -i "s|mq_js_bundle.js|mq_js_bundle.${js_hash}.js|" public/index.html

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,16 @@
   "installCommand": "bash scripts/vercel-install.sh",
   "buildCommand": "bash scripts/vercel-build.sh",
   "outputDirectory": "public",
-  "cleanUrls": true
+  "cleanUrls": true,
+  "headers": [
+    {
+      "source": "/(.*)\\.(wasm|js)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Fixes #205

When a new version is deployed, asset filenames staying the same means browsers may rely on cached copies. This PR adds content-hash-based cache busting to the Vercel build:

- `scripts/vercel-build.sh` now renames `mahjong-client.wasm` and `mq_js_bundle.js` to `mahjong-client.<sha1-8>.wasm` / `mq_js_bundle.<sha1-8>.js` and rewrites the references in `public/index.html` accordingly.
- `vercel.json` now serves `.wasm` / `.js` files with `Cache-Control: public, max-age=31536000, immutable`. This is safe because every deployed wasm/js filename embeds its content hash.
- `index.html` keeps Vercel's default `max-age=0, must-revalidate`, so browsers always pick up the latest entry point, which in turn points at the correct hashed assets.

Benefits:
- Repeat visits load the multi-MB wasm from the browser cache with zero network requests.
- No version mismatch between `index.html` and the wasm across deployments.

Local development is unaffected: the root `index.html` and `mq_js_bundle.js` are untouched; only the generated `public/` output uses hashed names.

## Test plan

- Verified the hash/rename/sed logic end to end with dummy files: output contains `mahjong-client.<hash>.wasm` / `mq_js_bundle.<hash>.js` and `public/index.html` references both hashed names correctly.
- `bash -n scripts/vercel-build.sh` passes; `vercel.json` validated as JSON.
- No Rust code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)