### PR TITLE
Add mahjong-net-server: WebSocket game server with room-code lobby

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,10 +30,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite 0.29.0",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -48,6 +115,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +134,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"
@@ -72,8 +154,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "rand_core",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -81,6 +163,15 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -98,6 +189,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -142,6 +259,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +292,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -178,9 +319,32 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
 ]
 
 [[package]]
@@ -191,8 +355,8 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -233,6 +397,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +512,12 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -311,7 +561,7 @@ checksum = "64b1d96218903768c1ce078b657c0d5965465c95a60d2682fd97443c9d2483dd"
 name = "mahjong-client"
 version = "0.1.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "macroquad",
  "mahjong-core",
  "mahjong-server",
@@ -323,11 +573,27 @@ name = "mahjong-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "rand",
+ "rand 0.10.1",
  "rstest",
  "serde",
  "strum",
  "strum_macros",
+]
+
+[[package]]
+name = "mahjong-net-server"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "futures-util",
+ "mahjong-server",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite 0.27.0",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -336,7 +602,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "mahjong-core",
- "rand",
+ "rand 0.10.1",
  "serde",
  "serde_json",
 ]
@@ -351,10 +617,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniquad"
@@ -379,10 +666,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "ndk-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1bcdd74c20ad5d95aacd60ef9ba40fdf77f767051040541df557b7a9b2a2121"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "num-traits"
@@ -403,6 +710,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +738,15 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -466,9 +794,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -477,8 +821,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom",
- "rand_core",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -561,6 +924,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +979,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +1032,22 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "strum"
@@ -648,6 +1076,91 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.27.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -681,10 +1194,139 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -697,6 +1339,30 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -771,6 +1437,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "winnow"
@@ -873,6 +1554,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/mahjong-client/src/adapter.rs
+++ b/crates/mahjong-client/src/adapter.rs
@@ -4,11 +4,21 @@
 //! CPUプレイヤーは人間と同じプロトコル（ServerEvent / ClientAction）で
 //! サーバとやり取りする。
 
+use std::collections::VecDeque;
+
+use macroquad::miniquad::date;
 use mahjong_server::cpu::client::{CpuClient, CpuConfig};
 use mahjong_server::cpu::personalities::default_cpu_configs;
 use mahjong_server::protocol::{ClientAction, ServerEvent};
 use mahjong_server::round::TurnPhase;
 use mahjong_server::table::{GameSettings, Table};
