### PR TITLE
Add native client online play: transport, RemoteAdapter, and online UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +241,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -333,6 +349,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -566,6 +593,7 @@ dependencies = [
  "mahjong-core",
  "mahjong-server",
  "serde",
+ "tungstenite 0.27.0",
 ]
 
 [[package]]
@@ -673,7 +701,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -688,7 +716,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -886,6 +914,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rstest"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +963,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1022,6 +1097,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,7 +1127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1066,6 +1147,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1125,7 +1212,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1301,9 +1388,12 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror",
  "utf-8",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1339,6 +1429,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf-8"
@@ -1417,6 +1513,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,12 +1560,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -1575,6 +1762,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/crates/mahjong-client/Cargo.toml
+++ b/crates/mahjong-client/Cargo.toml
@@ -10,3 +10,7 @@ mahjong-server = { path = "../mahjong-server" }
 macroquad = "0.4"
 serde = { version = "1", features = ["derive"] }
 getrandom = "0.4"
+
+# ネイティブのみ: WebSocket クライアント（WASM はフェーズ4で手書きJSグルーを使う）
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tungstenite = { version = "0.27", features = ["rustls-tls-webpki-roots"] }

--- a/crates/mahjong-client/src/adapter/mod.rs
+++ b/crates/mahjong-client/src/adapter/mod.rs
@@ -5,8 +5,10 @@
 //! 同じインターフェースで扱えるようにする。
 
 mod local;
+mod remote;
 
 pub use local::LocalAdapter;
+pub use remote::{ConnStatus, RemoteAdapter, RoomView, error_code_message};
 
 use mahjong_server::protocol::{ClientAction, ServerEvent};
 
@@ -29,4 +31,9 @@ pub trait GameAdapter {
 
     /// ゲームが終了しているか
     fn is_game_over(&self) -> bool;
+
+    /// 接続状態などの表示用テキスト（問題がなければ None）
+    fn status_text(&self) -> Option<String> {
+        None
+    }
 }

