### PR TITLE
Add WASM WebSocket transport via hand-written ws.js glue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
-/public/mahjong-client.wasm
-/public/mq_js_bundle.js
+# ローカルで scripts/vercel-build.sh を実行したときの生成物（ハッシュ付き含む）
+/public/*.wasm
+/public/*.js
 .DS_Store
 .claude/*

--- a/crates/mahjong-client/js/ws.js
+++ b/crates/mahjong-client/js/ws.js
@@ -1,0 +1,150 @@
+// オンライン対戦用 WebSocket プラグイン
+//
+// miniquad の mq_js_bundle.js が提供するプラグイン機構で WASM に
+// WebSocket 機能を注入する。wasm-bindgen は使わない（wasm_rng.rs と同じ方針）。
+//
+// Rust 側 (crates/mahjong-client/src/transport.rs) の extern "C" 宣言と
+// 関数シグネチャ・ステータス値を一致させること。
+"use strict";
+
+const MAHJONG_WS_VERSION = 1;
+
+// 接続ステータス（Rust 側と一致させる）
+// 0 = 接続中, 1 = 接続済み, 2 = 切断, 3 = エラー
+const MAHJONG_WS_CONNECTING = 0;
+const MAHJONG_WS_OPEN = 1;
+const MAHJONG_WS_CLOSED = 2;
+const MAHJONG_WS_ERROR = 3;
+
+const mahjong_ws = {
+    // handle (配列インデックス) -> { ws, status, queue: [Uint8Array] }
+    sockets: [],
+    encoder: new TextEncoder(),
+    decoder: new TextDecoder(),
+
+    read_str(ptr, len) {
+        return this.decoder.decode(new Uint8Array(wasm_memory.buffer, ptr, len));
+    },
+};
+
+// 接続を開始し、ハンドルを返す
+function mahjong_ws_connect(url_ptr, url_len) {
+    const url = mahjong_ws.read_str(url_ptr, url_len);
+    const handle = mahjong_ws.sockets.length;
+    const entry = { ws: null, status: MAHJONG_WS_CONNECTING, queue: [] };
+    mahjong_ws.sockets.push(entry);
+
+    try {
+        const ws = new WebSocket(url);
+        entry.ws = ws;
+        ws.onopen = () => {
+            entry.status = MAHJONG_WS_OPEN;
+        };
+        ws.onmessage = (event) => {
+            if (typeof event.data === "string") {
+                entry.queue.push(mahjong_ws.encoder.encode(event.data));
+            }
+        };
+        ws.onclose = () => {
+            if (entry.status !== MAHJONG_WS_ERROR) {
+                entry.status = MAHJONG_WS_CLOSED;
+            }
+        };
+        ws.onerror = (event) => {
+            console.error("mahjong_ws: WebSocketエラー", event);
+            entry.status = MAHJONG_WS_ERROR;
+        };
+    } catch (err) {
+        console.error("mahjong_ws: 接続に失敗しました", err);
+        entry.status = MAHJONG_WS_ERROR;
+    }
+
+    return handle;
+}
+
+// 接続ステータスを返す
+function mahjong_ws_status(handle) {
+    const entry = mahjong_ws.sockets[handle];
+    return entry ? entry.status : MAHJONG_WS_ERROR;
+}
+
+// テキストフレームを送信する（成功 0 / 失敗 -1）
+function mahjong_ws_send(handle, ptr, len) {
+    const entry = mahjong_ws.sockets[handle];
+    if (!entry || entry.status !== MAHJONG_WS_OPEN) {
+        return -1;
+    }
+    try {
+        entry.ws.send(mahjong_ws.read_str(ptr, len));
+        return 0;
+    } catch (err) {
+        console.error("mahjong_ws: 送信に失敗しました", err);
+        entry.status = MAHJONG_WS_ERROR;
+        return -1;
+    }
+}
+
+// 受信キュー先頭のメッセージのバイト長を返す（空なら -1）
+function mahjong_ws_next_msg_len(handle) {
+    const entry = mahjong_ws.sockets[handle];
+    if (!entry || entry.queue.length === 0) {
+        return -1;
+    }
+    return entry.queue[0].length;
+}
+
+// 受信キュー先頭のメッセージを buf_ptr へコピーして取り除く
+// （Rust 側が mahjong_ws_next_msg_len の長さでバッファを確保して呼ぶ）
+function mahjong_ws_read_msg(handle, buf_ptr) {
+    const entry = mahjong_ws.sockets[handle];
+    if (!entry || entry.queue.length === 0) {
+        return;
+    }
+    const msg = entry.queue.shift();
+    new Uint8Array(wasm_memory.buffer, buf_ptr, msg.length).set(msg);
+}
+
+// 接続を閉じる
+function mahjong_ws_close(handle) {
+    const entry = mahjong_ws.sockets[handle];
+    if (entry && entry.ws) {
+        try {
+            entry.ws.close();
+        } catch (_err) {
+            // 既に閉じている場合などは無視
+        }
+    }
+    if (entry && entry.status !== MAHJONG_WS_ERROR) {
+        entry.status = MAHJONG_WS_CLOSED;
+    }
+}
+
+// ページに設定された接続先URL (window.MAHJONG_SERVER_URL) を buf_ptr に書き込み、
+// バイト長を返す（未設定・容量不足なら 0 を返し、Rust 側が既定値を使う）
+function mahjong_ws_default_url(buf_ptr, cap) {
+    const url = typeof window !== "undefined" && window.MAHJONG_SERVER_URL;
+    if (!url) {
+        return 0;
+    }
+    const bytes = mahjong_ws.encoder.encode(url);
+    if (bytes.length > cap) {
+        console.error("mahjong_ws: MAHJONG_SERVER_URL が長すぎます");
+        return 0;
+    }
+    new Uint8Array(wasm_memory.buffer, buf_ptr, bytes.length).set(bytes);
+    return bytes.length;
+}
+
+miniquad_add_plugin({
+    name: "mahjong_ws",
+    version: MAHJONG_WS_VERSION,
+    register_plugin(importObject) {
+        importObject.env.mahjong_ws_connect = mahjong_ws_connect;
+        importObject.env.mahjong_ws_status = mahjong_ws_status;
+        importObject.env.mahjong_ws_send = mahjong_ws_send;
+        importObject.env.mahjong_ws_next_msg_len = mahjong_ws_next_msg_len;
+        importObject.env.mahjong_ws_read_msg = mahjong_ws_read_msg;
+        importObject.env.mahjong_ws_close = mahjong_ws_close;
+        importObject.env.mahjong_ws_default_url = mahjong_ws_default_url;
+    },
+});

--- a/crates/mahjong-client/src/transport.rs
+++ b/crates/mahjong-client/src/transport.rs
@@ -4,7 +4,8 @@
 //! ノンブロッキングな WebSocket 抽象。
 //!
 //! - ネイティブ: tungstenite を別スレッドで動かし、mpsc チャネルで橋渡しする
-//! - WASM: フェーズ4（手書きJSグルー）まではスタブ（常にエラーを返す）
+//! - WASM: 手書きJSグルー (crates/mahjong-client/js/ws.js) の関数を
+//!   extern "C" で呼ぶ（wasm-bindgen 不使用。wasm_rng.rs と同じ方針）
 
 /// トランスポートで発生したイベント
 // WASMスタブは Error しか生成しないが、ネイティブでは全バリアントを使う
@@ -41,8 +42,8 @@ pub fn default_server_url() -> String {
     }
     #[cfg(target_arch = "wasm32")]
     {
-        // フェーズ4で window.MAHJONG_SERVER_URL から取得する
-        "ws://127.0.0.1:8080/ws".to_string()
+        // index.html で window.MAHJONG_SERVER_URL が設定されていればそれを使う
+        wasm::page_server_url().unwrap_or_else(|| "ws://127.0.0.1:8080/ws".to_string())
     }
 }
 
@@ -56,8 +57,7 @@ pub fn connect(url: &str) -> Box<dyn Transport> {
     }
     #[cfg(target_arch = "wasm32")]
     {
-        let _ = url;
-        Box::new(wasm_stub::StubTransport::new())
+        Box::new(wasm::WasmTransport::connect(url))
     }
 }
 
@@ -204,31 +204,124 @@ mod native {
 }
 
 #[cfg(target_arch = "wasm32")]
-mod wasm_stub {
+mod wasm {
     use super::{Transport, WsEvent};
 
-    /// WASM用スタブ: 接続せず、一度だけエラーを通知する
-    pub struct StubTransport {
-        reported: bool,
+    // 接続ステータス（ws.js と一致させる）
+    const STATUS_OPEN: i32 = 1;
+    const STATUS_CLOSED: i32 = 2;
+    const STATUS_ERROR: i32 = 3;
+
+    // ws.js が miniquad のプラグイン機構で importObject.env に注入する関数群
+    unsafe extern "C" {
+        fn mahjong_ws_connect(url_ptr: *const u8, url_len: usize) -> i32;
+        fn mahjong_ws_status(handle: i32) -> i32;
+        fn mahjong_ws_send(handle: i32, ptr: *const u8, len: usize) -> i32;
+        fn mahjong_ws_next_msg_len(handle: i32) -> i32;
+        fn mahjong_ws_read_msg(handle: i32, buf_ptr: *mut u8);
+        fn mahjong_ws_close(handle: i32);
+        fn mahjong_ws_default_url(buf_ptr: *mut u8, cap: usize) -> i32;
     }
 
-    impl StubTransport {
-        pub fn new() -> Self {
-            StubTransport { reported: false }
+    /// ws.js プラグインのバージョン照合用
+    ///
+    /// mq_js_bundle.js の init_plugins が `{プラグイン名}_crate_version` を
+    /// 呼び、JS側のバージョンと一致するか検証する。
+    #[unsafe(no_mangle)]
+    pub extern "C" fn mahjong_ws_crate_version() -> u32 {
+        1
+    }
+
+    /// ページに設定された接続先URL (window.MAHJONG_SERVER_URL) を取得する
+    pub fn page_server_url() -> Option<String> {
+        let mut buf = vec![0u8; 1024];
+        let len = unsafe { mahjong_ws_default_url(buf.as_mut_ptr(), buf.len()) };
+        if len <= 0 {
+            return None;
+        }
+        buf.truncate(len as usize);
+        String::from_utf8(buf).ok()
+    }
+
+    /// WASM用トランスポート: ws.js の WebSocket をハンドル経由で操作する
+    pub struct WasmTransport {
+        handle: i32,
+        /// Opened を通知済みか
+        opened_reported: bool,
+        /// Closed/Error を通知済みか（以後 poll は空を返す）
+        terminated: bool,
+    }
+
+    impl WasmTransport {
+        pub fn connect(url: &str) -> Self {
+            let handle = unsafe { mahjong_ws_connect(url.as_ptr(), url.len()) };
+            WasmTransport {
+                handle,
+                opened_reported: false,
+                terminated: false,
+            }
         }
     }
 
-    impl Transport for StubTransport {
-        fn send_text(&mut self, _text: &str) {}
+    impl Transport for WasmTransport {
+        fn send_text(&mut self, text: &str) {
+            // 失敗（未接続・切断後）はステータス変化として poll で検出される
+            unsafe {
+                mahjong_ws_send(self.handle, text.as_ptr(), text.len());
+            }
+        }
 
         fn poll(&mut self) -> Vec<WsEvent> {
-            if self.reported {
-                Vec::new()
-            } else {
-                self.reported = true;
-                vec![WsEvent::Error(
-                    "このビルドではオンライン対戦は未対応です".to_string(),
-                )]
+            let mut events = Vec::new();
+            if self.terminated {
+                return events;
+            }
+
+            let status = unsafe { mahjong_ws_status(self.handle) };
+            if status == STATUS_OPEN && !self.opened_reported {
+                self.opened_reported = true;
+                events.push(WsEvent::Opened);
+            }
+
+            // 受信済みメッセージを取り出す（長さ取得 → コピーの2段階）
+            loop {
+                let len = unsafe { mahjong_ws_next_msg_len(self.handle) };
+                if len < 0 {
+                    break;
+                }
+                let mut buf = vec![0u8; len as usize];
+                unsafe {
+                    mahjong_ws_read_msg(self.handle, buf.as_mut_ptr());
+                }
+                match String::from_utf8(buf) {
+                    Ok(text) => events.push(WsEvent::Message(text)),
+                    Err(_) => events.push(WsEvent::Error(
+                        "サーバからのメッセージを解釈できません".to_string(),
+                    )),
+                }
+            }
+
+            // 終了状態は受信済みメッセージを流し切ってから通知する
+            match status {
+                STATUS_CLOSED => {
+                    self.terminated = true;
+                    events.push(WsEvent::Closed);
+                }
+                STATUS_ERROR => {
+                    self.terminated = true;
+                    events.push(WsEvent::Error("WebSocket接続エラー".to_string()));
+                }
+                _ => {}
+            }
+
+            events
+        }
+    }
+
+    impl Drop for WasmTransport {
+        fn drop(&mut self) {
+            unsafe {
+                mahjong_ws_close(self.handle);
             }
         }
     }

--- a/index.html
+++ b/index.html
@@ -18,7 +18,14 @@
 </head>
 <body>
     <canvas id="glcanvas" tabindex='1' width="1280" height="800"></canvas>
+    <script>
+        // オンライン対戦サーバのURL。
+        // 未設定なら ws://127.0.0.1:8080/ws（ローカル開発用）が使われる。
+        // 本番デプロイ時はビルドスクリプトがここを差し替える。
+        // window.MAHJONG_SERVER_URL = "wss://example.com/ws";
+    </script>
     <script src="mq_js_bundle.js"></script>
+    <script src="crates/mahjong-client/js/ws.js"></script>
     <script>
         if (typeof load === "function") {
             load("target/wasm32-unknown-unknown/release/mahjong-client.wasm");

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -17,6 +17,7 @@ mkdir -p public
 cargo build --release --target wasm32-unknown-unknown -p mahjong-client
 curl -L https://not-fl3.github.io/miniquad-samples/mq_js_bundle.js -o public/mq_js_bundle.js
 cp target/wasm32-unknown-unknown/release/mahjong-client.wasm public/mahjong-client.wasm
+cp crates/mahjong-client/js/ws.js public/ws.js
 cp index.html public/index.html
 
 # Rename assets with a content hash so browsers can cache them immutably
@@ -24,8 +25,18 @@ cp index.html public/index.html
 # stale version after a new deployment.
 wasm_hash=$(sha1sum public/mahjong-client.wasm | cut -c1-8)
 js_hash=$(sha1sum public/mq_js_bundle.js | cut -c1-8)
+ws_hash=$(sha1sum public/ws.js | cut -c1-8)
 mv public/mahjong-client.wasm "public/mahjong-client.${wasm_hash}.wasm"
 mv public/mq_js_bundle.js "public/mq_js_bundle.${js_hash}.js"
+mv public/ws.js "public/ws.${ws_hash}.js"
 
 sed -i "s|target/wasm32-unknown-unknown/release/mahjong-client.wasm|mahjong-client.${wasm_hash}.wasm|" public/index.html
 sed -i "s|mq_js_bundle.js|mq_js_bundle.${js_hash}.js|" public/index.html
+sed -i "s|crates/mahjong-client/js/ws.js|ws.${ws_hash}.js|" public/index.html
+
+# The online game server URL for the deployed client. Set the
+# MAHJONG_SERVER_URL environment variable in the Vercel project to
+# point the web client at the production server (e.g. wss://.../ws).
+if [ -n "${MAHJONG_SERVER_URL:-}" ]; then
+  sed -i "s|// window.MAHJONG_SERVER_URL = .*|window.MAHJONG_SERVER_URL = \"${MAHJONG_SERVER_URL}\";|" public/index.html
+fi


### PR DESCRIPTION
## Summary

Phase 4 of online multiplayer (#211, part of #207): the browser (WASM) client can now play online, with **no wasm-bindgen** — a hand-written miniquad plugin provides WebSocket access, following the same FFI approach as the existing `wasm_rng.rs`.

- **`crates/mahjong-client/js/ws.js`**: registered via `miniquad_add_plugin` before `load()`; injects `mahjong_ws_*` functions into `importObject.env`. Maintains a handle table of WebSockets with inbound message queues. Strings cross the boundary via `TextEncoder`/`TextDecoder` over the bundle-global `wasm_memory`, using a two-step length/copy read so JS never allocates wasm memory.
- **`transport.rs`**: the phase-3 stub is replaced by a real transport over the `extern "C"` symbols. Queued messages are drained before `Closed`/`Error` is reported. `mahjong_ws_crate_version` is exported so the bundle's plugin version check passes cleanly.
- **Server URL**: the page may set `window.MAHJONG_SERVER_URL`; otherwise `ws://127.0.0.1:8080/ws` (local dev). `vercel-build.sh` injects the production URL from a `MAHJONG_SERVER_URL` env var (to be configured in the Vercel project — phase 7, #214).
- **Build wiring**: `index.html` loads `ws.js` between the miniquad bundle and `load()`; `vercel-build.sh` copies + content-hashes `ws.js` like the other assets; `.gitignore` now covers locally generated hashed assets.

## Test plan

- [x] **Real-browser E2E**: built the WASM client, served it locally, ran `mahjong-net-server`, and drove the canvas in a browser — online menu opened, room created over a real browser WebSocket (server logs `room created code="65TGEL"` / `player joined seat=0` / `game started`), game started with 3 CPUs, and turns played end-to-end (discards visible from all seats, wall count advancing)
- [x] Local `scripts/vercel-build.sh` run produces `ws.<hash>.js` and `public/index.html` references the hashed name
- [x] `cargo test` workspace green; `cargo fmt` / `cargo clippy --all-targets` clean
- [x] Native client unaffected (transport native path untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