+
+const CPU_ACTION_DELAY_SECONDS: f64 = 1.0;
+
+struct PendingCpuActionBatch {
+    actions: Vec<(usize, ClientAction)>,
+    ready_at: f64,
+}
 
 /// ローカルアダプター: サーバを内蔵し、直接通信する
 pub struct LocalAdapter {
@@ -19,6 +29,8 @@ pub struct LocalAdapter {
     cpu_clients: [Option<CpuClient>; 4],
     /// 人間プレイヤー向けのイベントバッファ
     human_event_buffer: Vec<ServerEvent>,
+    /// 思考待ち中のCPUアクション（イベント処理単位のFIFO）
+    pending_cpu_action_batches: VecDeque<PendingCpuActionBatch>,
 }
 
 impl LocalAdapter {
@@ -48,6 +60,7 @@ impl LocalAdapter {
             human_player,
             cpu_clients,
             human_event_buffer: Vec::new(),
+            pending_cpu_action_batches: VecDeque::new(),
         }
     }
 
@@ -61,6 +74,7 @@ impl LocalAdapter {
 
     /// ゲームを開始する（最初の局を開始）
     pub fn start_game(&mut self) {
+        self.pending_cpu_action_batches.clear();
         self.table.start_round();
         // 局開始時のイベントをCPUに配信（人間イベントはバッファへ）
         self.process_all_events();
@@ -90,6 +104,15 @@ impl LocalAdapter {
     /// - 人間プレイヤーの手番ならUIで入力待ち
     /// - CPUプレイヤーの手番ならイベント配信で自動判断
     pub fn tick(&mut self) {
+        self.tick_at(date::now());
+    }
+
+    fn tick_at(&mut self, now: f64) {
+        // CPUが操作したティックでは次のツモまで進めず、操作順を画面に反映する。
+        if self.process_all_events_at(now) || !self.pending_cpu_action_batches.is_empty() {
+            return;
+        }
+
         let round = match self.table.current_round_mut() {
             Some(r) => r,
             None => return,
@@ -113,38 +136,69 @@ impl LocalAdapter {
         }
 
         // 生成されたイベントを処理（CPU配信 + 人間バッファリング）
-        self.process_all_events();
+        self.process_all_events_at(now);
     }
 
     /// サーバからイベントを取得し、CPUに配信しつつ人間イベントをバッファする
     ///
-    /// CPUのアクションが新たなイベントを生成する可能性があるためループする。
+    /// CPUのアクションは待機キューへ追加し、次回以降の呼び出しで実行する。
     fn process_all_events(&mut self) {
-        loop {
-            let all_events = self.table.drain_events();
-            if all_events.is_empty() {
-                break;
-            }
+        self.process_all_events_at(date::now());
+    }
 
-            // 人間プレイヤーのイベントをバッファに追加
-            for (idx, event) in &all_events {
-                if *idx == self.human_player {
-                    self.human_event_buffer.push(event.clone());
-                }
-            }
+    fn process_all_events_at(&mut self, now: f64) -> bool {
+        let cpu_acted = self.apply_ready_cpu_actions(now);
 
-            // CPUプレイヤーにイベントを配信してアクションを収集
-            let cpu_actions = self.collect_cpu_actions(&all_events);
+        let all_events = self.table.drain_events();
+        if all_events.is_empty() {
+            return cpu_acted;
+        }
 
-            if cpu_actions.is_empty() {
-                break;
-            }
-
-            // CPUのアクションをサーバに送信（これが新たなイベントを生成する）
-            for (player_idx, action) in cpu_actions {
-                self.table.handle_action(player_idx, action);
+        // 人間プレイヤーのイベントをバッファに追加
+        for (idx, event) in &all_events {
+            if *idx == self.human_player {
+                self.human_event_buffer.push(event.clone());
             }
         }
+
+        // CPUプレイヤーにイベントを配信してアクションを収集
+        let cpu_actions = self.collect_cpu_actions(&all_events);
+        self.schedule_cpu_actions(cpu_actions, now);
+
+        cpu_acted
+    }
+
+    fn schedule_cpu_actions(&mut self, actions: Vec<(usize, ClientAction)>, now: f64) {
+        if actions.is_empty() {
+            return;
+        }
+
+        let ready_at = self
+            .pending_cpu_action_batches
+            .back()
+            .map_or(now + CPU_ACTION_DELAY_SECONDS, |pending| {
+                pending.ready_at.max(now) + CPU_ACTION_DELAY_SECONDS
+            });
+
+        // 同じイベント処理で生じた応答は、鳴き解決などのため同時に適用する。
+        self.pending_cpu_action_batches
+            .push_back(PendingCpuActionBatch { actions, ready_at });
+    }
+
+    fn apply_ready_cpu_actions(&mut self, now: f64) -> bool {
+        let Some(pending) = self.pending_cpu_action_batches.front() else {
+            return false;
+        };
+        if pending.ready_at > now {
+            return false;
+        }
+
+        let pending = self.pending_cpu_action_batches.pop_front().unwrap();
+        for (player_idx, action) in pending.actions {
+            self.table.handle_action(player_idx, action);
+        }
+
+        true
     }
 
     /// CPUプレイヤーにイベントを配信し、アクションを収集する
@@ -180,6 +234,7 @@ impl LocalAdapter {
 
     /// 次の局を開始する
     pub fn next_round(&mut self) {
+        self.pending_cpu_action_batches.clear();
         self.table.finish_round();
         if !self.table.is_game_over {
             self.table.start_round();
@@ -379,5 +434,66 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_cpu_action_is_applied_after_one_second_delay() {
+        let mut adapter = LocalAdapter::new();
+        adapter.table.start_round();
+
+        {
+            let round = adapter.table.current_round_mut().unwrap();
+            round.current_player = 1;
+            round.phase = TurnPhase::WaitForDiscard;
+            round.players[1].draw(Tile::new(Tile::Z7));
+            round.drain_events();
+        }
+
+        adapter.schedule_cpu_actions(vec![(1, ClientAction::Discard { tile: None })], 10.0);
+
+        adapter.process_all_events_at(10.999);
+        assert_eq!(
+            adapter.table.current_round().unwrap().phase,
+            TurnPhase::WaitForDiscard
+        );
+
+        adapter.process_all_events_at(11.0);
+        assert_ne!(
+            adapter.table.current_round().unwrap().phase,
+            TurnPhase::WaitForDiscard
+        );
+    }
+
+    #[test]
+    fn test_only_one_cpu_action_batch_is_applied_per_tick() {
+        let mut adapter = LocalAdapter::new();
+        adapter.table.start_round();
+
+        {
+            let round = adapter.table.current_round_mut().unwrap();
+            for player_idx in [0, 2, 3] {
+                let seat_wind = round.players[player_idx].seat_wind;
+                let score = round.players[player_idx].score;
+                round.players[player_idx] = Player::new(seat_wind, Vec::new(), score);
+            }
+            round.current_player = 1;
+            round.phase = TurnPhase::WaitForDiscard;
+            round.players[1].draw(Tile::new(Tile::Z7));
+            round.drain_events();
+        }
+
+        adapter.schedule_cpu_actions(vec![(1, ClientAction::Discard { tile: None })], 10.0);
+        adapter.schedule_cpu_actions(vec![(2, ClientAction::Discard { tile: None })], 10.0);
+
+        adapter.tick_at(11.0);
+
+        let round = adapter.table.current_round().unwrap();
+        assert_eq!(round.current_player, 2);
+        assert_eq!(round.phase, TurnPhase::Draw);
+        assert_eq!(adapter.pending_cpu_action_batches.len(), 1);
+        assert_eq!(
+            adapter.pending_cpu_action_batches.front().unwrap().ready_at,
+            12.0
+        );
     }
 }

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -25,8 +25,8 @@ const AGARI_FONT: u16 = 32;
 const BOARD_CENTER_X: f32 = 500.0;
 const BOARD_CENTER_Y: f32 = 380.0;
 
-/// Camera2D の回転角度（度）— 自分(0°)、下家(90°)、対面(180°)、上家(-90°)
-const PLAYER_ROTATIONS: [f32; 4] = [0.0, 90.0, 180.0, -90.0];
+/// Camera2D の回転角度（度）— 自分(0°)、下家(-90°)、対面(180°)、上家(90°)
+const PLAYER_ROTATIONS: [f32; 4] = [0.0, -90.0, 180.0, 90.0];
 
 /// 盤面中心を軸に回転する Camera2D を生成する
 fn make_board_camera(rotation_deg: f32) -> Camera2D {
@@ -976,6 +976,16 @@ fn draw_result(state: &GameState, font: Option<&Font>, tile_textures: &TileTextu
         FONT_SIZE,
         Color::new(0.8, 0.8, 0.8, 0.7),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PLAYER_ROTATIONS;
+
+    #[test]
+    fn player_rotations_place_turn_order_counterclockwise() {
+        assert_eq!(PLAYER_ROTATIONS, [0.0, -90.0, 180.0, 90.0]);
+    }
 }
 
 fn draw_game_over(state: &GameState, font: Option<&Font>) {

--- a/crates/mahjong-net-server/Cargo.toml
+++ b/crates/mahjong-net-server/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mahjong-net-server"
+version = "0.1.0"
+authors = ["hi_go <me@clutte.red>"]
+edition = "2024"
+
+[dependencies]
+mahjong-server = { path = "../mahjong-server" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "net"] }
+axum = { version = "0.8", features = ["ws"] }
+futures-util = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+rand = "0.10"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tokio-tungstenite = "0.27"

--- a/crates/mahjong-net-server/src/connection.rs
+++ b/crates/mahjong-net-server/src/connection.rs
@@ -1,0 +1,309 @@
+//! WebSocket 接続の処理
+//!
+//! ハンドシェイク（Hello/Welcome）、ロビー操作（ルーム作成・参加）、
+//! 入室後のメッセージ中継を行う。1接続につき読み取りタスク（本体）と
+//! 書き込みタスクの2つが動く。
+
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::response::Response;
+use futures_util::stream::{SplitSink, SplitStream};
+use futures_util::{SinkExt, StreamExt};
+use mahjong_server::protocol::net::{ClientMessage, ErrorCode, PROTOCOL_VERSION, ServerMessage};
+use mahjong_server::table::GameSettings;
+use rand::RngExt;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::AppState;
+use crate::room::RoomMsg;
+
+/// 受信が途絶えてから接続を切るまでの時間
+///
+/// サーバは30秒ごとに Ping を送り、クライアント（ブラウザ/tungstenite）は
+/// 自動で Pong を返すため、生きている接続でこの時間無音になることはない。
+const IDLE_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Ping の送信間隔
+const PING_INTERVAL: Duration = Duration::from_secs(30);
+
+/// 接続ごとの送信バッファ（メッセージ数）
+const OUT_BUFFER: usize = 256;
+
+/// セッショントークンを生成する（128ビットのランダム16進文字列）
+fn generate_token() -> String {
+    format!("{:032x}", rand::rng().random::<u128>())
+}
+
+/// `/ws` ハンドラ
+pub async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> Response {
+    ws.on_upgrade(move |socket| handle_socket(socket, state))
+}
+
+async fn handle_socket(socket: WebSocket, state: AppState) {
+    let (sender, receiver) = socket.split();
+    let (out_tx, out_rx) = mpsc::channel::<ServerMessage>(OUT_BUFFER);
+
+    let writer = tokio::spawn(write_loop(sender, out_rx));
+
+    let mut conn = Connection {
+        receiver,
+        out_tx,
+        state,
+    };
+    conn.run().await;
+
+    // out_tx を破棄すると書き込みタスクが Close を送って終了する
+    drop(conn);
+    let _ = writer.await;
+}
+
+/// 送信専用タスク: キューのメッセージを JSON で送り、定期的に Ping を打つ
+async fn write_loop(
+    mut sender: SplitSink<WebSocket, Message>,
+    mut out_rx: mpsc::Receiver<ServerMessage>,
+) {
+    let mut ping = tokio::time::interval(PING_INTERVAL);
+    ping.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // 最初の tick は即時発火するので読み捨てる
+    ping.tick().await;
+
+    loop {
+        tokio::select! {
+            msg = out_rx.recv() => match msg {
+                Some(msg) => {
+                    let json = match msg.to_json() {
+                        Ok(json) => json,
+                        Err(e) => {
+                            tracing::error!("failed to encode message: {e}");
+                            continue;
+                        }
+                    };
+                    if sender.send(Message::Text(json.into())).await.is_err() {
+                        break;
+                    }
+                }
+                None => {
+                    let _ = sender.send(Message::Close(None)).await;
+                    break;
+                }
+            },
+            _ = ping.tick() => {
+                if sender.send(Message::Ping(Vec::new().into())).await.is_err() {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// 読み取り結果
+enum Read {
+    Msg(ClientMessage),
+    Closed,
+}
+
+/// 入室後の中継ループの終わり方
+enum InRoomOutcome {
+    /// 接続が切れた（タスク終了）
+    Closed,
+    /// 退出した（ロビーに戻る）
+    LeftRoom,
+}
+
+struct Connection {
+    receiver: SplitStream<WebSocket>,
+    out_tx: mpsc::Sender<ServerMessage>,
+    state: AppState,
+}
+
+impl Connection {
+    async fn run(&mut self) {
+        // --- ハンドシェイク ---
+        let (token, name) = match self.read().await {
+            Read::Msg(ClientMessage::Hello {
+                protocol_version,
+                session_token,
+                display_name,
+            }) => {
+                if protocol_version != PROTOCOL_VERSION {
+                    self.send_error(
+                        ErrorCode::VersionMismatch,
+                        &format!("server protocol version is {PROTOCOL_VERSION}"),
+                    )
+                    .await;
+                    return;
+                }
+                (session_token.unwrap_or_else(generate_token), display_name)
+            }
+            Read::Msg(_) => {
+                self.send_error(ErrorCode::BadMessage, "expected Hello")
+                    .await;
+                return;
+            }
+            Read::Closed => return,
+        };
+
+        self.send(ServerMessage::Welcome {
+            session_token: token.clone(),
+            protocol_version: PROTOCOL_VERSION,
+        })
+        .await;
+
+        // --- ロビー ⇄ 入室 ---
+        loop {
+            let msg = match self.read().await {
+                Read::Msg(msg) => msg,
+                Read::Closed => return,
+            };
+
+            let room_tx = match msg {
+                ClientMessage::CreateRoom { round_count } => {
+                    if !(1..=2).contains(&round_count) {
+                        self.send_error(ErrorCode::BadMessage, "round_count must be 1 or 2")
+                            .await;
+                        continue;
+                    }
+                    let settings = GameSettings {
+                        round_count,
+                        ..GameSettings::default()
+                    };
+                    let (_code, room_tx) = self.state.lobby.create_room(settings);
+                    Some(room_tx)
+                }
+                ClientMessage::JoinRoom { code } => {
+                    let found = self.state.lobby.get(&code);
+                    if found.is_none() {
+                        self.send_error(ErrorCode::RoomNotFound, "no such room")
+                            .await;
+                    }
+                    found
+                }
+                ClientMessage::Hello { .. } => {
+                    self.send_error(ErrorCode::BadMessage, "already greeted")
+                        .await;
+                    None
+                }
+                _ => {
+                    self.send_error(ErrorCode::NotInRoom, "join a room first")
+                        .await;
+                    None
+                }
+            };
+
+            let Some(room_tx) = room_tx else {
+                continue;
+            };
+
+            // --- 入室 ---
+            let (reply_tx, reply_rx) = oneshot::channel();
+            let join = RoomMsg::Join {
+                name: name.clone(),
+                token: token.clone(),
+                tx: self.out_tx.clone(),
+                reply: reply_tx,
+            };
+            if room_tx.send(join).await.is_err() {
+                self.send_error(ErrorCode::RoomNotFound, "room closed")
+                    .await;
+                continue;
+            }
+            let seat = match reply_rx.await {
+                Ok(Ok(seat)) => seat,
+                Ok(Err(code)) => {
+                    self.send_error(code, "join rejected").await;
+                    continue;
+                }
+                Err(_) => {
+                    self.send_error(ErrorCode::RoomNotFound, "room closed")
+                        .await;
+                    continue;
+                }
+            };
+
+            // --- 中継ループ ---
+            match self.relay(room_tx, seat).await {
+                InRoomOutcome::Closed => return,
+                InRoomOutcome::LeftRoom => continue,
+            }
+        }
+    }
+
+    /// 入室後: クライアントのメッセージをルームへ中継する
+    async fn relay(&mut self, room_tx: mpsc::Sender<RoomMsg>, seat: usize) -> InRoomOutcome {
+        loop {
+            let msg = match self.read().await {
+                Read::Msg(msg) => msg,
+                Read::Closed => {
+                    let _ = room_tx.send(RoomMsg::Disconnected { seat }).await;
+                    return InRoomOutcome::Closed;
+                }
+            };
+
+            match msg {
+                ClientMessage::LeaveRoom => {
+                    let _ = room_tx.send(RoomMsg::Leave { seat }).await;
+                    return InRoomOutcome::LeftRoom;
+                }
+                ClientMessage::Hello { .. }
+                | ClientMessage::CreateRoom { .. }
+                | ClientMessage::JoinRoom { .. } => {
+                    self.send_error(ErrorCode::BadMessage, "already in a room")
+                        .await;
+                }
+                msg => {
+                    if room_tx.send(RoomMsg::FromSeat { seat, msg }).await.is_err() {
+                        // ルームが閉じられた
+                        self.send_error(ErrorCode::RoomNotFound, "room closed")
+                            .await;
+                        return InRoomOutcome::LeftRoom;
+                    }
+                }
+            }
+        }
+    }
+
+    /// 次のクライアントメッセージを読む
+    ///
+    /// 不正な形式のフレームには `BadMessage` を返して読み続ける。
+    /// `IDLE_TIMEOUT` の間なにも届かなければ切断と判断する。
+    async fn read(&mut self) -> Read {
+        loop {
+            let frame = match tokio::time::timeout(IDLE_TIMEOUT, self.receiver.next()).await {
+                Ok(Some(Ok(frame))) => frame,
+                // ストリーム終了・プロトコルエラー・タイムアウトはすべて切断扱い
+                Ok(Some(Err(_))) | Ok(None) | Err(_) => return Read::Closed,
+            };
+
+            match frame {
+                Message::Text(text) => match ClientMessage::from_json(text.as_str()) {
+                    Ok(msg) => return Read::Msg(msg),
+                    Err(_) => {
+                        self.send_error(ErrorCode::BadMessage, "invalid message")
+                            .await;
+                    }
+                },
+                Message::Binary(_) => {
+                    self.send_error(ErrorCode::BadMessage, "binary frames not supported")
+                        .await;
+                }
+                // Ping への Pong 応答は下層が自動で行う
+                Message::Ping(_) | Message::Pong(_) => {}
+                Message::Close(_) => return Read::Closed,
+            }
+        }
+    }
+
+    async fn send(&self, msg: ServerMessage) {
+        let _ = self.out_tx.send(msg).await;
+    }
+
+    async fn send_error(&self, code: ErrorCode, message: &str) {
+        self.send(ServerMessage::Error {
+            code,
+            message: message.to_string(),
+        })
+        .await;
+    }
+}

--- a/crates/mahjong-net-server/src/lib.rs
+++ b/crates/mahjong-net-server/src/lib.rs
@@ -1,0 +1,40 @@
+//! オンライン対戦用ネットワークサーバ
+//!
+//! WebSocket でクライアントと接続し、ルームコード制のロビーと
+//! サーバ権威のゲーム進行を提供する。ゲームロジック自体は
+//! `mahjong_server::driver::GameDriver` に委譲する。
+//!
+//! 構成:
+//! - [`lobby`] — ルームコードとルームアクターのレジストリ
+//! - [`room`] — ルームアクター（1ルーム = 1 tokio タスク）
+//! - [`connection`] — WebSocket 接続のハンドシェイクとメッセージ中継
+
+pub mod connection;
+pub mod lobby;
+pub mod room;
+
+use axum::Router;
+use axum::routing::get;
+
+use lobby::Lobby;
+use room::RoomConfig;
+
+/// アプリケーション全体の共有状態
+#[derive(Clone)]
+pub struct AppState {
+    /// ルームレジストリ
+    pub lobby: Lobby,
+}
+
+/// ルーターを構築する
+///
+/// `/ws` が WebSocket エンドポイント、`/healthz` がヘルスチェック。
+pub fn app(config: RoomConfig) -> Router {
+    let state = AppState {
+        lobby: Lobby::new(config),
+    };
+    Router::new()
+        .route("/healthz", get(|| async { "ok" }))
+        .route("/ws", get(connection::ws_handler))
+        .with_state(state)
+}

--- a/crates/mahjong-net-server/src/lobby.rs
+++ b/crates/mahjong-net-server/src/lobby.rs
@@ -1,0 +1,130 @@
+//! ロビー（ルームレジストリ）
+//!
+//! ルームコードからルームアクターへの送信チャネルを引けるレジストリ。
+//! ロックは作成・参照・削除の間だけ保持する（ゲーム状態は持たない）。
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use mahjong_server::table::GameSettings;
+use rand::RngExt;
+use tokio::sync::mpsc;
+
+use crate::room::{RoomConfig, RoomMsg, run_room};
+
+/// ルームコードの文字種（紛らわしい 0/O/1/I を除いた32文字）
+const CODE_ALPHABET: &[u8] = b"ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+/// ルームコードの長さ
+const CODE_LEN: usize = 6;
+
+/// ルームコードを生成する（約30ビットのエントロピー）
+fn generate_code() -> String {
+    let mut rng = rand::rng();
+    (0..CODE_LEN)
+        .map(|_| CODE_ALPHABET[rng.random_range(0..CODE_ALPHABET.len())] as char)
+        .collect()
+}
+
+/// ロビー: ルームコード → ルームアクターのレジストリ
+#[derive(Clone)]
+pub struct Lobby {
+    rooms: Arc<Mutex<HashMap<String, mpsc::Sender<RoomMsg>>>>,
+    config: RoomConfig,
+}
+
+impl Lobby {
+    /// 新しいロビーを作成する
+    pub fn new(config: RoomConfig) -> Self {
+        Lobby {
+            rooms: Arc::new(Mutex::new(HashMap::new())),
+            config,
+        }
+    }
+
+    /// ルームを作成し、アクタータスクを起動する
+    ///
+    /// 生成したルームコードと、ルームへの送信チャネルを返す。
+    pub fn create_room(&self, settings: GameSettings) -> (String, mpsc::Sender<RoomMsg>) {
+        let (tx, rx) = mpsc::channel(64);
+
+        let code = {
+            let mut rooms = self.rooms.lock().unwrap();
+            // 衝突したら引き直す
+            let code = loop {
+                let candidate = generate_code();
+                if !rooms.contains_key(&candidate) {
+                    break candidate;
+                }
+            };
+            rooms.insert(code.clone(), tx.clone());
+            code
+        };
+
+        tracing::info!(code, "room created");
+        tokio::spawn(run_room(
+            code.clone(),
+            settings,
+            self.clone(),
+            rx,
+            self.config,
+        ));
+
+        (code, tx)
+    }
+
+    /// ルームコードからルームを引く（大文字小文字は区別しない）
+    pub fn get(&self, code: &str) -> Option<mpsc::Sender<RoomMsg>> {
+        let normalized = code.trim().to_ascii_uppercase();
+        self.rooms.lock().unwrap().get(&normalized).cloned()
+    }
+
+    /// ルームをレジストリから削除する（ルームアクターが終了時に呼ぶ）
+    pub fn remove(&self, code: &str) {
+        self.rooms.lock().unwrap().remove(code);
+        tracing::info!(code, "room removed");
+    }
+
+    /// 現在のルーム数
+    pub fn room_count(&self) -> usize {
+        self.rooms.lock().unwrap().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_code_format() {
+        for _ in 0..100 {
+            let code = generate_code();
+            assert_eq!(code.len(), CODE_LEN);
+            assert!(
+                code.bytes().all(|b| CODE_ALPHABET.contains(&b)),
+                "コードに不正な文字が含まれる: {code}"
+            );
+            // 紛らわしい文字が含まれない
+            assert!(!code.contains(['0', 'O', '1', 'I']));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_and_lookup_room() {
+        let lobby = Lobby::new(RoomConfig::default());
+        let (code, _tx) = lobby.create_room(GameSettings::default());
+
+        assert_eq!(lobby.room_count(), 1);
+        assert!(lobby.get(&code).is_some());
+        // 小文字や空白付きでも引ける
+        assert!(
+            lobby
+                .get(&format!(" {} ", code.to_ascii_lowercase()))
+                .is_some()
+        );
+        assert!(lobby.get("ZZZZZZ").is_none());
+
+        lobby.remove(&code);
+        assert_eq!(lobby.room_count(), 0);
+    }
+}

--- a/crates/mahjong-net-server/src/main.rs
+++ b/crates/mahjong-net-server/src/main.rs
@@ -1,0 +1,34 @@
+//! mahjong-net-server エントリポイント
+//!
+//! `PORT` 環境変数でリッスンポートを指定する（デフォルト 8080）。
+//! ログは `RUST_LOG` で制御する（例: `RUST_LOG=mahjong_net_server=debug`）。
+
+use std::net::SocketAddr;
+
+use mahjong_net_server::app;
+use mahjong_net_server::room::RoomConfig;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "mahjong_net_server=info".into()),
+        )
+        .init();
+
+    let port: u16 = std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(8080);
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .unwrap_or_else(|e| panic!("failed to bind {addr}: {e}"));
+    tracing::info!("listening on {addr}");
+
+    axum::serve(listener, app(RoomConfig::default()))
+        .await
+        .expect("server error");
+}

--- a/crates/mahjong-net-server/src/room.rs
+++ b/crates/mahjong-net-server/src/room.rs
@@ -1,0 +1,487 @@
+//! ルームアクター
+//!
+//! 1ルーム = 1 tokio タスク。ルームが `GameDriver`（卓 + CPU）を所有し、
+//! 接続タスクからの `RoomMsg` を mpsc で逐次処理する。
+//! 同期的な卓の操作が await をまたがないため、ゲーム状態のロックは不要。
+
+use std::time::Duration;
+
+use mahjong_server::cpu::personalities::default_cpu_configs;
+use mahjong_server::driver::GameDriver;
+use mahjong_server::protocol::net::{ClientMessage, ErrorCode, SeatInfo, ServerMessage};
+use mahjong_server::table::GameSettings;
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::Instant;
+
+use crate::lobby::Lobby;
+
+/// ルームの動作タイミング設定
+///
+/// 本番は `Default`、テストでは短い値に差し替える。
+#[derive(Debug, Clone, Copy)]
+pub struct RoomConfig {
+    /// 局結果画面からの自動進行までの猶予
+    pub ready_timeout: Duration,
+    /// 対局開始前のルームの生存期間
+    pub lobby_timeout: Duration,
+    /// 対局中に全員切断してからルームを破棄するまでの猶予
+    pub abandoned_timeout: Duration,
+}
+
+impl Default for RoomConfig {
+    fn default() -> Self {
+        RoomConfig {
+            ready_timeout: Duration::from_secs(60),
+            lobby_timeout: Duration::from_secs(30 * 60),
+            abandoned_timeout: Duration::from_secs(5 * 60),
+        }
+    }
+}
+
+/// 接続タスクからルームアクターへのメッセージ
+pub enum RoomMsg {
+    /// 入室要求
+    Join {
+        /// 表示名
+        name: String,
+        /// セッショントークン
+        token: String,
+        /// この接続への送信チャネル
+        tx: mpsc::Sender<ServerMessage>,
+        /// 割り当てた座席（またはエラー）の返信先
+        reply: oneshot::Sender<Result<usize, ErrorCode>>,
+    },
+    /// 座席からのクライアントメッセージ
+    FromSeat {
+        /// 座席インデックス
+        seat: usize,
+        /// メッセージ本体
+        msg: ClientMessage,
+    },
+    /// 明示的な退出
+    Leave {
+        /// 座席インデックス
+        seat: usize,
+    },
+    /// 切断（ソケットが閉じた）
+    Disconnected {
+        /// 座席インデックス
+        seat: usize,
+    },
+}
+
+/// 着席中のプレイヤー
+struct Seat {
+    #[allow(dead_code)] // 再接続（フェーズ5）で照合に使う
+    token: String,
+    name: String,
+    /// 接続への送信チャネル（None = 切断中）
+    tx: Option<mpsc::Sender<ServerMessage>>,
+}
+
+/// ホストの座席インデックス（最初の入室者）
+const HOST_SEAT: usize = 0;
+
+/// ルームの状態
+struct Room {
+    code: String,
+    settings: GameSettings,
+    config: RoomConfig,
+    seats: [Option<Seat>; 4],
+    driver: Option<GameDriver>,
+    /// 局結果の確認待ち中か
+    awaiting_ready: bool,
+    /// 各座席の次局進行確認
+    ready: [bool; 4],
+    /// GameOver を送信済みか
+    game_over_sent: bool,
+    /// 次局自動進行の期限
+    ready_deadline: Option<Instant>,
+    /// ルーム破棄の期限
+    close_deadline: Option<Instant>,
+    /// ルームを閉じるフラグ
+    closing: bool,
+}
+
+/// ルームアクターのメインループ
+pub async fn run_room(
+    code: String,
+    settings: GameSettings,
+    lobby: Lobby,
+    mut rx: mpsc::Receiver<RoomMsg>,
+    config: RoomConfig,
+) {
+    let mut room = Room {
+        code: code.clone(),
+        settings,
+        config,
+        seats: [None, None, None, None],
+        driver: None,
+        awaiting_ready: false,
+        ready: [false; 4],
+        game_over_sent: false,
+        ready_deadline: None,
+        close_deadline: Some(Instant::now() + config.lobby_timeout),
+        closing: false,
+    };
+
+    loop {
+        let ready_at = deadline_or_far(room.ready_deadline);
+        let close_at = deadline_or_far(room.close_deadline);
+
+        tokio::select! {
+            msg = rx.recv() => match msg {
+                Some(msg) => room.handle_msg(msg).await,
+                None => break,
+            },
+            _ = tokio::time::sleep_until(ready_at), if room.ready_deadline.is_some() => {
+                tracing::debug!(code = room.code, "ready timeout; auto-advancing round");
+                room.advance_round().await;
+            }
+            _ = tokio::time::sleep_until(close_at), if room.close_deadline.is_some() => {
+                tracing::info!(code = room.code, "room expired");
+                room.closing = true;
+            }
+        }
+
+        if room.closing {
+            break;
+        }
+    }
+
+    lobby.remove(&code);
+}
+
+/// select! のために None を遠い未来の時刻に変換する
+///
+/// `if` ガードで無効化されるため、この時刻が実際に使われることはない。
+fn deadline_or_far(deadline: Option<Instant>) -> Instant {
+    deadline.unwrap_or_else(|| Instant::now() + Duration::from_secs(365 * 24 * 3600))
+}
+
+impl Room {
+    /// ゲームが開始済みか
+    fn game_started(&self) -> bool {
+        self.driver.is_some()
+    }
+
+    async fn handle_msg(&mut self, msg: RoomMsg) {
+        match msg {
+            RoomMsg::Join {
+                name,
+                token,
+                tx,
+                reply,
+            } => {
+                let result = self.try_join(name, token, tx);
+                let _ = reply.send(result);
+                if result.is_ok() {
+                    self.broadcast_room_state().await;
+                }
+            }
+            RoomMsg::FromSeat { seat, msg } => self.handle_client_message(seat, msg).await,
+            // 退出と切断はフェーズ2では同じ扱い（フェーズ5で再接続対応時に分岐する）
+            RoomMsg::Leave { seat } | RoomMsg::Disconnected { seat } => {
+                self.handle_departure(seat).await
+            }
+        }
+    }
+
+    /// 空席を探して着席させる
+    fn try_join(
+        &mut self,
+        name: String,
+        token: String,
+        tx: mpsc::Sender<ServerMessage>,
+    ) -> Result<usize, ErrorCode> {
+        if self.game_started() {
+            // 再接続（トークン照合）はフェーズ5で対応する
+            return Err(ErrorCode::GameInProgress);
+        }
+        let seat = self
+            .seats
+            .iter()
+            .position(|s| s.is_none())
+            .ok_or(ErrorCode::RoomFull)?;
+        self.seats[seat] = Some(Seat {
+            token,
+            name,
+            tx: Some(tx),
+        });
+        tracing::info!(code = self.code, seat, "player joined");
+        Ok(seat)
+    }
+
+    async fn handle_client_message(&mut self, seat: usize, msg: ClientMessage) {
+        match msg {
+            ClientMessage::StartGame => self.handle_start_game(seat).await,
+            ClientMessage::Action(action) => {
+                if !self.game_started() || self.awaiting_ready {
+                    self.send_error(seat, ErrorCode::InvalidAction, "no action expected now")
+                        .await;
+                    return;
+                }
+                let accepted = self
+                    .driver
+                    .as_mut()
+                    .expect("checked above")
+                    .handle_action(seat, action);
+                if !accepted {
+                    self.send_error(seat, ErrorCode::InvalidAction, "action rejected")
+                        .await;
+                }
+                self.progress_game().await;
+            }
+            ClientMessage::ReadyNextRound => {
+                if !self.awaiting_ready {
+                    self.send_error(seat, ErrorCode::InvalidAction, "not awaiting next round")
+                        .await;
+                    return;
+                }
+                self.ready[seat] = true;
+                if self.all_connected_humans_ready() {
+                    self.advance_round().await;
+                }
+            }
+            // Hello / CreateRoom / JoinRoom / LeaveRoom は接続タスク側で処理済み
+            _ => {
+                self.send_error(seat, ErrorCode::BadMessage, "unexpected message")
+                    .await;
+            }
+        }
+    }
+
+    async fn handle_start_game(&mut self, seat: usize) {
+        if seat != HOST_SEAT {
+            self.send_error(seat, ErrorCode::NotHost, "only the host can start")
+                .await;
+            return;
+        }
+        if self.game_started() {
+            self.send_error(seat, ErrorCode::GameInProgress, "game already started")
+                .await;
+            return;
+        }
+
+        let mut driver = GameDriver::new(self.settings.clone());
+        let configs = default_cpu_configs();
+        for s in 0..4 {
+            let config = configs[s % configs.len()].clone();
+            if self.seats[s].is_some() {
+                // 人間の座席にもシャドーCPUを常駐させ、切断時に即代打ちできるようにする
+                driver.set_shadow_cpu(s, config);
+            } else {
+                driver.set_cpu(s, config);
+            }
+        }
+        driver.start_game();
+        self.driver = Some(driver);
+        // 開始したのでロビーの生存期限は解除
+        self.close_deadline = None;
+
+        tracing::info!(code = self.code, "game started");
+        self.broadcast_room_state().await;
+        self.progress_game().await;
+    }
+
+    /// 入力待ちまでゲームを進め、イベントを配信し、局終了を確認する
+    async fn progress_game(&mut self) {
+        if let Some(driver) = self.driver.as_mut() {
+            driver.run_until_blocked();
+        }
+        self.flush_events().await;
+        self.check_round_end();
+    }
+
+    /// 各座席のイベントを接続へ送信する
+    async fn flush_events(&mut self) {
+        let Some(driver) = self.driver.as_mut() else {
+            return;
+        };
+        for seat in 0..4 {
+            // 切断中・空席のバッファも溜め込まないよう必ず drain する
+            let events = driver.drain_events(seat);
+            let Some(tx) = self.seats[seat].as_ref().and_then(|s| s.tx.clone()) else {
+                continue;
+            };
+            for event in events {
+                if tx.send(ServerMessage::Event(event)).await.is_err() {
+                    // 送信失敗は切断として扱う（Disconnected が後続で届く）
+                    break;
+                }
+            }
+        }
+    }
+
+    /// 局が終了していたら次局確認待ちに入る
+    fn check_round_end(&mut self) {
+        let Some(driver) = self.driver.as_ref() else {
+            return;
+        };
+        if self.awaiting_ready || self.game_over_sent {
+            return;
+        }
+        let round_over = driver
+            .table()
+            .current_round()
+            .map(|r| r.is_over())
+            .unwrap_or(false);
+        if round_over {
+            self.awaiting_ready = true;
+            self.ready = [false; 4];
+            self.ready_deadline = Some(Instant::now() + self.config.ready_timeout);
+        }
+    }
+
+    /// 接続中の人間全員が次局進行を確認したか
+    fn all_connected_humans_ready(&self) -> bool {
+        (0..4)
+            .filter(|&s| self.seats[s].as_ref().is_some_and(|seat| seat.tx.is_some()))
+            .all(|s| self.ready[s])
+    }
+
+    /// 次の局へ進める（ゲーム終了なら GameOver を配信する）
+    async fn advance_round(&mut self) {
+        self.awaiting_ready = false;
+        self.ready_deadline = None;
+
+        let Some(driver) = self.driver.as_mut() else {
+            return;
+        };
+        driver.next_round();
+
+        if driver.is_game_over() {
+            let final_scores = driver.table().scores;
+            self.broadcast(ServerMessage::GameOver { final_scores })
+                .await;
+            self.game_over_sent = true;
+            // 全員が切断したら閉じる。念のため期限も設定する
+            self.close_deadline = Some(Instant::now() + self.config.abandoned_timeout);
+            tracing::info!(code = self.code, "game over");
+        } else {
+            self.progress_game().await;
+        }
+    }
+
+    /// 退出または切断を処理する
+    async fn handle_departure(&mut self, seat: usize) {
+        // 開始前: 座席を空ける。ホストが抜けたらルームを閉じる
+        if !self.game_started() {
+            self.seats[seat] = None;
+            tracing::info!(code = self.code, seat, "player left");
+            if seat == HOST_SEAT {
+                self.broadcast_error(ErrorCode::NotInRoom, "room closed by host")
+                    .await;
+                self.closing = true;
+                return;
+            }
+            if self.seats.iter().all(|s| s.is_none()) {
+                self.closing = true;
+                return;
+            }
+            self.broadcast_room_state().await;
+            return;
+        }
+
+        // ゲーム終了後: 座席を空け、全員いなくなったら閉じる
+        if self.game_over_sent {
+            self.seats[seat] = None;
+            if self.seats.iter().all(|s| s.is_none()) {
+                self.closing = true;
+            }
+            return;
+        }
+
+        // 対局中: 座席は保持したまま切断扱いにし、CPUが代打ちする
+        if let Some(s) = self.seats[seat].as_mut() {
+            s.tx = None;
+        }
+        tracing::info!(
+            code = self.code,
+            seat,
+            "player disconnected; CPU takes over"
+        );
+        if let Some(driver) = self.driver.as_mut() {
+            driver.set_cpu_controlled(seat, true);
+            // 切断した座席の入力待ちで止まっていたら既定アクションで進める
+            driver.force_default_action(seat);
+        }
+        // 確認待ち中の切断はその座席の確認を不要にする
+        if self.awaiting_ready && self.all_connected_humans_ready() {
+            self.advance_round().await;
+        } else {
+            self.progress_game().await;
+        }
+
+        if !self.any_connected_human() {
+            self.close_deadline = Some(Instant::now() + self.config.abandoned_timeout);
+        }
+    }
+
+    /// 接続中の人間がいるか
+    fn any_connected_human(&self) -> bool {
+        self.seats
+            .iter()
+            .any(|s| s.as_ref().is_some_and(|seat| seat.tx.is_some()))
+    }
+
+    /// 全員に RoomState を送る（your_seat は受信者ごとに変わる）
+    async fn broadcast_room_state(&self) {
+        let seats_info: [SeatInfo; 4] = std::array::from_fn(|s| match &self.seats[s] {
+            Some(seat) => SeatInfo::Human {
+                name: seat.name.clone(),
+                connected: seat.tx.is_some(),
+            },
+            None => {
+                if self.game_started() {
+                    SeatInfo::Cpu
+                } else {
+                    SeatInfo::Empty
+                }
+            }
+        });
+
+        for seat in 0..4 {
+            let Some(tx) = self.seats[seat].as_ref().and_then(|s| s.tx.clone()) else {
+                continue;
+            };
+            let msg = ServerMessage::RoomState {
+                code: self.code.clone(),
+                seats: seats_info.clone(),
+                host_seat: HOST_SEAT,
+                your_seat: seat,
+            };
+            let _ = tx.send(msg).await;
+        }
+    }
+
+    /// 接続中の全員にメッセージを送る
+    async fn broadcast(&self, msg: ServerMessage) {
+        for seat in self.seats.iter().flatten() {
+            if let Some(tx) = &seat.tx {
+                let _ = tx.send(msg.clone()).await;
+            }
+        }
+    }
+
+    /// 接続中の全員にエラーを送る
+    async fn broadcast_error(&self, code: ErrorCode, message: &str) {
+        self.broadcast(ServerMessage::Error {
+            code,
+            message: message.to_string(),
+        })
+        .await;
+    }
+
+    /// 特定の座席にエラーを送る
+    async fn send_error(&self, seat: usize, code: ErrorCode, message: &str) {
+        if let Some(tx) = self.seats[seat].as_ref().and_then(|s| s.tx.clone()) {
+            let _ = tx
+                .send(ServerMessage::Error {
+                    code,
+                    message: message.to_string(),
+                })
+                .await;
+        }
+    }
+}

--- a/crates/mahjong-net-server/tests/integration.rs
+++ b/crates/mahjong-net-server/tests/integration.rs
@@ -1,0 +1,410 @@
+//! 統合テスト
+//!
+//! サーバをプロセス内で起動し、tokio-tungstenite のヘッドレスクライアント
+//! （ツモ切りボット）を接続して、ロビー操作と対局進行を検証する。
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use mahjong_net_server::app;
+use mahjong_net_server::room::RoomConfig;
+use mahjong_server::protocol::net::{ClientMessage, ErrorCode, PROTOCOL_VERSION, ServerMessage};
+use mahjong_server::protocol::{ClientAction, ServerEvent};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
+
+/// テスト用の短いタイマー設定
+fn fast_config() -> RoomConfig {
+    RoomConfig {
+        ready_timeout: Duration::from_millis(200),
+        lobby_timeout: Duration::from_secs(30),
+        abandoned_timeout: Duration::from_secs(5),
+    }
+}
+
+/// サーバをプロセス内で起動し、リッスンアドレスを返す
+async fn start_server(config: RoomConfig) -> SocketAddr {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app(config)).await.unwrap();
+    });
+    addr
+}
+
+/// 最終得点の整合性を確認する
+///
+/// ゲーム終了時に場に残った供託リーチ棒は誰にも配られないため、
+/// 総和は「初期点数の合計 − 1000 × 残り供託」になる。
+fn assert_scores_consistent(scores: [i32; 4]) {
+    let sum: i32 = scores.iter().sum();
+    assert!(sum <= 25000 * 4, "総和が初期点数を超えている: {scores:?}");
+    assert_eq!(
+        (25000 * 4 - sum) % 1000,
+        0,
+        "総和の差が供託単位でない: {scores:?}"
+    );
+}
+
+/// テスト用 WebSocket クライアント
+struct TestClient {
+    ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
+}
+
+impl TestClient {
+    async fn connect(addr: SocketAddr) -> Self {
+        let (ws, _) = connect_async(format!("ws://{addr}/ws")).await.unwrap();
+        TestClient { ws }
+    }
+
+    async fn send(&mut self, msg: &ClientMessage) {
+        let json = msg.to_json().unwrap();
+        self.ws.send(Message::text(json)).await.unwrap();
+    }
+
+    /// 次の ServerMessage を受信する（Ping/Pong は読み飛ばす）
+    async fn recv(&mut self) -> ServerMessage {
+        loop {
+            let frame = tokio::time::timeout(Duration::from_secs(10), self.ws.next())
+                .await
+                .expect("受信がタイムアウトした")
+                .expect("接続が閉じられた")
+                .expect("WebSocketエラー");
+            match frame {
+                Message::Text(text) => {
+                    return ServerMessage::from_json(text.as_str()).expect("不正なJSON");
+                }
+                Message::Ping(_) | Message::Pong(_) => continue,
+                Message::Close(_) => panic!("接続が閉じられた"),
+                other => panic!("予期しないフレーム: {other:?}"),
+            }
+        }
+    }
+
+    /// Error メッセージが届くまで読み、そのエラーコードを返す
+    async fn recv_error(&mut self) -> ErrorCode {
+        for _ in 0..100 {
+            if let ServerMessage::Error { code, .. } = self.recv().await {
+                return code;
+            }
+        }
+        panic!("Errorメッセージが届かなかった");
+    }
+
+    /// Hello を送り、Welcome のセッショントークンを返す
+    async fn hello(&mut self, name: &str) -> String {
+        self.send(&ClientMessage::Hello {
+            protocol_version: PROTOCOL_VERSION,
+            session_token: None,
+            display_name: name.to_string(),
+        })
+        .await;
+        match self.recv().await {
+            ServerMessage::Welcome { session_token, .. } => session_token,
+            other => panic!("Welcomeでないメッセージ: {other:?}"),
+        }
+    }
+
+    /// ルームを作成し、ルームコードを返す
+    async fn create_room(&mut self) -> String {
+        self.send(&ClientMessage::CreateRoom { round_count: 1 })
+            .await;
+        match self.recv().await {
+            ServerMessage::RoomState { code, .. } => code,
+            other => panic!("RoomStateでないメッセージ: {other:?}"),
+        }
+    }
+
+    /// ツモ切りボットとして GameOver まで打ち続ける
+    ///
+    /// `send_ready` が false の場合は局結果の確認（ReadyNextRound）を送らず、
+    /// サーバ側の自動進行に任せる。
+    async fn play_until_game_over(&mut self, send_ready: bool) -> [i32; 4] {
+        loop {
+            match self.recv().await {
+                ServerMessage::Event(event) => match event {
+                    ServerEvent::TileDrawn { can_tsumo, .. } => {
+                        let action = if can_tsumo {
+                            ClientAction::Tsumo
+                        } else {
+                            ClientAction::Discard { tile: None }
+                        };
+                        self.send(&ClientMessage::Action(action)).await;
+                    }
+                    ServerEvent::CallAvailable { .. } => {
+                        self.send(&ClientMessage::Action(ClientAction::Pass)).await;
+                    }
+                    ServerEvent::NineTerminalsAvailable => {
+                        self.send(&ClientMessage::Action(ClientAction::NineTerminals {
+                            declare: false,
+                        }))
+                        .await;
+                    }
+                    ServerEvent::RoundWon { .. } | ServerEvent::RoundDraw { .. } if send_ready => {
+                        self.send(&ClientMessage::ReadyNextRound).await;
+                    }
+                    _ => {}
+                },
+                ServerMessage::GameOver { final_scores } => return final_scores,
+                ServerMessage::Error { code, message } => {
+                    panic!("予期しないエラー: {code:?} {message}");
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+/// 2人の人間 + CPU2人で東風戦を最後まで打ち切れることを確認する
+#[tokio::test]
+async fn test_full_game_with_two_humans() {
+    tokio::time::timeout(Duration::from_secs(120), async {
+        let addr = start_server(fast_config()).await;
+
+        let mut host = TestClient::connect(addr).await;
+        host.hello("ホスト").await;
+        let code = host.create_room().await;
+
+        let mut guest = TestClient::connect(addr).await;
+        guest.hello("ゲスト").await;
+        guest
+            .send(&ClientMessage::JoinRoom { code: code.clone() })
+            .await;
+
+        // ゲストは自分の入室を反映した RoomState を受け取る
+        match guest.recv().await {
+            ServerMessage::RoomState { your_seat, .. } => assert_eq!(your_seat, 1),
+            other => panic!("RoomStateでないメッセージ: {other:?}"),
+        }
+        // ホストにも更新された RoomState が届く
+        match host.recv().await {
+            ServerMessage::RoomState { seats, .. } => {
+                assert!(matches!(
+                    seats[1],
+                    mahjong_server::protocol::net::SeatInfo::Human { .. }
+                ));
+            }
+            other => panic!("RoomStateでないメッセージ: {other:?}"),
+        }
+
+        host.send(&ClientMessage::StartGame).await;
+
+        let (host_scores, guest_scores) = tokio::join!(
+            host.play_until_game_over(true),
+            guest.play_until_game_over(true),
+        );
+
+        // 両者が同じ最終得点を観測し、点数の整合性が取れている
+        assert_eq!(host_scores, guest_scores);
+        assert_scores_consistent(host_scores);
+    })
+    .await
+    .expect("テスト全体がタイムアウトした");
+}
+
+/// ReadyNextRound を誰も送らなくても自動進行で GameOver まで到達することを確認する
+#[tokio::test]
+async fn test_ready_timeout_auto_advances() {
+    tokio::time::timeout(Duration::from_secs(120), async {
+        let addr = start_server(fast_config()).await;
+
+        let mut host = TestClient::connect(addr).await;
+        host.hello("ホスト").await;
+        host.create_room().await;
+        host.send(&ClientMessage::StartGame).await;
+
+        let scores = host.play_until_game_over(false).await;
+        assert_scores_consistent(scores);
+    })
+    .await
+    .expect("テスト全体がタイムアウトした");
+}
+
+/// プロトコルバージョン不一致は VersionMismatch エラーになる
+#[tokio::test]
+async fn test_version_mismatch() {
+    let addr = start_server(fast_config()).await;
+    let mut client = TestClient::connect(addr).await;
+    client
+        .send(&ClientMessage::Hello {
+            protocol_version: PROTOCOL_VERSION + 1,
+            session_token: None,
+            display_name: "古いクライアント".to_string(),
+        })
+        .await;
+    assert_eq!(client.recv_error().await, ErrorCode::VersionMismatch);
+}
+
+/// Hello 以外の最初のメッセージは BadMessage になる
+#[tokio::test]
+async fn test_message_before_hello() {
+    let addr = start_server(fast_config()).await;
+    let mut client = TestClient::connect(addr).await;
+    client.send(&ClientMessage::StartGame).await;
+    assert_eq!(client.recv_error().await, ErrorCode::BadMessage);
+}
+
+/// 存在しないルームコードへの参加は RoomNotFound になる
+#[tokio::test]
+async fn test_join_unknown_room() {
+    let addr = start_server(fast_config()).await;
+    let mut client = TestClient::connect(addr).await;
+    client.hello("迷子").await;
+    client
+        .send(&ClientMessage::JoinRoom {
+            code: "ZZZZZZ".to_string(),
+        })
+        .await;
+    assert_eq!(client.recv_error().await, ErrorCode::RoomNotFound);
+}
+
+/// 満席のルームへの参加は RoomFull になる
+#[tokio::test]
+async fn test_room_full() {
+    let addr = start_server(fast_config()).await;
+
+    let mut host = TestClient::connect(addr).await;
+    host.hello("ホスト").await;
+    let code = host.create_room().await;
+
+    let mut guests = Vec::new();
+    for i in 0..3 {
+        let mut guest = TestClient::connect(addr).await;
+        guest.hello(&format!("ゲスト{i}")).await;
+        guest
+            .send(&ClientMessage::JoinRoom { code: code.clone() })
+            .await;
+        match guest.recv().await {
+            ServerMessage::RoomState { .. } => {}
+            other => panic!("RoomStateでないメッセージ: {other:?}"),
+        }
+        guests.push(guest);
+    }
+
+    let mut fifth = TestClient::connect(addr).await;
+    fifth.hello("5人目").await;
+    fifth
+        .send(&ClientMessage::JoinRoom { code: code.clone() })
+        .await;
+    assert_eq!(fifth.recv_error().await, ErrorCode::RoomFull);
+}
+
+/// ホスト以外の StartGame は NotHost になる
+#[tokio::test]
+async fn test_non_host_cannot_start() {
+    let addr = start_server(fast_config()).await;
+
+    let mut host = TestClient::connect(addr).await;
+    host.hello("ホスト").await;
+    let code = host.create_room().await;
+
+    let mut guest = TestClient::connect(addr).await;
+    guest.hello("ゲスト").await;
+    guest
+        .send(&ClientMessage::JoinRoom { code: code.clone() })
+        .await;
+    guest.send(&ClientMessage::StartGame).await;
+    assert_eq!(guest.recv_error().await, ErrorCode::NotHost);
+}
+
+/// 手番でないプレイヤーのアクションは InvalidAction になる
+#[tokio::test]
+async fn test_out_of_turn_action_rejected() {
+    let addr = start_server(fast_config()).await;
+
+    let mut host = TestClient::connect(addr).await;
+    host.hello("ホスト").await;
+    let code = host.create_room().await;
+
+    let mut guest = TestClient::connect(addr).await;
+    guest.hello("ゲスト").await;
+    guest
+        .send(&ClientMessage::JoinRoom { code: code.clone() })
+        .await;
+
+    host.recv().await; // ゲスト入室の RoomState
+    host.send(&ClientMessage::StartGame).await;
+
+    // 開始直後の手番はホスト（座席0=親）。ゲストの打牌は拒否される
+    guest
+        .send(&ClientMessage::Action(ClientAction::Discard { tile: None }))
+        .await;
+    assert_eq!(guest.recv_error().await, ErrorCode::InvalidAction);
+}
+
+/// 対局開始後の参加は GameInProgress になる
+#[tokio::test]
+async fn test_join_after_start_rejected() {
+    let addr = start_server(fast_config()).await;
+
+    let mut host = TestClient::connect(addr).await;
+    host.hello("ホスト").await;
+    let code = host.create_room().await;
+    host.send(&ClientMessage::StartGame).await;
+
+    let mut late = TestClient::connect(addr).await;
+    late.hello("遅刻").await;
+    late.send(&ClientMessage::JoinRoom { code: code.clone() })
+        .await;
+    assert_eq!(late.recv_error().await, ErrorCode::GameInProgress);
+}
+
+/// 対局が始まらないルームは期限切れで破棄される
+#[tokio::test]
+async fn test_lobby_room_expires() {
+    let config = RoomConfig {
+        lobby_timeout: Duration::from_millis(200),
+        ..fast_config()
+    };
+    let addr = start_server(config).await;
+
+    let mut host = TestClient::connect(addr).await;
+    host.hello("ホスト").await;
+    let code = host.create_room().await;
+
+    tokio::time::sleep(Duration::from_millis(600)).await;
+
+    let mut guest = TestClient::connect(addr).await;
+    guest.hello("ゲスト").await;
+    guest
+        .send(&ClientMessage::JoinRoom { code: code.clone() })
+        .await;
+    assert_eq!(guest.recv_error().await, ErrorCode::RoomNotFound);
+}
+
+/// 対局中に片方が切断しても CPU が代打ちして対局が完走することを確認する
+#[tokio::test]
+async fn test_disconnect_mid_game_cpu_takes_over() {
+    tokio::time::timeout(Duration::from_secs(120), async {
+        let addr = start_server(fast_config()).await;
+
+        let mut host = TestClient::connect(addr).await;
+        host.hello("ホスト").await;
+        let code = host.create_room().await;
+
+        let mut guest = TestClient::connect(addr).await;
+        guest.hello("ゲスト").await;
+        guest
+            .send(&ClientMessage::JoinRoom { code: code.clone() })
+            .await;
+
+        host.recv().await; // ゲスト入室の RoomState
+        host.send(&ClientMessage::StartGame).await;
+
+        // ゲストはゲーム開始を確認してから切断する
+        loop {
+            if let ServerMessage::Event(ServerEvent::GameStarted { .. }) = guest.recv().await {
+                break;
+            }
+        }
+        drop(guest);
+
+        // ホストは最後まで打ち切れる（ゲスト座席はCPUが代打ち）
+        let scores = host.play_until_game_over(true).await;
+        assert_scores_consistent(scores);
+    })
+    .await
+    .expect("テスト全体がタイムアウトした");
+}

--- a/crates/mahjong-server/src/driver.rs
+++ b/crates/mahjong-server/src/driver.rs
@@ -12,12 +12,23 @@ use crate::protocol::{ClientAction, ServerEvent};
 use crate::round::TurnPhase;
 use crate::table::{GameSettings, Table};
 
+/// 座席に割り当てられたCPUクライアント
+struct CpuSeat {
+    client: CpuClient,
+    /// この座席をCPUが操作するか
+    ///
+    /// false の場合は「シャドーCPU」: イベントを受け取って内部状態を
+    /// 追跡するだけで、アクションは出さない（人間が操作する座席）。
+    /// 切断時に true に切り替えるだけで即座に代打ちできる。
+    controlled: bool,
+}
+
 /// ゲームドライバー: 卓とCPUクライアントを所有し、ゲームを進行する
 pub struct GameDriver {
     table: Table,
-    /// 各座席のCPUクライアント（Noneなら人間が操作する座席）
-    cpu_clients: [Option<CpuClient>; 4],
-    /// CPUでない座席向けのイベントバッファ
+    /// 各座席のCPUクライアント（Noneなら人間のみの座席）
+    cpus: [Option<CpuSeat>; 4],
+    /// CPUが操作していない座席向けのイベントバッファ
     event_buffers: [Vec<ServerEvent>; 4],
 }
 
@@ -26,16 +37,51 @@ impl GameDriver {
     pub fn new(settings: GameSettings) -> Self {
         GameDriver {
             table: Table::new(settings),
-            cpu_clients: [None, None, None, None],
+            cpus: [None, None, None, None],
             event_buffers: [const { Vec::new() }; 4],
         }
     }
 
-    /// 指定した座席にCPUクライアントを割り当てる
+    /// 指定した座席にCPUクライアントを割り当てる（CPUが操作する）
     pub fn set_cpu(&mut self, seat: usize, config: CpuConfig) {
         if seat < 4 {
-            self.cpu_clients[seat] = Some(CpuClient::new(config));
+            self.cpus[seat] = Some(CpuSeat {
+                client: CpuClient::new(config),
+                controlled: true,
+            });
         }
+    }
+
+    /// 指定した座席にシャドーCPUを割り当てる
+    ///
+    /// イベントを配信して内部状態を追跡させるが、アクションは出さない。
+    /// 人間の座席に割り当てておくと、切断時に
+    /// [`set_cpu_controlled`](Self::set_cpu_controlled) で即座に代打ちできる。
+    pub fn set_shadow_cpu(&mut self, seat: usize, config: CpuConfig) {
+        if seat < 4 {
+            self.cpus[seat] = Some(CpuSeat {
+                client: CpuClient::new(config),
+                controlled: false,
+            });
+        }
+    }
+
+    /// 指定した座席のCPU操作を切り替える
+    ///
+    /// CPUクライアントが割り当てられていない座席は切り替えられず false を返す。
+    pub fn set_cpu_controlled(&mut self, seat: usize, controlled: bool) -> bool {
+        match self.cpus.get_mut(seat) {
+            Some(Some(cpu)) => {
+                cpu.controlled = controlled;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// 指定した座席をCPUが操作しているか
+    pub fn is_cpu_controlled(&self, seat: usize) -> bool {
+        matches!(self.cpus.get(seat), Some(Some(cpu)) if cpu.controlled)
     }
 
     /// 卓への参照を取得する
@@ -112,6 +158,61 @@ impl GameDriver {
         self.process_all_events();
     }
 
+    /// 人間の入力が必要になるか局が終わるまでゲームを進める
+    ///
+    /// ツモフェーズを繰り返し実行し、CPUのアクションはイベントポンプで
+    /// 自動処理する。フレームループを持たないネットワークサーバ向け。
+    /// 牌山が有限なので必ず停止する。
+    pub fn run_until_blocked(&mut self) {
+        loop {
+            let round = match self.table.current_round() {
+                Some(r) => r,
+                None => return,
+            };
+            if round.is_over() || round.phase != TurnPhase::Draw {
+                return;
+            }
+            self.tick();
+        }
+    }
+
+    /// 指定した座席が入力待ちなら既定のアクション（ツモ切り/パス/続行）を実行する
+    ///
+    /// CPU代打ちへの切り替え直後や行動タイムアウト時に、入力待ちで
+    /// 停止したゲームを進めるために使う。実行したら true を返す。
+    pub fn force_default_action(&mut self, seat: usize) -> bool {
+        let action = {
+            let round = match self.table.current_round() {
+                Some(r) => r,
+                None => return false,
+            };
+            if round.is_over() {
+                return false;
+            }
+            match round.phase {
+                TurnPhase::WaitForDiscard if round.current_player == seat => {
+                    ClientAction::Discard { tile: None }
+                }
+                TurnPhase::WaitForCalls => {
+                    let pending = round
+                        .call_state
+                        .as_ref()
+                        .map(|cs| !cs.responded[seat])
+                        .unwrap_or(false);
+                    if !pending {
+                        return false;
+                    }
+                    ClientAction::Pass
+                }
+                TurnPhase::WaitForNineTerminals if round.current_player == seat => {
+                    ClientAction::NineTerminals { declare: false }
+                }
+                _ => return false,
+            }
+        };
+        self.handle_action(seat, action)
+    }
+
     /// 現在の局が終了しているか
     pub fn is_round_over(&self) -> bool {
         match self.table.current_round() {
@@ -145,9 +246,9 @@ impl GameDriver {
                 break;
             }
 
-            // CPUでない座席のイベントをバッファに追加
+            // CPUが操作していない座席のイベントをバッファに追加
             for (seat, event) in &all_events {
-                if self.cpu_clients[*seat].is_none() {
+                if !self.is_cpu_controlled(*seat) {
                     self.event_buffers[*seat].push(event.clone());
                 }
             }
@@ -166,7 +267,10 @@ impl GameDriver {
         }
     }
 
-    /// CPUプレイヤーにイベントを配信し、アクションを収集する
+    /// CPUクライアントにイベントを配信し、操作中の座席のアクションを収集する
+    ///
+    /// シャドーCPU（controlled = false）にもイベントは配信するが、
+    /// 返ってきたアクションは捨てる。
     fn collect_cpu_actions(
         &mut self,
         events: &[(usize, ServerEvent)],
@@ -174,8 +278,9 @@ impl GameDriver {
         let mut actions = Vec::new();
 
         for (seat, event) in events {
-            if let Some(cpu) = &mut self.cpu_clients[*seat]
-                && let Some(action) = cpu.handle_event(event)
+            if let Some(cpu) = &mut self.cpus[*seat]
+                && let Some(action) = cpu.client.handle_event(event)
+                && cpu.controlled
             {
                 actions.push((*seat, action));
             }
@@ -405,6 +510,79 @@ mod tests {
                     driver.handle_action(0, ClientAction::Pass);
                 }
             }
+        }
+    }
+
+    /// シャドーCPUはイベントを受け取ってもアクションを出さないことを確認
+    #[test]
+    fn test_shadow_cpu_does_not_act() {
+        let mut driver = driver_with_three_cpus();
+        // 座席0にシャドーCPUを割り当てる（人間扱いのまま）
+        let config = default_cpu_configs()[0].clone();
+        driver.set_shadow_cpu(0, config);
+        assert!(!driver.is_cpu_controlled(0));
+
+        driver.start_game_with_seed(42);
+        driver.run_until_blocked();
+
+        // 座席0の入力待ちで停止している（シャドーCPUが勝手に打牌していない）
+        let round = driver.table().current_round().unwrap();
+        assert!(!round.is_over());
+        assert_eq!(round.current_player, 0);
+        assert_eq!(round.phase, TurnPhase::WaitForDiscard);
+
+        // 座席0にはイベントが届いている
+        let events = driver.drain_events(0);
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, ServerEvent::TileDrawn { .. })),
+            "シャドーCPU座席にTileDrawnが届いていない"
+        );
+    }
+
+    /// シャドーCPUを操作状態に切り替えると局が自動進行することを確認
+    #[test]
+    fn test_shadow_cpu_takeover_completes_round() {
+        let mut driver = driver_with_three_cpus();
+        let config = default_cpu_configs()[0].clone();
+        driver.set_shadow_cpu(0, config);
+
+        driver.start_game_with_seed(42);
+        driver.run_until_blocked();
+        assert!(!driver.is_round_over());
+
+        // 代打ちに切り替え
+        assert!(driver.set_cpu_controlled(0, true));
+        assert!(driver.is_cpu_controlled(0));
+
+        // 切り替え時点で座席0は打牌待ちのため、既定アクションで進める。
+        // 以降は全席CPUなので局は最後まで自動進行する。
+        assert!(driver.force_default_action(0));
+        driver.run_until_blocked();
+
+        assert!(driver.is_round_over(), "代打ち後に局が進行しなかった");
+    }
+
+    /// CPUクライアント未割り当ての座席は操作切り替えできないことを確認
+    #[test]
+    fn test_set_cpu_controlled_requires_cpu_client() {
+        let mut driver = GameDriver::new(GameSettings::default());
+        assert!(!driver.set_cpu_controlled(0, true));
+        assert!(!driver.is_cpu_controlled(0));
+    }
+
+    /// run_until_blocked が人間の打牌待ちで停止することを確認
+    #[test]
+    fn test_run_until_blocked_stops_at_human_turn() {
+        let mut driver = driver_with_three_cpus();
+        driver.start_game_with_seed(123);
+        driver.run_until_blocked();
+
+        let round = driver.table().current_round().unwrap();
+        if !round.is_over() {
+            // 停止位置はDrawフェーズ以外（人間入力待ちか局終了）
+            assert_ne!(round.phase, TurnPhase::Draw);
         }
     }
 


### PR DESCRIPTION
## Summary

Phase 2 of online multiplayer (#209, part of #207): a single-binary WebSocket game server. Built on the phase-1 groundwork (`GameDriver`, `protocol::net`).

- **`mahjong-net-server` crate** (tokio + axum): `/ws` + `/healthz`, `PORT` env, tracing.
- **Lobby**: 6-char room codes (32-char unambiguous alphabet, ~30 bits), collision retry, case-insensitive lookup. Registry holds only `code -> mpsc::Sender<RoomMsg>`.
- **Actor-per-room**: one tokio task owns the `GameDriver` and seat table; the synchronous game state never crosses an await point, so there is no locking on game state.
- **Shadow CPUs on all 4 seats**: human seats get an event-tracking `CpuClient` that never acts; on mid-game disconnect the seat flips to CPU control instantly and the table keeps moving (`force_default_action` unblocks a seat that was mid-turn).
- **Game flow**: host-only `StartGame` fills empty seats with default CPU configs; per-seat events fan out as `ServerMessage::Event`; `ReadyNextRound` collection with a configurable auto-advance timeout (default 60 s); `GameOver` broadcast.
- **Lifecycle**: server pings every 30 s with a 90 s idle cutoff; rooms are GC'd on lobby expiry (30 min), abandoned games (5 min with no humans), and after game over.
- **`GameDriver` additions** (mahjong-server): `set_shadow_cpu` / `set_cpu_controlled` / `is_cpu_controlled`, `run_until_blocked` (frame-loop-less progression), `force_default_action`.

Reconnect/resync (#212) and per-action timeouts / rate limits (#213) are intentionally out of scope; disconnect handling here is takeover-only with no rejoin.

## Test plan

- [x] Integration tests (11) with in-process server + headless tsumogiri-bot clients over tokio-tungstenite:
  - full East-wind game with 2 humans + 2 CPUs to `GameOver` (both clients observe identical final scores)
  - ready-timeout auto-advance with no `ReadyNextRound` sent
  - mid-game disconnect -> CPU takeover -> game completes
  - negative: version mismatch, message before Hello, unknown room, full room, non-host start, out-of-turn action, join after start, lobby expiry
- [x] `GameDriver` unit tests for shadow CPU (no acting, takeover completes round, controlled toggle guards)
- [x] `cargo test` workspace green (server 352 / integration 11); integration suite run 3x for flake check
- [x] `cargo fmt` / `cargo clippy --all-targets` clean
- [x] `cargo build -p mahjong-client --target wasm32-unknown-unknown --release` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