--- a/crates/mahjong-client/src/adapter/remote.rs
+++ b/crates/mahjong-client/src/adapter/remote.rs
@@ -579,6 +579,10 @@ mod tests {
 
         let start = std::time::Instant::now();
         let mut started = false;
+        // 連続で届くイベント（TileDrawn + NineTerminalsAvailable など）を
+        // まとめて判断するため、50msの静止を待ってから行動する
+        let mut pending: Vec<ServerEvent> = Vec::new();
+        let mut last_event_at = std::time::Instant::now();
 
         loop {
             assert!(
@@ -596,6 +600,9 @@ mod tests {
                 ConnStatus::Disconnected,
                 "サーバから切断された"
             );
+            if adapter.is_game_over() {
+                break;
+            }
 
             if !started {
                 if adapter.room().is_some() {
@@ -605,9 +612,30 @@ mod tests {
                 continue;
             }
 
-            for event in adapter.poll_events() {
+            let mut new_events = adapter.poll_events();
+            if !new_events.is_empty() {
+                pending.append(&mut new_events);
+                last_event_at = std::time::Instant::now();
+                continue;
+            }
+            if pending.is_empty() || last_event_at.elapsed() < std::time::Duration::from_millis(50)
+            {
+                continue;
+            }
+
+            let batch = std::mem::take(&mut pending);
+            // 九種九牌の選択があるターンは宣言拒否のみ送る
+            // （拒否するとサーバが TileDrawn を再送して打牌を促す）
+            let nine_terminals = batch
+                .iter()
+                .any(|e| matches!(e, ServerEvent::NineTerminalsAvailable));
+            if nine_terminals {
+                adapter.send_action(ClientAction::NineTerminals { declare: false });
+            }
+
+            for event in batch {
                 match event {
-                    ServerEvent::TileDrawn { can_tsumo, .. } => {
+                    ServerEvent::TileDrawn { can_tsumo, .. } if !nine_terminals => {
                         let action = if can_tsumo {
                             ClientAction::Tsumo
                         } else {
@@ -618,18 +646,11 @@ mod tests {
                     ServerEvent::CallAvailable { .. } => {
                         adapter.send_action(ClientAction::Pass);
                     }
-                    ServerEvent::NineTerminalsAvailable => {
-                        adapter.send_action(ClientAction::NineTerminals { declare: false });
-                    }
                     ServerEvent::RoundWon { .. } | ServerEvent::RoundDraw { .. } => {
                         adapter.request_next_round();
                     }
                     _ => {}
                 }
-            }
-
-            if adapter.is_game_over() {
-                break;
             }
         }
     }

--- a/crates/mahjong-client/src/adapter/remote.rs
+++ b/crates/mahjong-client/src/adapter/remote.rs
@@ -1,0 +1,647 @@
+//! リモートアダプター
+//!
+//! WebSocket 経由で mahjong-net-server と通信する。
+//! ロビー操作（ルーム作成・参加・開始）と対局中のイベント中継を担う。
+//!
+//! 接続〜入室の流れ:
+//! 1. `create_room` / `join_room` でトランスポートを開き、意図を保持する
+//! 2. `Opened` を受けたら `Hello` を送る
+//! 3. `Welcome` を受けたら保持していた `CreateRoom` / `JoinRoom` を送る
+//! 4. `RoomState` で入室完了（`room()` が Some になる）
+//! 5. ホストが `start_game` → `Event(GameStarted)` で対局開始
+
+use mahjong_server::protocol::net::{
+    ClientMessage, ErrorCode, PROTOCOL_VERSION, SeatInfo, ServerMessage,
+};
+use mahjong_server::protocol::{ClientAction, ServerEvent};
+
+use super::GameAdapter;
+use crate::transport::{Transport, WsEvent};
+
+/// 接続状態
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnStatus {
+    /// 接続・ハンドシェイク中
+    Connecting,
+    /// 接続済み
+    Connected,
+    /// 切断された
+    Disconnected,
+}
+
+/// ルームの表示用スナップショット
+#[derive(Debug, Clone)]
+pub struct RoomView {
+    /// ルームコード
+    pub code: String,
+    /// 各座席の状態
+    pub seats: [SeatInfo; 4],
+    /// ホストの座席
+    pub host_seat: usize,
+    /// 自分の座席
+    pub your_seat: usize,
+}
+
+impl RoomView {
+    /// 自分がホストか
+    pub fn is_host(&self) -> bool {
+        self.your_seat == self.host_seat
+    }
+}
+
+/// 直近のエラー
+#[derive(Debug, Clone)]
+pub struct RemoteError {
+    /// サーバが返したエラーコード（通信層のエラーは None）
+    pub code: Option<ErrorCode>,
+    /// 説明（UI 表示用）
+    pub message: String,
+}
+
+/// Welcome 受信後に送るロビー操作
+enum LobbyIntent {
+    Create { round_count: u8 },
+    Join { code: String },
+}
+
+/// リモートアダプター: ネットワーク越しにサーバとやり取りする
+pub struct RemoteAdapter {
+    transport: Box<dyn Transport>,
+    status: ConnStatus,
+    display_name: String,
+    session_token: Option<String>,
+    pending_intent: Option<LobbyIntent>,
+    room: Option<RoomView>,
+    events: Vec<ServerEvent>,
+    last_error: Option<RemoteError>,
+    game_started: bool,
+    game_over: bool,
+    ready_sent: bool,
+}
+
+impl RemoteAdapter {
+    /// トランスポートと意図を指定して作成する（テスト用にも使う）
+    fn with_transport(
+        transport: Box<dyn Transport>,
+        display_name: &str,
+        intent: LobbyIntent,
+    ) -> Self {
+        RemoteAdapter {
+            transport,
+            status: ConnStatus::Connecting,
+            display_name: display_name.to_string(),
+            session_token: None,
+            pending_intent: Some(intent),
+            room: None,
+            events: Vec::new(),
+            last_error: None,
+            game_started: false,
+            game_over: false,
+            ready_sent: false,
+        }
+    }
+
+    /// サーバに接続してルームを作成する
+    pub fn create_room(url: &str, display_name: &str, round_count: u8) -> Self {
+        Self::with_transport(
+            crate::transport::connect(url),
+            display_name,
+            LobbyIntent::Create { round_count },
+        )
+    }
+
+    /// サーバに接続して既存のルームに参加する
+    pub fn join_room(url: &str, display_name: &str, code: &str) -> Self {
+        Self::with_transport(
+            crate::transport::connect(url),
+            display_name,
+            LobbyIntent::Join {
+                code: code.trim().to_ascii_uppercase(),
+            },
+        )
+    }
+
+    /// 対局を開始する（ホストのみ有効。結果はサーバが判断する）
+    pub fn start_game(&mut self) {
+        self.send(&ClientMessage::StartGame);
+    }
+
+    /// ルームから退出する
+    pub fn leave_room(&mut self) {
+        self.send(&ClientMessage::LeaveRoom);
+        self.room = None;
+    }
+
+    /// 現在の接続状態
+    pub fn status(&self) -> ConnStatus {
+        self.status
+    }
+
+    /// 入室中のルーム情報
+    pub fn room(&self) -> Option<&RoomView> {
+        self.room.as_ref()
+    }
+
+    /// 対局が開始したか（GameStarted を受信したか）
+    pub fn game_started(&self) -> bool {
+        self.game_started
+    }
+
+    /// 直近のエラーを取り出す（取り出すとクリアされる）
+    pub fn take_error(&mut self) -> Option<RemoteError> {
+        self.last_error.take()
+    }
+
+    /// 受信を処理して内部状態を更新する
+    fn pump(&mut self) {
+        for ws_event in self.transport.poll() {
+            match ws_event {
+                WsEvent::Opened => {
+                    let hello = ClientMessage::Hello {
+                        protocol_version: PROTOCOL_VERSION,
+                        session_token: self.session_token.clone(),
+                        display_name: self.display_name.clone(),
+                    };
+                    self.send(&hello);
+                }
+                WsEvent::Message(json) => match ServerMessage::from_json(&json) {
+                    Ok(msg) => self.handle_server_message(msg),
+                    Err(_) => {
+                        self.last_error = Some(RemoteError {
+                            code: None,
+                            message: "サーバからの応答を解釈できません".to_string(),
+                        });
+                    }
+                },
+                WsEvent::Closed => {
+                    self.status = ConnStatus::Disconnected;
+                }
+                WsEvent::Error(message) => {
+                    self.status = ConnStatus::Disconnected;
+                    self.last_error = Some(RemoteError {
+                        code: None,
+                        message,
+                    });
+                }
+            }
+        }
+    }
+
+    fn handle_server_message(&mut self, msg: ServerMessage) {
+        match msg {
+            ServerMessage::Welcome { session_token, .. } => {
+                self.session_token = Some(session_token);
+                self.status = ConnStatus::Connected;
+                if let Some(intent) = self.pending_intent.take() {
+                    let msg = match intent {
+                        LobbyIntent::Create { round_count } => {
+                            ClientMessage::CreateRoom { round_count }
+                        }
+                        LobbyIntent::Join { code } => ClientMessage::JoinRoom { code },
+                    };
+                    self.send(&msg);
+                }
+            }
+            ServerMessage::RoomState {
+                code,
+                seats,
+                host_seat,
+                your_seat,
+            } => {
+                self.room = Some(RoomView {
+                    code,
+                    seats,
+                    host_seat,
+                    your_seat,
+                });
+            }
+            ServerMessage::Event(event) => {
+                if matches!(event, ServerEvent::GameStarted { .. }) {
+                    self.game_started = true;
+                    // 新しい局が始まったので次局確認を再送可能にする
+                    self.ready_sent = false;
+                }
+                self.events.push(event);
+            }
+            ServerMessage::GameOver { .. } => {
+                self.game_over = true;
+            }
+            ServerMessage::Error { code, message } => {
+                self.last_error = Some(RemoteError {
+                    code: Some(code),
+                    message,
+                });
+            }
+            // 再接続（フェーズ5）で対応する
+            ServerMessage::Resync { .. } | ServerMessage::PlayerConnectionChanged { .. } => {}
+        }
+    }
+
+    fn send(&mut self, msg: &ClientMessage) {
+        match msg.to_json() {
+            Ok(json) => self.transport.send_text(&json),
+            Err(e) => {
+                self.last_error = Some(RemoteError {
+                    code: None,
+                    message: format!("メッセージの作成に失敗しました: {e}"),
+                });
+            }
+        }
+    }
+}
+
+impl GameAdapter for RemoteAdapter {
+    fn send_action(&mut self, action: ClientAction) {
+        self.send(&ClientMessage::Action(action));
+    }
+
+    fn poll_events(&mut self) -> Vec<ServerEvent> {
+        self.pump();
+        std::mem::take(&mut self.events)
+    }
+
+    fn tick(&mut self) {
+        self.pump();
+    }
+
+    fn request_next_round(&mut self) {
+        // 多重クリックでの重複送信を防ぐ（次の GameStarted でリセット）
+        if !self.ready_sent {
+            self.send(&ClientMessage::ReadyNextRound);
+            self.ready_sent = true;
+        }
+    }
+
+    fn is_game_over(&self) -> bool {
+        self.game_over
+    }
+
+    fn status_text(&self) -> Option<String> {
+        match self.status {
+            ConnStatus::Disconnected => Some("サーバとの接続が切れました".to_string()),
+            ConnStatus::Connecting => Some("接続中...".to_string()),
+            ConnStatus::Connected => None,
+        }
+    }
+}
+
+/// エラーコードを表示用の日本語文言に変換する
+pub fn error_code_message(code: ErrorCode) -> &'static str {
+    match code {
+        ErrorCode::VersionMismatch => "クライアントのバージョンがサーバと一致しません",
+        ErrorCode::RoomNotFound => "ルームが見つかりません",
+        ErrorCode::RoomFull => "ルームが満席です",
+        ErrorCode::NotHost => "ホストのみ操作できます",
+        ErrorCode::NotInRoom => "ルームに参加していません",
+        ErrorCode::GameInProgress => "対局中のため参加できません",
+        ErrorCode::InvalidAction => "無効な操作です",
+        ErrorCode::BadMessage => "不正なメッセージです",
+        ErrorCode::RateLimited => "操作が頻繁すぎます。しばらく待ってください",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
+    use std::rc::Rc;
+
+    use mahjong_core::tile::{Tile, Wind};
+
+    use super::*;
+
+    /// スクリプト化されたモックトランスポート
+    struct MockTransport {
+        incoming: Rc<RefCell<VecDeque<WsEvent>>>,
+        sent: Rc<RefCell<Vec<String>>>,
+    }
+
+    /// モックの操作ハンドル（受信の注入と送信内容の検査）
+    struct MockHandle {
+        incoming: Rc<RefCell<VecDeque<WsEvent>>>,
+        sent: Rc<RefCell<Vec<String>>>,
+    }
+
+    impl MockHandle {
+        fn push(&self, event: WsEvent) {
+            self.incoming.borrow_mut().push_back(event);
+        }
+
+        fn push_msg(&self, msg: &ServerMessage) {
+            self.push(WsEvent::Message(msg.to_json().unwrap()));
+        }
+
+        fn sent(&self) -> Vec<ClientMessage> {
+            self.sent
+                .borrow()
+                .iter()
+                .map(|json| ClientMessage::from_json(json).unwrap())
+                .collect()
+        }
+    }
+
+    impl Transport for MockTransport {
+        fn send_text(&mut self, text: &str) {
+            self.sent.borrow_mut().push(text.to_string());
+        }
+
+        fn poll(&mut self) -> Vec<WsEvent> {
+            self.incoming.borrow_mut().drain(..).collect()
+        }
+    }
+
+    fn mock_pair() -> (Box<dyn Transport>, MockHandle) {
+        let incoming = Rc::new(RefCell::new(VecDeque::new()));
+        let sent = Rc::new(RefCell::new(Vec::new()));
+        let transport = MockTransport {
+            incoming: incoming.clone(),
+            sent: sent.clone(),
+        };
+        (Box::new(transport), MockHandle { incoming, sent })
+    }
+
+    fn create_adapter() -> (RemoteAdapter, MockHandle) {
+        let (transport, handle) = mock_pair();
+        let adapter = RemoteAdapter::with_transport(
+            transport,
+            "テスト",
+            LobbyIntent::Create { round_count: 1 },
+        );
+        (adapter, handle)
+    }
+
+    fn welcome() -> ServerMessage {
+        ServerMessage::Welcome {
+            session_token: "token123".to_string(),
+            protocol_version: PROTOCOL_VERSION,
+        }
+    }
+
+    fn room_state(your_seat: usize) -> ServerMessage {
+        ServerMessage::RoomState {
+            code: "ABC234".to_string(),
+            seats: [
+                SeatInfo::Human {
+                    name: "ホスト".to_string(),
+                    connected: true,
+                },
+                SeatInfo::Empty,
+                SeatInfo::Empty,
+                SeatInfo::Empty,
+            ],
+            host_seat: 0,
+            your_seat,
+        }
+    }
+
+    fn game_started_event() -> ServerEvent {
+        ServerEvent::GameStarted {
+            seat_wind: Wind::East,
+            hand: vec![Tile::new(Tile::M1); 13],
+            scores: [25000; 4],
+            prevailing_wind: Wind::East,
+            dora_indicators: vec![Tile::new(Tile::P5)],
+            round_number: 0,
+            total_rounds: 4,
+            honba: 0,
+            riichi_sticks: 0,
+        }
+    }
+
+    #[test]
+    fn test_handshake_sends_hello_then_intent() {
+        let (mut adapter, handle) = create_adapter();
+        assert_eq!(adapter.status(), ConnStatus::Connecting);
+
+        handle.push(WsEvent::Opened);
+        adapter.tick();
+
+        let sent = handle.sent();
+        assert_eq!(sent.len(), 1);
+        match &sent[0] {
+            ClientMessage::Hello {
+                protocol_version,
+                display_name,
+                ..
+            } => {
+                assert_eq!(*protocol_version, PROTOCOL_VERSION);
+                assert_eq!(display_name, "テスト");
+            }
+            other => panic!("Helloでないメッセージ: {other:?}"),
+        }
+
+        handle.push_msg(&welcome());
+        adapter.tick();
+
+        assert_eq!(adapter.status(), ConnStatus::Connected);
+        let sent = handle.sent();
+        assert_eq!(sent.len(), 2);
+        assert!(matches!(
+            sent[1],
+            ClientMessage::CreateRoom { round_count: 1 }
+        ));
+    }
+
+    #[test]
+    fn test_join_intent_uppercases_code() {
+        let (transport, handle) = mock_pair();
+        let mut adapter = RemoteAdapter::with_transport(
+            transport,
+            "ゲスト",
+            LobbyIntent::Join {
+                code: " abc234 ".trim().to_ascii_uppercase(),
+            },
+        );
+
+        handle.push(WsEvent::Opened);
+        handle.push_msg(&welcome());
+        adapter.tick();
+
+        let sent = handle.sent();
+        match &sent[1] {
+            ClientMessage::JoinRoom { code } => assert_eq!(code, "ABC234"),
+            other => panic!("JoinRoomでないメッセージ: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_room_state_updates_room_view() {
+        let (mut adapter, handle) = create_adapter();
+        handle.push(WsEvent::Opened);
+        handle.push_msg(&welcome());
+        handle.push_msg(&room_state(0));
+        adapter.tick();
+
+        let room = adapter.room().expect("ルーム情報が無い");
+        assert_eq!(room.code, "ABC234");
+        assert_eq!(room.your_seat, 0);
+        assert!(room.is_host());
+    }
+
+    #[test]
+    fn test_game_started_event_flows_through() {
+        let (mut adapter, handle) = create_adapter();
+        handle.push(WsEvent::Opened);
+        handle.push_msg(&welcome());
+        handle.push_msg(&ServerMessage::Event(game_started_event()));
+
+        let events = adapter.poll_events();
+        assert!(adapter.game_started());
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], ServerEvent::GameStarted { .. }));
+        // 取り出したらキューは空になる
+        assert!(adapter.poll_events().is_empty());
+    }
+
+    #[test]
+    fn test_server_error_is_reported_once() {
+        let (mut adapter, handle) = create_adapter();
+        handle.push_msg(&ServerMessage::Error {
+            code: ErrorCode::RoomNotFound,
+            message: "no such room".to_string(),
+        });
+        adapter.tick();
+
+        let err = adapter.take_error().expect("エラーが記録されていない");
+        assert_eq!(err.code, Some(ErrorCode::RoomNotFound));
+        assert!(adapter.take_error().is_none());
+    }
+
+    #[test]
+    fn test_transport_error_disconnects() {
+        let (mut adapter, handle) = create_adapter();
+        handle.push(WsEvent::Error("接続に失敗しました".to_string()));
+        adapter.tick();
+
+        assert_eq!(adapter.status(), ConnStatus::Disconnected);
+        assert!(adapter.take_error().is_some());
+        assert!(adapter.status_text().is_some());
+    }
+
+    #[test]
+    fn test_closed_disconnects() {
+        let (mut adapter, handle) = create_adapter();
+        handle.push(WsEvent::Closed);
+        adapter.tick();
+        assert_eq!(adapter.status(), ConnStatus::Disconnected);
+    }
+
+    #[test]
+    fn test_send_action_serializes_action_message() {
+        let (mut adapter, handle) = create_adapter();
+        adapter.send_action(ClientAction::Discard { tile: None });
+
+        let sent = handle.sent();
+        assert!(matches!(
+            sent[0],
+            ClientMessage::Action(ClientAction::Discard { tile: None })
+        ));
+    }
+
+    #[test]
+    fn test_ready_next_round_is_deduplicated() {
+        let (mut adapter, handle) = create_adapter();
+
+        adapter.request_next_round();
+        adapter.request_next_round();
+        assert_eq!(
+            handle
+                .sent()
+                .iter()
+                .filter(|m| matches!(m, ClientMessage::ReadyNextRound))
+                .count(),
+            1
+        );
+
+        // 次の局が始まったら再送可能になる
+        handle.push_msg(&ServerMessage::Event(game_started_event()));
+        adapter.tick();
+        adapter.request_next_round();
+        assert_eq!(
+            handle
+                .sent()
+                .iter()
+                .filter(|m| matches!(m, ClientMessage::ReadyNextRound))
+                .count(),
+            2
+        );
+    }
+
+    /// 実際のトランスポートでローカルサーバに接続し、1ゲーム打ち切るE2Eテスト
+    ///
+    /// 実行前に `cargo run -p mahjong-net-server` でサーバを起動しておくこと:
+    /// `cargo test -p mahjong-client -- --ignored e2e`
+    #[test]
+    #[ignore = "要ローカルサーバ (cargo run -p mahjong-net-server)"]
+    fn test_e2e_full_game_against_local_server() {
+        let url = crate::transport::default_server_url();
+        let mut adapter = RemoteAdapter::create_room(&url, "E2Eテスト", 1);
+
+        let start = std::time::Instant::now();
+        let mut started = false;
+
+        loop {
+            assert!(
+                start.elapsed() < std::time::Duration::from_secs(120),
+                "E2Eテストがタイムアウトした"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(5));
+
+            adapter.tick();
+            if let Some(err) = adapter.take_error() {
+                panic!("サーバエラー: {:?} {}", err.code, err.message);
+            }
+            assert_ne!(
+                adapter.status(),
+                ConnStatus::Disconnected,
+                "サーバから切断された"
+            );
+
+            if !started {
+                if adapter.room().is_some() {
+                    adapter.start_game();
+                    started = true;
+                }
+                continue;
+            }
+
+            for event in adapter.poll_events() {
+                match event {
+                    ServerEvent::TileDrawn { can_tsumo, .. } => {
+                        let action = if can_tsumo {
+                            ClientAction::Tsumo
+                        } else {
+                            ClientAction::Discard { tile: None }
+                        };
+                        adapter.send_action(action);
+                    }
+                    ServerEvent::CallAvailable { .. } => {
+                        adapter.send_action(ClientAction::Pass);
+                    }
+                    ServerEvent::NineTerminalsAvailable => {
+                        adapter.send_action(ClientAction::NineTerminals { declare: false });
+                    }
+                    ServerEvent::RoundWon { .. } | ServerEvent::RoundDraw { .. } => {
+                        adapter.request_next_round();
+                    }
+                    _ => {}
+                }
+            }
+
+            if adapter.is_game_over() {
+                break;
+            }
+        }
+    }
+
+    #[test]
+    fn test_game_over_sets_flag() {
+        let (mut adapter, handle) = create_adapter();
+        assert!(!adapter.is_game_over());
+        handle.push_msg(&ServerMessage::GameOver {
+            final_scores: [30000, 25000, 25000, 20000],
+        });
+        adapter.tick();
+        assert!(adapter.is_game_over());
+    }
+}

--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -148,6 +148,49 @@ pub struct GameState {
     pub nine_terminals_pending: bool,
     /// 対局開始前設定
     pub setup_state: SetupState,
+    /// オンライン対戦UIの状態
+    pub online_state: OnlineUiState,
+}
+
+/// オンライン対戦UI（メニュー・ロビー）の状態
+#[derive(Debug, Clone)]
+pub struct OnlineUiState {
+    /// 表示名の入力欄
+    pub name_input: String,
+    /// ルームコードの入力欄
+    pub code_input: String,
+    /// true ならルームコード欄、false なら名前欄にフォーカス
+    pub code_focused: bool,
+    /// 接続状況・エラーの表示文言
+    pub status_line: Option<String>,
+    /// status_line がエラーか（赤色で表示する）
+    pub status_is_error: bool,
+    /// 入室中のルーム表示（メインループがアダプターからコピーする）
+    pub room: Option<RoomViewUi>,
+}
+
+impl OnlineUiState {
+    pub fn new() -> Self {
+        OnlineUiState {
+            name_input: "プレイヤー".to_string(),
+            code_input: String::new(),
+            code_focused: false,
+            status_line: None,
+            status_is_error: false,
+            room: None,
+        }
+    }
+}
+
+/// ロビー画面に表示するルーム情報
+#[derive(Debug, Clone)]
+pub struct RoomViewUi {
+    /// ルームコード
+    pub code: String,
+    /// 各座席の表示文言（東南西北の順）
+    pub seat_labels: [String; 4],
+    /// 自分がホストか（対局開始ボタンの表示に使う）
+    pub is_host: bool,
 }
 
 /// 対局開始前の設定画面の状態
@@ -232,6 +275,10 @@ impl SetupState {
 pub enum GamePhase {
     /// 対局開始前の設定画面
     Setup,
+    /// オンライン対戦メニュー（名前・ルームコード入力）
+    OnlineMenu,
+    /// オンラインロビー（メンバー待ち）
+    OnlineLobby,
     /// ゲーム開始前
     WaitingForStart,
     /// 対局中
@@ -294,6 +341,7 @@ impl GameState {
             pon_pending_options: Vec::new(),
             nine_terminals_pending: false,
             setup_state: SetupState::new(),
+            online_state: OnlineUiState::new(),
         }
     }
 

--- a/crates/mahjong-client/src/main.rs
+++ b/crates/mahjong-client/src/main.rs
@@ -1,21 +1,24 @@
 //! 麻雀クライアント（Macroquad）
 //!
 //! ブラウザ上で動作する4人打ち日本式リーチ麻雀。
-//! GameAdapterを通してサーバとやり取りする（ローカル対戦はLocalAdapter）。
+//! GameAdapterを通してサーバとやり取りする
+//! （ローカル対戦はLocalAdapter、オンライン対戦はRemoteAdapter）。
 
 use macroquad::prelude::*;
 
 mod adapter;
 mod game;
 mod renderer;
+mod transport;
 
 // WASM用カスタム乱数バックエンド（wasm-bindgen不要）
 #[cfg(target_arch = "wasm32")]
 mod wasm_rng;
 
-use adapter::{GameAdapter, LocalAdapter};
-use game::{GamePhase, GameState};
-use renderer::TileTextures;
+use adapter::{ConnStatus, GameAdapter, LocalAdapter, RemoteAdapter, RoomView, error_code_message};
+use game::{GamePhase, GameState, RoomViewUi};
+use mahjong_server::protocol::net::SeatInfo;
+use renderer::{OnlineLobbyAction, OnlineMenuAction, SetupAction, TileTextures};
 
 fn window_conf() -> Conf {
     Conf {
@@ -23,6 +26,79 @@ fn window_conf() -> Conf {
         window_width: 1280,
         window_height: 800,
         ..Default::default()
+    }
+}
+
+/// 入力された表示名を整形する（空なら既定値）
+fn display_name(state: &GameState) -> String {
+    let name = state.online_state.name_input.trim();
+    if name.is_empty() {
+        "プレイヤー".to_string()
+    } else {
+        name.to_string()
+    }
+}
+
+/// ステータス行を設定する
+fn set_status(state: &mut GameState, message: &str, is_error: bool) {
+    state.online_state.status_line = Some(message.to_string());
+    state.online_state.status_is_error = is_error;
+}
+
+/// ロビー画面用の座席表示文言を組み立てる
+fn build_seat_labels(room: &RoomView) -> [String; 4] {
+    let winds = ["東", "南", "西", "北"];
+    std::array::from_fn(|i| {
+        let who = match &room.seats[i] {
+            SeatInfo::Empty => "空席".to_string(),
+            SeatInfo::Cpu => "CPU".to_string(),
+            SeatInfo::Human { name, connected } => {
+                if *connected {
+                    name.clone()
+                } else {
+                    format!("{name}（切断中）")
+                }
+            }
+        };
+        let mut marks = String::new();
+        if i == room.your_seat {
+            marks.push_str("（あなた）");
+        }
+        if i == room.host_seat {
+            marks.push_str("（ホスト）");
+        }
+        format!("{}: {}{}", winds[i], who, marks)
+    })
+}
+
+/// リモートアダプターの状態をUI表示用にコピーする
+fn sync_online_ui(remote: &mut RemoteAdapter, state: &mut GameState) {
+    state.online_state.room = remote.room().map(|room| RoomViewUi {
+        code: room.code.clone(),
+        seat_labels: build_seat_labels(room),
+        is_host: room.is_host(),
+    });
+
+    if let Some(err) = remote.take_error() {
+        let message = match err.code {
+            Some(code) => error_code_message(code).to_string(),
+            None => err.message,
+        };
+        set_status(state, &message, true);
+        return;
+    }
+
+    // エラー表示中は接続ステータスで上書きしない
+    if state.online_state.status_is_error {
+        return;
+    }
+
+    match remote.status() {
+        ConnStatus::Connecting => set_status(state, "サーバに接続中...", false),
+        ConnStatus::Connected => {
+            state.online_state.status_line = None;
+        }
+        ConnStatus::Disconnected => set_status(state, "サーバとの接続が切れました", true),
     }
 }
 
@@ -36,7 +112,10 @@ async fn main() {
         eprintln!("警告: 日本語フォントを読み込めませんでした。デフォルトフォントで表示します。");
     }
 
+    // 対局中のアダプター（ローカル or リモート）
     let mut adapter: Option<Box<dyn GameAdapter>> = None;
+    // ロビー段階のリモート接続（対局開始時に adapter へ引き継ぐ）
+    let mut online: Option<RemoteAdapter> = None;
     let mut game_state = GameState::new();
 
     loop {
@@ -44,19 +123,115 @@ async fn main() {
 
         let overlay_click = renderer::draw_game(&game_state, font.as_ref(), &tile_textures);
 
+        // ロビー段階のリモート接続を進める
+        if let Some(remote) = &mut online {
+            remote.tick();
+            sync_online_ui(remote, &mut game_state);
+
+            if remote.game_started() {
+                // 対局開始: ゲームアダプターとして引き継ぐ
+                game_state.online_state.status_line = None;
+                game_state.online_state.status_is_error = false;
+                adapter = Some(Box::new(online.take().expect("checked above")));
+            }
+        }
+
+        // アダプターを毎フレーム進め、イベントを反映する
+        if let Some(adp) = &mut adapter {
+            adp.tick();
+            for event in adp.poll_events() {
+                game_state.handle_event(event);
+            }
+            // 対局中の接続バナー（ローカル対戦では常に None）
+            game_state.online_state.status_line = adp.status_text();
+            game_state.online_state.status_is_error = true;
+        }
+
         match game_state.phase {
             GamePhase::Setup => {
                 // 設定画面の入力処理
-                if let Some(configs) = renderer::handle_setup_input(&mut game_state, font.as_ref())
-                {
-                    // 対局開始
-                    let mut new_adapter = LocalAdapter::with_cpu_configs(configs);
-                    new_adapter.start_game();
-                    let events = new_adapter.poll_events();
-                    for event in events {
-                        game_state.handle_event(event);
+                if let Some(action) = renderer::handle_setup_input(&mut game_state, font.as_ref()) {
+                    match action {
+                        SetupAction::StartLocal(configs) => {
+                            // ローカル対局開始
+                            let mut new_adapter = LocalAdapter::with_cpu_configs(configs);
+                            new_adapter.start_game();
+                            let events = new_adapter.poll_events();
+                            for event in events {
+                                game_state.handle_event(event);
+                            }
+                            adapter = Some(Box::new(new_adapter));
+                        }
+                        SetupAction::GoOnline => {
+                            game_state.online_state.status_line = None;
+                            game_state.online_state.status_is_error = false;
+                            game_state.online_state.room = None;
+                            game_state.phase = GamePhase::OnlineMenu;
+                        }
                     }
-                    adapter = Some(Box::new(new_adapter));
+                }
+            }
+
+            GamePhase::OnlineMenu => {
+                if let Some(action) = renderer::handle_online_menu_input(&mut game_state) {
+                    match action {
+                        OnlineMenuAction::CreateRoom => {
+                            let url = transport::default_server_url();
+                            let name = display_name(&game_state);
+                            online = Some(RemoteAdapter::create_room(&url, &name, 1));
+                            set_status(&mut game_state, "サーバに接続中...", false);
+                        }
+                        OnlineMenuAction::JoinRoom => {
+                            let code = game_state.online_state.code_input.clone();
+                            if code.chars().count() != 6 {
+                                set_status(
+                                    &mut game_state,
+                                    "ルームコードを6文字で入力してください",
+                                    true,
+                                );
+                            } else {
+                                let url = transport::default_server_url();
+                                let name = display_name(&game_state);
+                                online = Some(RemoteAdapter::join_room(&url, &name, &code));
+                                set_status(&mut game_state, "サーバに接続中...", false);
+                            }
+                        }
+                        OnlineMenuAction::Back => {
+                            online = None;
+                            game_state.online_state.status_line = None;
+                            game_state.online_state.status_is_error = false;
+                            game_state.phase = GamePhase::Setup;
+                        }
+                    }
+                }
+
+                // 入室できたらロビーへ
+                if game_state.online_state.room.is_some() {
+                    game_state.online_state.status_line = None;
+                    game_state.online_state.status_is_error = false;
+                    game_state.phase = GamePhase::OnlineLobby;
+                }
+            }
+
+            GamePhase::OnlineLobby => {
+                if let Some(action) = renderer::handle_online_lobby_input(&game_state) {
+                    match action {
+                        OnlineLobbyAction::StartGame => {
+                            if let Some(remote) = &mut online {
+                                remote.start_game();
+                            }
+                        }
+                        OnlineLobbyAction::Leave => {
+                            if let Some(remote) = &mut online {
+                                remote.leave_room();
+                            }
+                            online = None;
+                            game_state.online_state.room = None;
+                            game_state.online_state.status_line = None;
+                            game_state.online_state.status_is_error = false;
+                            game_state.phase = GamePhase::OnlineMenu;
+                        }
+                    }
                 }
             }
 
@@ -65,13 +240,6 @@ async fn main() {
                     let action = game_state.handle_input(overlay_click);
                     if let Some(act) = action {
                         adp.send_action(act);
-                    }
-
-                    adp.tick();
-
-                    let events = adp.poll_events();
-                    for event in events {
-                        game_state.handle_event(event);
                     }
                 }
             }
@@ -86,10 +254,6 @@ async fn main() {
                             game_state.phase = GamePhase::GameOver;
                         } else {
                             adp.request_next_round();
-                            let events = adp.poll_events();
-                            for event in events {
-                                game_state.handle_event(event);
-                            }
                         }
                     }
                 }
@@ -100,6 +264,7 @@ async fn main() {
                     // 設定画面に戻る
                     game_state = GameState::new();
                     adapter = None;
+                    online = None;
                 }
             }
 

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -2,7 +2,11 @@
 //!
 //! 埋め込みPNGを使って麻雀牌を描画する。
 
+mod online;
 mod overlay;
+pub use online::{
+    OnlineLobbyAction, OnlineMenuAction, handle_online_lobby_input, handle_online_menu_input,
+};
 pub use overlay::OverlayClick;
 
 use macroquad::prelude::*;
@@ -154,6 +158,14 @@ pub fn draw_game(
             draw_setup(state, font);
             None
         }
+        GamePhase::OnlineMenu => {
+            online::draw_online_menu(state, font);
+            None
+        }
+        GamePhase::OnlineLobby => {
+            online::draw_online_lobby(state, font);
+            None
+        }
         GamePhase::WaitingForStart => {
             draw_jp_text(font, "ゲーム開始中...", 540.0, 400.0, 30, WHITE);
             None
@@ -165,7 +177,9 @@ pub fn draw_game(
             draw_other_player_hands(state, tile_textures);
             draw_hand(state, font, tile_textures);
             draw_melds(state, tile_textures);
-            overlay::draw_action_buttons(state, font, tile_textures)
+            let click = overlay::draw_action_buttons(state, font, tile_textures);
+            online::draw_connection_banner(state, font);
+            click
         }
         GamePhase::RoundResult => {
             draw_dora_indicators(state, font, tile_textures);
@@ -175,6 +189,7 @@ pub fn draw_game(
             draw_hand(state, font, tile_textures);
             draw_melds(state, tile_textures);
             draw_result(state, font, tile_textures);
+            online::draw_connection_banner(state, font);
             None
         }
         GamePhase::GameOver => {
@@ -1157,10 +1172,50 @@ fn draw_setup(state: &GameState, font: Option<&Font>) {
         28,
         WHITE,
     );
+
+    // オンライン対戦ボタン
+    let online_btn = SetupButton {
+        x: 490.0,
+        y: 700.0,
+        w: 300.0,
+        h: 40.0,
+    };
+    draw_rectangle(
+        online_btn.x,
+        online_btn.y,
+        online_btn.w,
+        online_btn.h,
+        Color::new(0.15, 0.25, 0.5, 1.0),
+    );
+    draw_rectangle_lines(
+        online_btn.x,
+        online_btn.y,
+        online_btn.w,
+        online_btn.h,
+        2.0,
+        Color::new(0.3, 0.5, 0.9, 1.0),
+    );
+    // ボタン(40px)内でフォント(22px)を垂直中央: btn_y + (40+22)/2 = btn_y + 31
+    draw_jp_text(
+        font,
+        "オンライン対戦",
+        online_btn.x + 73.0,
+        online_btn.y + 31.0,
+        22,
+        WHITE,
+    );
 }
 
-/// 設定画面の入力を処理する。対局開始が押された場合 Some(configs) を返す。
-pub fn handle_setup_input(state: &mut GameState, _font: Option<&Font>) -> Option<[CpuConfig; 3]> {
+/// 設定画面での操作
+pub enum SetupAction {
+    /// ローカル対局を開始する
+    StartLocal([CpuConfig; 3]),
+    /// オンライン対戦メニューへ
+    GoOnline,
+}
+
+/// 設定画面の入力を処理する。ボタンが押された場合 Some(action) を返す。
+pub fn handle_setup_input(state: &mut GameState, _font: Option<&Font>) -> Option<SetupAction> {
     if !is_mouse_button_pressed(MouseButton::Left) {
         return None;
     }
@@ -1210,7 +1265,18 @@ pub fn handle_setup_input(state: &mut GameState, _font: Option<&Font>) -> Option
     if start_btn.contains(mx, my) {
         let configs = setup.build_configs();
         state.phase = GamePhase::WaitingForStart;
-        return Some(configs);
+        return Some(SetupAction::StartLocal(configs));
+    }
+
+    // オンライン対戦ボタン
+    let online_btn = SetupButton {
+        x: 490.0,
+        y: 700.0,
+        w: 300.0,
+        h: 40.0,
+    };
+    if online_btn.contains(mx, my) {
+        return Some(SetupAction::GoOnline);
     }
 
     None

--- a/crates/mahjong-client/src/renderer/online.rs
+++ b/crates/mahjong-client/src/renderer/online.rs
@@ -1,0 +1,363 @@
+//! オンライン対戦のメニュー・ロビー画面
+//!
+//! 描画と入力処理。ネットワーク操作そのものは行わず、
+//! メインループへアクションを返す。
+
+use macroquad::prelude::*;
+
+use super::draw_jp_text;
+use crate::game::GameState;
+
+/// ボタン・入力欄の矩形
+struct Rect2 {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+}
+
+impl Rect2 {
+    fn contains(&self, mx: f32, my: f32) -> bool {
+        mx >= self.x && mx < self.x + self.w && my >= self.y && my < self.y + self.h
+    }
+}
+
+/// 表示名の最大文字数
+const NAME_MAX_CHARS: usize = 12;
+/// ルームコードの文字数
+const CODE_MAX_CHARS: usize = 6;
+
+// レイアウト定数（ウィンドウ 1280x800）
+const NAME_BOX: Rect2 = Rect2 {
+    x: 440.0,
+    y: 250.0,
+    w: 400.0,
+    h: 44.0,
+};
+const CODE_BOX: Rect2 = Rect2 {
+    x: 440.0,
+    y: 350.0,
+    w: 400.0,
+    h: 44.0,
+};
+const CREATE_BTN: Rect2 = Rect2 {
+    x: 440.0,
+    y: 450.0,
+    w: 400.0,
+    h: 50.0,
+};
+const JOIN_BTN: Rect2 = Rect2 {
+    x: 440.0,
+    y: 520.0,
+    w: 400.0,
+    h: 50.0,
+};
+const BACK_BTN: Rect2 = Rect2 {
+    x: 440.0,
+    y: 610.0,
+    w: 400.0,
+    h: 40.0,
+};
+const START_BTN: Rect2 = Rect2 {
+    x: 440.0,
+    y: 560.0,
+    w: 400.0,
+    h: 56.0,
+};
+const LEAVE_BTN: Rect2 = Rect2 {
+    x: 440.0,
+    y: 650.0,
+    w: 400.0,
+    h: 40.0,
+};
+
+/// オンラインメニューでの操作
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnlineMenuAction {
+    /// ルームを作成する
+    CreateRoom,
+    /// ルームコードで参加する
+    JoinRoom,
+    /// 設定画面に戻る
+    Back,
+}
+
+/// ロビーでの操作
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnlineLobbyAction {
+    /// 対局を開始する（ホストのみ）
+    StartGame,
+    /// 退出する
+    Leave,
+}
+
+fn draw_button(font: Option<&Font>, rect: &Rect2, label: &str, accent: bool) {
+    let bg = if accent {
+        Color::new(0.6, 0.15, 0.15, 1.0)
+    } else {
+        Color::new(0.25, 0.25, 0.25, 1.0)
+    };
+    let border = if accent {
+        Color::new(0.9, 0.3, 0.3, 1.0)
+    } else {
+        Color::new(0.5, 0.5, 0.5, 1.0)
+    };
+    draw_rectangle(rect.x, rect.y, rect.w, rect.h, bg);
+    draw_rectangle_lines(rect.x, rect.y, rect.w, rect.h, 2.0, border);
+    // ボタン内でフォント(24px)を垂直中央に: y + (h+24)/2
+    let text_w = label.chars().count() as f32 * 24.0;
+    draw_jp_text(
+        font,
+        label,
+        rect.x + (rect.w - text_w) / 2.0,
+        rect.y + (rect.h + 24.0) / 2.0,
+        24,
+        WHITE,
+    );
+}
+
+fn draw_input_box(font: Option<&Font>, rect: &Rect2, text: &str, focused: bool) {
+    draw_rectangle(
+        rect.x,
+        rect.y,
+        rect.w,
+        rect.h,
+        Color::new(0.1, 0.1, 0.1, 1.0),
+    );
+    let border = if focused {
+        Color::new(1.0, 0.9, 0.3, 1.0)
+    } else {
+        Color::new(0.5, 0.5, 0.5, 1.0)
+    };
+    draw_rectangle_lines(rect.x, rect.y, rect.w, rect.h, 2.0, border);
+    // カーソル付きで内容を表示
+    let shown = if focused {
+        format!("{text}_")
+    } else {
+        text.to_string()
+    };
+    draw_jp_text(font, &shown, rect.x + 10.0, rect.y + 31.0, 24, WHITE);
+}
+
+fn draw_status_line(state: &GameState, font: Option<&Font>, y: f32) {
+    if let Some(line) = &state.online_state.status_line {
+        let color = if state.online_state.status_is_error {
+            Color::new(1.0, 0.4, 0.4, 1.0)
+        } else {
+            Color::new(0.8, 0.8, 0.8, 1.0)
+        };
+        draw_jp_text(font, line, 440.0, y, 22, color);
+    }
+}
+
+/// オンラインメニュー画面を描画する
+pub fn draw_online_menu(state: &GameState, font: Option<&Font>) {
+    let online = &state.online_state;
+
+    draw_rectangle(190.0, 80.0, 900.0, 640.0, Color::new(0.0, 0.0, 0.0, 0.85));
+    draw_rectangle_lines(
+        190.0,
+        80.0,
+        900.0,
+        640.0,
+        2.0,
+        Color::new(0.5, 0.5, 0.5, 1.0),
+    );
+
+    draw_jp_text(font, "オンライン対戦", 500.0, 140.0, 36, WHITE);
+
+    draw_jp_text(
+        font,
+        "名前:",
+        NAME_BOX.x,
+        NAME_BOX.y - 10.0,
+        22,
+        Color::new(0.8, 0.8, 0.8, 1.0),
+    );
+    draw_input_box(font, &NAME_BOX, &online.name_input, !online.code_focused);
+
+    draw_jp_text(
+        font,
+        "ルームコード（参加する場合）:",
+        CODE_BOX.x,
+        CODE_BOX.y - 10.0,
+        22,
+        Color::new(0.8, 0.8, 0.8, 1.0),
+    );
+    draw_input_box(font, &CODE_BOX, &online.code_input, online.code_focused);
+
+    draw_button(font, &CREATE_BTN, "ルームを作成", true);
+    draw_button(font, &JOIN_BTN, "ルームに参加", true);
+    draw_button(font, &BACK_BTN, "戻る", false);
+
+    draw_status_line(state, font, BACK_BTN.y + BACK_BTN.h + 40.0);
+}
+
+/// オンラインメニューの入力を処理する
+pub fn handle_online_menu_input(state: &mut GameState) -> Option<OnlineMenuAction> {
+    let online = &mut state.online_state;
+
+    // 文字入力（フォーカス中の欄へ）
+    while let Some(c) = get_char_pressed() {
+        if c.is_control() {
+            continue;
+        }
+        if online.code_focused {
+            let c = c.to_ascii_uppercase();
+            // ルームコードの文字種（紛らわしい 0/O/1/I は無い）のみ受け付ける
+            if online.code_input.chars().count() < CODE_MAX_CHARS
+                && c.is_ascii_alphanumeric()
+                && !"0O1I".contains(c)
+            {
+                online.code_input.push(c);
+            }
+        } else if online.name_input.chars().count() < NAME_MAX_CHARS {
+            online.name_input.push(c);
+        }
+    }
+    if is_key_pressed(KeyCode::Backspace) {
+        if online.code_focused {
+            online.code_input.pop();
+        } else {
+            online.name_input.pop();
+        }
+    }
+    if is_key_pressed(KeyCode::Tab) {
+        online.code_focused = !online.code_focused;
+    }
+
+    if !is_mouse_button_pressed(MouseButton::Left) {
+        return None;
+    }
+    let (mx, my) = mouse_position();
+
+    if NAME_BOX.contains(mx, my) {
+        online.code_focused = false;
+        return None;
+    }
+    if CODE_BOX.contains(mx, my) {
+        online.code_focused = true;
+        return None;
+    }
+    if CREATE_BTN.contains(mx, my) {
+        return Some(OnlineMenuAction::CreateRoom);
+    }
+    if JOIN_BTN.contains(mx, my) {
+        return Some(OnlineMenuAction::JoinRoom);
+    }
+    if BACK_BTN.contains(mx, my) {
+        return Some(OnlineMenuAction::Back);
+    }
+
+    None
+}
+
+/// ロビー画面を描画する
+pub fn draw_online_lobby(state: &GameState, font: Option<&Font>) {
+    let online = &state.online_state;
+
+    draw_rectangle(190.0, 80.0, 900.0, 640.0, Color::new(0.0, 0.0, 0.0, 0.85));
+    draw_rectangle_lines(
+        190.0,
+        80.0,
+        900.0,
+        640.0,
+        2.0,
+        Color::new(0.5, 0.5, 0.5, 1.0),
+    );
+
+    draw_jp_text(font, "ロビー", 580.0, 140.0, 36, WHITE);
+
+    let Some(room) = &online.room else {
+        draw_jp_text(font, "ルーム情報を取得中...", 500.0, 300.0, 26, WHITE);
+        draw_status_line(state, font, 380.0);
+        return;
+    };
+
+    // ルームコード（友人に共有する）
+    draw_jp_text(
+        font,
+        &format!("ルームコード: {}", room.code),
+        440.0,
+        220.0,
+        32,
+        Color::new(1.0, 0.9, 0.3, 1.0),
+    );
+    draw_jp_text(
+        font,
+        "このコードを友人に伝えて参加してもらいましょう",
+        440.0,
+        252.0,
+        18,
+        Color::new(0.7, 0.7, 0.7, 1.0),
+    );
+
+    // 座席一覧
+    for (i, label) in room.seat_labels.iter().enumerate() {
+        let y = 310.0 + i as f32 * 50.0;
+        draw_rectangle(
+            440.0,
+            y - 28.0,
+            400.0,
+            40.0,
+            Color::new(0.15, 0.15, 0.15, 1.0),
+        );
+        draw_jp_text(font, label, 452.0, y, 24, WHITE);
+    }
+
+    if room.is_host {
+        draw_button(font, &START_BTN, "対局開始", true);
+        draw_jp_text(
+            font,
+            "空席はCPUが入ります",
+            START_BTN.x + 110.0,
+            START_BTN.y - 8.0,
+            18,
+            Color::new(0.7, 0.7, 0.7, 1.0),
+        );
+    } else {
+        draw_jp_text(
+            font,
+            "ホストの開始を待っています...",
+            480.0,
+            START_BTN.y + 34.0,
+            24,
+            Color::new(0.8, 0.8, 0.8, 1.0),
+        );
+    }
+    draw_button(font, &LEAVE_BTN, "退出", false);
+
+    draw_status_line(state, font, LEAVE_BTN.y + LEAVE_BTN.h + 36.0);
+}
+
+/// ロビーの入力を処理する
+pub fn handle_online_lobby_input(state: &GameState) -> Option<OnlineLobbyAction> {
+    if !is_mouse_button_pressed(MouseButton::Left) {
+        return None;
+    }
+    let (mx, my) = mouse_position();
+
+    let is_host = state
+        .online_state
+        .room
+        .as_ref()
+        .is_some_and(|room| room.is_host);
+    if is_host && START_BTN.contains(mx, my) {
+        return Some(OnlineLobbyAction::StartGame);
+    }
+    if LEAVE_BTN.contains(mx, my) {
+        return Some(OnlineLobbyAction::Leave);
+    }
+
+    None
+}
+
+/// 対局中の接続状態バナーを描画する
+pub fn draw_connection_banner(state: &GameState, font: Option<&Font>) {
+    if let Some(line) = &state.online_state.status_line {
+        let w = 420.0;
+        let x = (1280.0 - w) / 2.0;
+        draw_rectangle(x, 4.0, w, 32.0, Color::new(0.5, 0.1, 0.1, 0.9));
+        draw_jp_text(font, line, x + 16.0, 27.0, 20, WHITE);
+    }
+}

--- a/crates/mahjong-client/src/transport.rs
+++ b/crates/mahjong-client/src/transport.rs
@@ -1,0 +1,235 @@
+//! WebSocketトランスポート
+//!
+//! macroquad のフレームループから毎フレーム poll できる、
+//! ノンブロッキングな WebSocket 抽象。
+//!
+//! - ネイティブ: tungstenite を別スレッドで動かし、mpsc チャネルで橋渡しする
+//! - WASM: フェーズ4（手書きJSグルー）まではスタブ（常にエラーを返す）
+
+/// トランスポートで発生したイベント
+// WASMスタブは Error しか生成しないが、ネイティブでは全バリアントを使う
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+#[derive(Debug, Clone)]
+pub enum WsEvent {
+    /// 接続が確立した
+    Opened,
+    /// テキストメッセージを受信した
+    Message(String),
+    /// 接続が閉じられた
+    Closed,
+    /// エラーが発生した（接続失敗・通信エラー）
+    Error(String),
+}
+
+/// ノンブロッキングな WebSocket 接続
+///
+/// `RemoteAdapter` はこのトレイト経由で通信するため、
+/// テストではスクリプト化したモックに差し替えられる。
+pub trait Transport {
+    /// テキストフレームを送信する（未接続・切断後の送信は無視される）
+    fn send_text(&mut self, text: &str);
+
+    /// 発生したイベントをすべて取り出す（ブロックしない）
+    fn poll(&mut self) -> Vec<WsEvent>;
+}
+
+/// 既定の接続先URLを返す
+pub fn default_server_url() -> String {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        std::env::var("MAHJONG_SERVER_URL").unwrap_or_else(|_| "ws://127.0.0.1:8080/ws".to_string())
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        // フェーズ4で window.MAHJONG_SERVER_URL から取得する
+        "ws://127.0.0.1:8080/ws".to_string()
+    }
+}
+
+/// サーバへの接続を開始し、トランスポートを返す
+///
+/// 接続は非同期に進行し、結果は `poll()` の `Opened` / `Error` で通知される。
+pub fn connect(url: &str) -> Box<dyn Transport> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        Box::new(native::NativeTransport::connect(url))
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = url;
+        Box::new(wasm_stub::StubTransport::new())
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use std::net::TcpStream;
+    use std::sync::mpsc::{Receiver, Sender, TryRecvError, channel};
+    use std::time::Duration;
+
+    use tungstenite::Message;
+    use tungstenite::stream::MaybeTlsStream;
+
+    use super::{Transport, WsEvent};
+
+    /// 受信待ちのポーリング間隔
+    const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+    /// ネイティブ用トランスポート: 通信スレッドとチャネルで橋渡しする
+    pub struct NativeTransport {
+        out_tx: Sender<String>,
+        in_rx: Receiver<WsEvent>,
+    }
+
+    impl NativeTransport {
+        pub fn connect(url: &str) -> Self {
+            let (out_tx, out_rx) = channel::<String>();
+            let (in_tx, in_rx) = channel::<WsEvent>();
+            let url = url.to_string();
+            std::thread::spawn(move || run_socket(&url, &out_rx, &in_tx));
+            NativeTransport { out_tx, in_rx }
+        }
+    }
+
+    impl Transport for NativeTransport {
+        fn send_text(&mut self, text: &str) {
+            // スレッド終了後（切断後）の送信は無視する
+            let _ = self.out_tx.send(text.to_string());
+        }
+
+        fn poll(&mut self) -> Vec<WsEvent> {
+            let mut events = Vec::new();
+            // Err はキューが空か、スレッド終了済み（Closed/Error は通知済み）
+            while let Ok(event) = self.in_rx.try_recv() {
+                events.push(event);
+            }
+            events
+        }
+    }
+
+    /// 通信スレッド本体
+    fn run_socket(url: &str, out_rx: &Receiver<String>, in_tx: &Sender<WsEvent>) {
+        let (mut socket, _) = match tungstenite::connect(url) {
+            Ok(ok) => ok,
+            Err(e) => {
+                let _ = in_tx.send(WsEvent::Error(format!("接続に失敗しました: {e}")));
+                return;
+            }
+        };
+
+        // 送受信を1ループで回すためノンブロッキングにする
+        if let Err(e) = set_nonblocking(socket.get_mut()) {
+            let _ = in_tx.send(WsEvent::Error(format!("ソケット設定に失敗しました: {e}")));
+            return;
+        }
+
+        if in_tx.send(WsEvent::Opened).is_err() {
+            return;
+        }
+
+        loop {
+            // 送信キューを書き込みバッファへ移す
+            loop {
+                match out_rx.try_recv() {
+                    Ok(text) => {
+                        if let Err(e) = socket.write(Message::text(text)) {
+                            let _ = in_tx.send(WsEvent::Error(format!("送信エラー: {e}")));
+                            return;
+                        }
+                    }
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => {
+                        // トランスポートが破棄された: 接続を閉じて終了
+                        let _ = socket.close(None);
+                        let _ = socket.flush();
+                        return;
+                    }
+                }
+            }
+
+            // 書き込みバッファを送出する（Pong の自動応答もここで送られる）
+            match socket.flush() {
+                Ok(()) => {}
+                Err(tungstenite::Error::Io(ref e))
+                    if e.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed) => {
+                    let _ = in_tx.send(WsEvent::Closed);
+                    return;
+                }
+                Err(e) => {
+                    let _ = in_tx.send(WsEvent::Error(format!("送信エラー: {e}")));
+                    return;
+                }
+            }
+
+            // 受信
+            match socket.read() {
+                Ok(Message::Text(text)) => {
+                    if in_tx.send(WsEvent::Message(text.to_string())).is_err() {
+                        let _ = socket.close(None);
+                        return;
+                    }
+                }
+                Ok(Message::Close(_)) => {
+                    let _ = in_tx.send(WsEvent::Closed);
+                    return;
+                }
+                // Ping/Pong は下層が応答をキューイングする。Binary は使わない
+                Ok(_) => {}
+                Err(tungstenite::Error::Io(ref e))
+                    if e.kind() == std::io::ErrorKind::WouldBlock =>
+                {
+                    std::thread::sleep(POLL_INTERVAL);
+                }
+                Err(tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed) => {
+                    let _ = in_tx.send(WsEvent::Closed);
+                    return;
+                }
+                Err(e) => {
+                    let _ = in_tx.send(WsEvent::Error(format!("通信エラー: {e}")));
+                    return;
+                }
+            }
+        }
+    }
+
+    /// 下層の TCP ストリームをノンブロッキングに設定する
+    fn set_nonblocking(stream: &mut MaybeTlsStream<TcpStream>) -> std::io::Result<()> {
+        match stream {
+            MaybeTlsStream::Plain(s) => s.set_nonblocking(true),
+            MaybeTlsStream::Rustls(s) => s.get_ref().set_nonblocking(true),
+            _ => Ok(()),
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm_stub {
+    use super::{Transport, WsEvent};
+
+    /// WASM用スタブ: 接続せず、一度だけエラーを通知する
+    pub struct StubTransport {
+        reported: bool,
+    }
+
+    impl StubTransport {
+        pub fn new() -> Self {
+            StubTransport { reported: false }
+        }
+    }
+
+    impl Transport for StubTransport {
+        fn send_text(&mut self, _text: &str) {}
+
+        fn poll(&mut self) -> Vec<WsEvent> {
+            if self.reported {
+                Vec::new()
+            } else {
+                self.reported = true;
+                vec![WsEvent::Error(
+                    "このビルドではオンライン対戦は未対応です".to_string(),
+                )]
+            }
+        }
+    }
+}

--- a/crates/mahjong-net-server/src/room.rs
+++ b/crates/mahjong-net-server/src/room.rs
@@ -221,21 +221,26 @@ impl Room {
                         .await;
                     return;
                 }
-                let accepted = self
-                    .driver
-                    .as_mut()
-                    .expect("checked above")
-                    .handle_action(seat, action);
+                let driver = self.driver.as_mut().expect("checked above");
+                let accepted = driver.handle_action(seat, action.clone());
                 if !accepted {
-                    self.send_error(seat, ErrorCode::InvalidAction, "action rejected")
-                        .await;
+                    let phase = driver
+                        .table()
+                        .current_round()
+                        .map(|r| format!("{:?}", r.phase));
+                    self.send_error(
+                        seat,
+                        ErrorCode::InvalidAction,
+                        &format!("action rejected: seat={seat} action={action:?} phase={phase:?}"),
+                    )
+                    .await;
                 }
                 self.progress_game().await;
             }
             ClientMessage::ReadyNextRound => {
                 if !self.awaiting_ready {
-                    self.send_error(seat, ErrorCode::InvalidAction, "not awaiting next round")
-                        .await;
+                    // 自動進行タイマーと行き違いになった遅延確認は無害なので
+                    // エラーにせず黙って無視する
                     return;
                 }
                 self.ready[seat] = true;

--- a/crates/mahjong-net-server/tests/integration.rs
+++ b/crates/mahjong-net-server/tests/integration.rs
@@ -48,6 +48,30 @@ fn assert_scores_consistent(scores: [i32; 4]) {
     );
 }
 
+/// 診断トレース用にメッセージを短い文字列へ要約する
+fn summarize(msg: &ServerMessage) -> String {
+    match msg {
+        ServerMessage::Event(e) => match e {
+            ServerEvent::GameStarted { round_number, .. } => {
+                format!("GameStarted(round={round_number})")
+            }
+            ServerEvent::TileDrawn { can_tsumo, .. } => format!("TileDrawn(can_tsumo={can_tsumo})"),
+            ServerEvent::TileDiscarded { player, .. } => format!("TileDiscarded({player:?})"),
+            ServerEvent::CallAvailable { .. } => "CallAvailable".to_string(),
+            ServerEvent::PlayerCalled {
+                player, call_type, ..
+            } => format!("PlayerCalled({player:?},{call_type:?})"),
+            ServerEvent::NineTerminalsAvailable => "NineTerminalsAvailable".to_string(),
+            ServerEvent::RoundWon { winner, .. } => format!("RoundWon({winner:?})"),
+            ServerEvent::RoundDraw { reason, .. } => format!("RoundDraw({reason:?})"),
+            other => format!("{other:?}").chars().take(30).collect(),
+        },
+        ServerMessage::GameOver { .. } => "GameOver".to_string(),
+        ServerMessage::Error { code, message } => format!("Error({code:?},{message})"),
+        other => format!("{other:?}").chars().take(30).collect(),
+    }
+}
+
 /// テスト用 WebSocket クライアント
 struct TestClient {
     ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
@@ -119,41 +143,82 @@ impl TestClient {
         }
     }
 
+    /// 受信済みのメッセージをまとめて取り出す（50msの静止で区切る）
+    ///
+    /// `TileDrawn` と `NineTerminalsAvailable` のように連続で送られる
+    /// イベントは別フレームで届くため、まとめてから行動を判断する。
+    async fn recv_batch(&mut self) -> Vec<ServerMessage> {
+        let mut batch = vec![self.recv().await];
+        loop {
+            let frame = match tokio::time::timeout(Duration::from_millis(50), self.ws.next()).await
+            {
+                Ok(Some(Ok(frame))) => frame,
+                // 静止 or 切断（切断は次の recv で検出する）
+                Err(_) | Ok(None) | Ok(Some(Err(_))) => break,
+            };
+            match frame {
+                Message::Text(text) => {
+                    batch.push(ServerMessage::from_json(text.as_str()).expect("不正なJSON"));
+                }
+                Message::Ping(_) | Message::Pong(_) => continue,
+                _ => break,
+            }
+        }
+        batch
+    }
+
     /// ツモ切りボットとして GameOver まで打ち続ける
     ///
     /// `send_ready` が false の場合は局結果の確認（ReadyNextRound）を送らず、
     /// サーバ側の自動進行に任せる。
     async fn play_until_game_over(&mut self, send_ready: bool) -> [i32; 4] {
         loop {
-            match self.recv().await {
-                ServerMessage::Event(event) => match event {
-                    ServerEvent::TileDrawn { can_tsumo, .. } => {
-                        let action = if can_tsumo {
-                            ClientAction::Tsumo
-                        } else {
-                            ClientAction::Discard { tile: None }
-                        };
-                        self.send(&ClientMessage::Action(action)).await;
-                    }
-                    ServerEvent::CallAvailable { .. } => {
-                        self.send(&ClientMessage::Action(ClientAction::Pass)).await;
-                    }
-                    ServerEvent::NineTerminalsAvailable => {
-                        self.send(&ClientMessage::Action(ClientAction::NineTerminals {
-                            declare: false,
-                        }))
-                        .await;
-                    }
-                    ServerEvent::RoundWon { .. } | ServerEvent::RoundDraw { .. } if send_ready => {
-                        self.send(&ClientMessage::ReadyNextRound).await;
+            let batch = self.recv_batch().await;
+            // 失敗時の診断用トレース（パニック時のみ表示される）
+            for msg in &batch {
+                println!("[bot] recv {}", summarize(msg));
+            }
+
+            // 九種九牌の選択があるターンはフェーズが WaitForNineTerminals の
+            // ため、同時に届いた TileDrawn への打牌は無効になる。宣言を
+            // 拒否すると、サーバが TileDrawn を再送して打牌を促す
+            let nine_terminals = batch
+                .iter()
+                .any(|m| matches!(m, ServerMessage::Event(ServerEvent::NineTerminalsAvailable)));
+            if nine_terminals {
+                self.send(&ClientMessage::Action(ClientAction::NineTerminals {
+                    declare: false,
+                }))
+                .await;
+            }
+
+            for msg in batch {
+                match msg {
+                    ServerMessage::Event(event) => match event {
+                        ServerEvent::TileDrawn { can_tsumo, .. } if !nine_terminals => {
+                            let action = if can_tsumo {
+                                ClientAction::Tsumo
+                            } else {
+                                ClientAction::Discard { tile: None }
+                            };
+                            self.send(&ClientMessage::Action(action)).await;
+                        }
+                        ServerEvent::CallAvailable { .. } => {
+                            self.send(&ClientMessage::Action(ClientAction::Pass)).await;
+                        }
+                        ServerEvent::RoundWon { .. } | ServerEvent::RoundDraw { .. }
+                            if send_ready =>
+                        {
+                            self.send(&ClientMessage::ReadyNextRound).await;
+                        }
+                        _ => {}
+                    },
+                    ServerMessage::GameOver { final_scores } => return final_scores,
+                    ServerMessage::Error { code, message } => {
+                        panic!("予期しないエラー: {code:?} {message}");
                     }
                     _ => {}
-                },
-                ServerMessage::GameOver { final_scores } => return final_scores,
-                ServerMessage::Error { code, message } => {
-                    panic!("予期しないエラー: {code:?} {message}");
                 }
-                _ => {}
             }
         }
     }

--- a/crates/mahjong-net-server/tests/integration.rs
+++ b/crates/mahjong-net-server/tests/integration.rs
@@ -65,9 +65,11 @@ impl TestClient {
     }
 
     /// 次の ServerMessage を受信する（Ping/Pong は読み飛ばす）
+    ///
+    /// タイムアウトはCI等の高負荷環境での誤検知を避けるため長めに取る。
     async fn recv(&mut self) -> ServerMessage {
         loop {
-            let frame = tokio::time::timeout(Duration::from_secs(10), self.ws.next())
+            let frame = tokio::time::timeout(Duration::from_secs(30), self.ws.next())
                 .await
                 .expect("受信がタイムアウトした")
                 .expect("接続が閉じられた")

--- a/crates/mahjong-server/src/driver.rs
+++ b/crates/mahjong-server/src/driver.rs
@@ -496,9 +496,18 @@ mod tests {
             driver.tick();
             let events = driver.drain_events(0);
 
+            // 九種九牌の選択があるターンは宣言拒否のみ送る
+            // （拒否するとサーバが TileDrawn を再送して打牌を促す）
+            let nine_terminals = events
+                .iter()
+                .any(|e| matches!(e, ServerEvent::NineTerminalsAvailable));
+            if nine_terminals {
+                driver.handle_action(0, ClientAction::NineTerminals { declare: false });
+            }
+
             for event in &events {
                 match event {
-                    ServerEvent::TileDrawn { can_tsumo, .. } => {
+                    ServerEvent::TileDrawn { can_tsumo, .. } if !nine_terminals => {
                         // ツモ切り（和了可能ならツモ和了）
                         if *can_tsumo {
                             driver.handle_action(0, ClientAction::Tsumo);
@@ -508,9 +517,6 @@ mod tests {
                     }
                     ServerEvent::CallAvailable { .. } => {
                         driver.handle_action(0, ClientAction::Pass);
-                    }
-                    ServerEvent::NineTerminalsAvailable => {
-                        driver.handle_action(0, ClientAction::NineTerminals { declare: false });
                     }
                     _ => {}
                 }


### PR DESCRIPTION
## Summary

Phase 3 of online multiplayer (#210, part of #207): the native client can now create/join rooms and play online against `mahjong-net-server`.

- **`transport.rs`**: `Transport` trait + `WsEvent` for frame-loop-friendly WebSocket I/O. Native impl runs sync `tungstenite` on a dedicated thread (non-blocking socket, `std::sync::mpsc` bridge — no tokio in the client; rustls for `wss://`). The WASM build compiles against a stub that reports online play as unsupported until the hand-written JS glue lands in phase 4 (#211).
- **`RemoteAdapter`** (implements `GameAdapter`): Hello/Welcome handshake, deferred CreateRoom/JoinRoom intent, `RoomState` tracking, event passthrough, `ReadyNextRound` dedup, `GameOver` detection, and Japanese error messages for every `ErrorCode`.
- **UI**: new `OnlineMenu` (display name + room-code entry, create/join/back) and `OnlineLobby` (room code, 4 seat slots with wind/name/CPU/empty + host/you markers, host-only start, leave) scenes; online entry button on the setup screen; a red connection banner during play when the transport degrades.
- **`main.rs`**: adapters are ticked/polled every frame so asynchronous remote events apply as they arrive; the lobby-stage `RemoteAdapter` is handed off as `Box<dyn GameAdapter>` when `GameStarted` arrives. Server URL via `MAHJONG_SERVER_URL` (default `ws://127.0.0.1:8080/ws`).

### Protocol race fixes found by testing

- **Nine terminals**: after declining, the server re-sends `TileDrawn`; bots that discarded immediately on the first `TileDrawn` (sent alongside `NineTerminalsAvailable` while the phase is `WaitForNineTerminals`) double-discarded. All test bots now batch events and send only the decline.
- **Late `ReadyNextRound`**: a confirmation racing the auto-advance timer is now silently ignored by the room instead of producing `InvalidAction` — prevents spurious error overlays in real clients.
- `InvalidAction` errors now include the rejected action and current phase for debuggability.

## Test plan

- [x] `RemoteAdapter` unit tests against a scripted mock transport (handshake order, intent dispatch, room view, error paths, ready dedup, disconnect, game over) — 10 tests
- [x] **E2E over a real WebSocket**: ignored test `test_e2e_full_game_against_local_server` plays a full game (create room → start → tsumogiri to GameOver) against a locally running `mahjong-net-server`; verified passing (~6 s)
- [x] Integration suite run **30x consecutively clean** after the race fixes (previously flaked ~1 in 10)
- [x] `cargo test` workspace green; `cargo fmt` / `cargo clippy --all-targets` clean
- [x] `cargo build -p mahjong-client --target wasm32-unknown-unknown --release` passes

### Manual E2E checklist (GUI)

- [ ] `cargo run -p mahjong-net-server` + 2x `cargo run -p mahjong-client`: host creates a room, guest joins via code, host starts, play a hand to the result screen
- [ ] Join with a wrong code shows ルームが見つかりません
- [ ] Guest sees ホストの開始を待っています; non-host has no start button
- [ ] Killing the server mid-game shows the red connection banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)
