### PR TITLE
Add action timeouts, rate limiting, and connection caps

### DIFF
--- a/crates/mahjong-client/src/adapter/mod.rs
+++ b/crates/mahjong-client/src/adapter/mod.rs
@@ -36,4 +36,9 @@ pub trait GameAdapter {
     fn status_text(&self) -> Option<String> {
         None
     }
+
+    /// 手番の制限時間の残り秒数（制限がなければ None）
+    fn turn_remaining_secs(&self) -> Option<u32> {
+        None
+    }
 }

--- a/crates/mahjong-client/src/adapter/remote.rs
+++ b/crates/mahjong-client/src/adapter/remote.rs
@@ -100,6 +100,8 @@ pub struct RemoteAdapter {
     reconnect_attempts: u32,
     /// 各座席の人間プレイヤーの接続状態（None = 人間以外/不明）
     peer_connected: [Option<bool>; 4],
+    /// 手番の制限時間の期限（秒, clock 基準）。None なら表示しない
+    turn_deadline: Option<f64>,
 }
 
 impl RemoteAdapter {
@@ -130,6 +132,7 @@ impl RemoteAdapter {
             reconnect_at: None,
             reconnect_attempts: 0,
             peer_connected: [None; 4],
+            turn_deadline: None,
         }
     }
 
@@ -367,6 +370,9 @@ impl RemoteAdapter {
                     }
                 }
             }
+            ServerMessage::TurnTimer { seconds } => {
+                self.turn_deadline = Some((self.clock)() + seconds as f64);
+            }
             ServerMessage::GameOver { .. } => {
                 self.game_over = true;
                 self.reconnecting = false;
@@ -392,6 +398,14 @@ impl RemoteAdapter {
         self.peer_connected.iter().any(|p| p == &Some(false))
     }
 
+    /// 手番の制限時間の残り秒数（手番待ちでなければ None）
+    pub fn turn_remaining_secs(&self) -> Option<u32> {
+        self.turn_deadline.map(|deadline| {
+            let remaining = (deadline - (self.clock)()).max(0.0);
+            remaining.ceil() as u32
+        })
+    }
+
     fn send(&mut self, msg: &ClientMessage) {
         match msg.to_json() {
             Ok(json) => self.transport.send_text(&json),
@@ -407,6 +421,8 @@ impl RemoteAdapter {
 
 impl GameAdapter for RemoteAdapter {
     fn send_action(&mut self, action: ClientAction) {
+        // 操作したので手番のカウントダウンを止める
+        self.turn_deadline = None;
         self.send(&ClientMessage::Action(action));
     }
 
@@ -446,6 +462,11 @@ impl GameAdapter for RemoteAdapter {
                 }
             }
         }
+    }
+
+    fn turn_remaining_secs(&self) -> Option<u32> {
+        // 固有メソッドへ委譲する（固有メソッドが優先解決されるため再帰しない）
+        RemoteAdapter::turn_remaining_secs(self)
     }
 }
 
@@ -752,7 +773,17 @@ mod tests {
     #[ignore = "要ローカルサーバ (cargo run -p mahjong-net-server)"]
     fn test_e2e_full_game_against_local_server() {
         let url = crate::transport::default_server_url();
-        let mut adapter = RemoteAdapter::create_room(&url, "E2Eテスト", 1);
+        // 本番の時計は macroquad（ウィンドウ前提）なので、ヘッドレスな
+        // E2E では std の経過秒で代用する
+        let (transport, connector) = RemoteAdapter::connector_for(&url);
+        let clock_start = std::time::Instant::now();
+        let mut adapter = RemoteAdapter::build(
+            transport,
+            connector,
+            Box::new(move || clock_start.elapsed().as_secs_f64()),
+            "E2Eテスト",
+            LobbyIntent::Create { round_count: 1 },
+        );
 
         let start = std::time::Instant::now();
         let mut started = false;
@@ -1028,6 +1059,52 @@ mod tests {
         });
         adapter.tick();
         assert!(adapter.status_text().is_none());
+    }
+
+    #[test]
+    fn test_turn_timer_counts_down_and_clears_on_action() {
+        let (transport, handle) = mock_pair();
+        let now = Rc::new(RefCell::new(100.0_f64));
+        let now_clock = now.clone();
+        let mut adapter = RemoteAdapter::build(
+            transport,
+            Box::new(|| panic!("再接続なし")),
+            Box::new(move || *now_clock.borrow()),
+            "テスト",
+            LobbyIntent::Create { round_count: 1 },
+        );
+
+        // 手番タイマー（90秒）を受信
+        handle.push_msg(&ServerMessage::TurnTimer { seconds: 90 });
+        adapter.tick();
+        assert_eq!(adapter.turn_remaining_secs(), Some(90));
+
+        // 30秒経過 → 残り60秒
+        *now.borrow_mut() = 130.0;
+        assert_eq!(adapter.turn_remaining_secs(), Some(60));
+
+        // 操作するとカウントダウンが消える
+        adapter.send_action(ClientAction::Discard { tile: None });
+        assert_eq!(adapter.turn_remaining_secs(), None);
+    }
+
+    #[test]
+    fn test_turn_timer_floors_at_zero() {
+        let (transport, handle) = mock_pair();
+        let now = Rc::new(RefCell::new(0.0_f64));
+        let now_clock = now.clone();
+        let mut adapter = RemoteAdapter::build(
+            transport,
+            Box::new(|| panic!("再接続なし")),
+            Box::new(move || *now_clock.borrow()),
+            "テスト",
+            LobbyIntent::Create { round_count: 1 },
+        );
+        handle.push_msg(&ServerMessage::TurnTimer { seconds: 5 });
+        adapter.tick();
+        // 期限を過ぎても負にならず 0
+        *now.borrow_mut() = 100.0;
+        assert_eq!(adapter.turn_remaining_secs(), Some(0));
     }
 
     #[test]

--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -167,6 +167,8 @@ pub struct OnlineUiState {
     pub status_is_error: bool,
     /// 入室中のルーム表示（メインループがアダプターからコピーする）
     pub room: Option<RoomViewUi>,
+    /// 手番の制限時間の残り秒数（オンラインで自分の手番のときのみ Some）
+    pub turn_remaining: Option<u32>,
 }
 
 impl OnlineUiState {
@@ -178,6 +180,7 @@ impl OnlineUiState {
             status_line: None,
             status_is_error: false,
             room: None,
+            turn_remaining: None,
         }
     }
 }

--- a/crates/mahjong-client/src/main.rs
+++ b/crates/mahjong-client/src/main.rs
@@ -145,6 +145,8 @@ async fn main() {
             // 対局中の接続バナー（ローカル対戦では常に None）
             game_state.online_state.status_line = adp.status_text();
             game_state.online_state.status_is_error = true;
+            // 手番の残り時間（オンラインのみ）
+            game_state.online_state.turn_remaining = adp.turn_remaining_secs();
         }
 
         match game_state.phase {

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -179,6 +179,7 @@ pub fn draw_game(
             draw_melds(state, tile_textures);
             let click = overlay::draw_action_buttons(state, font, tile_textures);
             online::draw_connection_banner(state, font);
+            online::draw_turn_timer(state, font);
             click
         }
         GamePhase::RoundResult => {

--- a/crates/mahjong-client/src/renderer/online.rs
+++ b/crates/mahjong-client/src/renderer/online.rs
@@ -361,3 +361,32 @@ pub fn draw_connection_banner(state: &GameState, font: Option<&Font>) {
         draw_jp_text(font, line, x + 16.0, 27.0, 20, WHITE);
     }
 }
+
+/// 自分の手番の制限時間カウントダウンを描画する
+///
+/// オンラインで自分が操作待ちのときだけ表示する。
+pub fn draw_turn_timer(state: &GameState, font: Option<&Font>) {
+    let Some(remaining) = state.online_state.turn_remaining else {
+        return;
+    };
+    // 自分が操作できる場面のみ表示する
+    let my_turn = state.is_my_turn || !state.available_calls.is_empty();
+    if !my_turn {
+        return;
+    }
+
+    // 残り10秒以下は赤、それ以外は黄
+    let color = if remaining <= 10 {
+        Color::new(1.0, 0.3, 0.3, 1.0)
+    } else {
+        Color::new(1.0, 0.9, 0.3, 1.0)
+    };
+    draw_jp_text(
+        font,
+        &format!("残り {remaining} 秒"),
+        870.0,
+        660.0,
+        28,
+        color,
+    );
+}

--- a/crates/mahjong-net-server/src/connection.rs
+++ b/crates/mahjong-net-server/src/connection.rs
@@ -4,9 +4,12 @@
 //! 入室後のメッセージ中継を行う。1接続につき読み取りタスク（本体）と
 //! 書き込みタスクの2つが動く。
 
-use std::time::Duration;
+use std::collections::VecDeque;
+use std::net::{IpAddr, SocketAddr};
+use std::time::{Duration, Instant};
 
 use axum::extract::State;
+use axum::extract::connect_info::ConnectInfo;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::response::Response;
 use futures_util::stream::{SplitSink, SplitStream};
@@ -31,17 +34,34 @@ const PING_INTERVAL: Duration = Duration::from_secs(30);
 /// 接続ごとの送信バッファ（メッセージ数）
 const OUT_BUFFER: usize = 256;
 
+/// WebSocket フレーム/メッセージの最大サイズ（バイト）
+const MAX_MESSAGE_SIZE: usize = 4 * 1024;
+
+/// 1秒あたりに許す受信メッセージ数
+const MAX_MSG_PER_SEC: usize = 20;
+
+/// 接続を切るまでに許す違反（不正メッセージ・レート超過）の累計
+const MAX_STRIKES: u32 = 10;
+
 /// セッショントークンを生成する（128ビットのランダム16進文字列）
 fn generate_token() -> String {
     format!("{:032x}", rand::rng().random::<u128>())
 }
 
 /// `/ws` ハンドラ
-pub async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> Response {
-    ws.on_upgrade(move |socket| handle_socket(socket, state))
+pub async fn ws_handler(
+    ws: WebSocketUpgrade,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    State(state): State<AppState>,
+) -> Response {
+    // フレーム/メッセージサイズを制限して巨大ペイロードを防ぐ
+    let ws = ws
+        .max_message_size(MAX_MESSAGE_SIZE)
+        .max_frame_size(MAX_MESSAGE_SIZE);
+    ws.on_upgrade(move |socket| handle_socket(socket, addr.ip(), state))
 }
 
-async fn handle_socket(socket: WebSocket, state: AppState) {
+async fn handle_socket(socket: WebSocket, peer_ip: IpAddr, state: AppState) {
     let (sender, receiver) = socket.split();
     let (out_tx, out_rx) = mpsc::channel::<ServerMessage>(OUT_BUFFER);
 
@@ -51,6 +71,9 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
         receiver,
         out_tx,
         state,
+        peer_ip,
+        recent_msgs: VecDeque::new(),
+        strikes: 0,
     };
     conn.run().await;
 
@@ -116,6 +139,12 @@ struct Connection {
     receiver: SplitStream<WebSocket>,
     out_tx: mpsc::Sender<ServerMessage>,
     state: AppState,
+    /// 接続元のIP（レート制限のキー）
+    peer_ip: IpAddr,
+    /// 直近1秒間の受信時刻（メッセージレート計測）
+    recent_msgs: VecDeque<Instant>,
+    /// 違反（不正メッセージ・レート超過）の累計
+    strikes: u32,
 }
 
 impl Connection {
@@ -160,6 +189,11 @@ impl Connection {
 
             let room_tx = match msg {
                 ClientMessage::CreateRoom { round_count } => {
+                    if !self.allow_room_entry() {
+                        self.send_error(ErrorCode::RateLimited, "too many room attempts")
+                            .await;
+                        continue;
+                    }
                     if !(1..=2).contains(&round_count) {
                         self.send_error(ErrorCode::BadMessage, "round_count must be 1 or 2")
                             .await;
@@ -173,6 +207,11 @@ impl Connection {
                     Some(room_tx)
                 }
                 ClientMessage::JoinRoom { code } => {
+                    if !self.allow_room_entry() {
+                        self.send_error(ErrorCode::RateLimited, "too many room attempts")
+                            .await;
+                        continue;
+                    }
                     let found = self.state.lobby.get(&code);
                     if found.is_none() {
                         self.send_error(ErrorCode::RoomNotFound, "no such room")
@@ -273,6 +312,7 @@ impl Connection {
     ///
     /// 不正な形式のフレームには `BadMessage` を返して読み続ける。
     /// `IDLE_TIMEOUT` の間なにも届かなければ切断と判断する。
+    /// 不正メッセージ・レート超過が累計 `MAX_STRIKES` に達したら切断する。
     async fn read(&mut self) -> Read {
         loop {
             let frame = match tokio::time::timeout(IDLE_TIMEOUT, self.receiver.next()).await {
@@ -282,22 +322,68 @@ impl Connection {
             };
 
             match frame {
-                Message::Text(text) => match ClientMessage::from_json(text.as_str()) {
-                    Ok(msg) => return Read::Msg(msg),
-                    Err(_) => {
-                        self.send_error(ErrorCode::BadMessage, "invalid message")
+                Message::Text(text) => {
+                    // メッセージレートを超過したら違反として扱う
+                    if self.over_message_rate() {
+                        self.send_error(ErrorCode::RateLimited, "too many messages")
                             .await;
+                        if self.strike() {
+                            return Read::Closed;
+                        }
+                        continue;
                     }
-                },
+                    match ClientMessage::from_json(text.as_str()) {
+                        Ok(msg) => return Read::Msg(msg),
+                        Err(_) => {
+                            self.send_error(ErrorCode::BadMessage, "invalid message")
+                                .await;
+                            if self.strike() {
+                                return Read::Closed;
+                            }
+                        }
+                    }
+                }
                 Message::Binary(_) => {
                     self.send_error(ErrorCode::BadMessage, "binary frames not supported")
                         .await;
+                    if self.strike() {
+                        return Read::Closed;
+                    }
                 }
                 // Ping への Pong 応答は下層が自動で行う
                 Message::Ping(_) | Message::Pong(_) => {}
                 Message::Close(_) => return Read::Closed,
             }
         }
+    }
+
+    /// 受信メッセージが直近1秒の上限を超えているか判定する
+    ///
+    /// 呼び出しごとに現在時刻を記録し、1秒より古い記録を捨てる。
+    fn over_message_rate(&mut self) -> bool {
+        let now = Instant::now();
+        let cutoff = now.checked_sub(Duration::from_secs(1));
+        while let Some(&front) = self.recent_msgs.front() {
+            match cutoff {
+                Some(cutoff) if front < cutoff => {
+                    self.recent_msgs.pop_front();
+                }
+                _ => break,
+            }
+        }
+        self.recent_msgs.push_back(now);
+        self.recent_msgs.len() > MAX_MSG_PER_SEC
+    }
+
+    /// 違反を1つ加算し、累計が上限に達したら true（切断すべき）を返す
+    fn strike(&mut self) -> bool {
+        self.strikes += 1;
+        self.strikes >= MAX_STRIKES
+    }
+
+    /// IPごとの入室レート制限を確認する（超過なら false）
+    fn allow_room_entry(&self) -> bool {
+        self.state.rate_limiter.check(self.peer_ip)
     }
 
     async fn send(&self, msg: ServerMessage) {

--- a/crates/mahjong-net-server/src/lib.rs
+++ b/crates/mahjong-net-server/src/lib.rs
@@ -11,12 +11,14 @@
 
 pub mod connection;
 pub mod lobby;
+pub mod ratelimit;
 pub mod room;
 
 use axum::Router;
 use axum::routing::get;
 
 use lobby::Lobby;
+use ratelimit::RateLimiter;
 use room::RoomConfig;
 
 /// アプリケーション全体の共有状態
@@ -24,6 +26,8 @@ use room::RoomConfig;
 pub struct AppState {
     /// ルームレジストリ
     pub lobby: Lobby,
+    /// IPごとの入室レート制限
+    pub rate_limiter: RateLimiter,
 }
 
 /// ルーターを構築する
@@ -32,6 +36,7 @@ pub struct AppState {
 pub fn app(config: RoomConfig) -> Router {
     let state = AppState {
         lobby: Lobby::new(config),
+        rate_limiter: RateLimiter::new(),
     };
     Router::new()
         .route("/healthz", get(|| async { "ok" }))

--- a/crates/mahjong-net-server/src/main.rs
+++ b/crates/mahjong-net-server/src/main.rs
@@ -28,7 +28,11 @@ async fn main() {
         .unwrap_or_else(|e| panic!("failed to bind {addr}: {e}"));
     tracing::info!("listening on {addr}");
 
-    axum::serve(listener, app(RoomConfig::default()))
-        .await
-        .expect("server error");
+    // ConnectInfo<SocketAddr> を有効にして接続元IPを取得できるようにする
+    axum::serve(
+        listener,
+        app(RoomConfig::default()).into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await
+    .expect("server error");
 }

--- a/crates/mahjong-net-server/src/ratelimit.rs
+++ b/crates/mahjong-net-server/src/ratelimit.rs
@@ -1,0 +1,108 @@
+//! レート制限
+//!
+//! IPアドレスごとの入室試行回数を一定時間窓で制限し、
+//! ルームコードの総当たりや乱立を抑える。
+
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::net::IpAddr;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// 1つのIPが時間窓内に許される入室試行回数
+const MAX_ATTEMPTS: usize = 10;
+
+/// 時間窓の長さ
+const WINDOW: Duration = Duration::from_secs(60);
+
+/// IPごとの入室試行レート制限
+#[derive(Clone, Default)]
+pub struct RateLimiter {
+    attempts: Arc<Mutex<HashMap<IpAddr, VecDeque<Instant>>>>,
+}
+
+impl RateLimiter {
+    /// 新しいレート制限を作成する
+    pub fn new() -> Self {
+        RateLimiter::default()
+    }
+
+    /// 入室試行を1回記録し、許可されるかを返す
+    ///
+    /// 直近の時間窓内の試行が上限未満なら記録して `true` を返す。
+    /// 上限に達していれば記録せず `false` を返す。
+    pub fn check(&self, ip: IpAddr) -> bool {
+        self.check_at(ip, Instant::now())
+    }
+
+    /// 時刻を指定して試行を判定する（テスト用）
+    fn check_at(&self, ip: IpAddr, now: Instant) -> bool {
+        let mut map = self.attempts.lock().unwrap();
+        let entry = map.entry(ip).or_default();
+
+        // 時間窓より古い記録を捨てる
+        let cutoff = now.checked_sub(WINDOW);
+        while let Some(&front) = entry.front() {
+            match cutoff {
+                Some(cutoff) if front < cutoff => {
+                    entry.pop_front();
+                }
+                _ => break,
+            }
+        }
+
+        if entry.len() >= MAX_ATTEMPTS {
+            return false;
+        }
+        entry.push_back(now);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ip() -> IpAddr {
+        "127.0.0.1".parse().unwrap()
+    }
+
+    #[test]
+    fn test_allows_up_to_limit_then_blocks() {
+        let limiter = RateLimiter::new();
+        let now = Instant::now();
+        for i in 0..MAX_ATTEMPTS {
+            assert!(limiter.check_at(ip(), now), "{i}回目は許可されるべき");
+        }
+        // 上限超過は拒否
+        assert!(!limiter.check_at(ip(), now), "上限超過は拒否されるべき");
+    }
+
+    #[test]
+    fn test_window_expiry_resets() {
+        let limiter = RateLimiter::new();
+        let start = Instant::now();
+        for _ in 0..MAX_ATTEMPTS {
+            assert!(limiter.check_at(ip(), start));
+        }
+        assert!(!limiter.check_at(ip(), start));
+
+        // 時間窓を超えて経過すると再び許可される
+        let later = start + WINDOW + Duration::from_secs(1);
+        assert!(limiter.check_at(ip(), later));
+    }
+
+    #[test]
+    fn test_separate_ips_are_independent() {
+        let limiter = RateLimiter::new();
+        let now = Instant::now();
+        let a: IpAddr = "10.0.0.1".parse().unwrap();
+        let b: IpAddr = "10.0.0.2".parse().unwrap();
+        for _ in 0..MAX_ATTEMPTS {
+            assert!(limiter.check_at(a, now));
+        }
+        assert!(!limiter.check_at(a, now));
+        // 別IPは影響を受けない
+        assert!(limiter.check_at(b, now));
+    }
+}

--- a/crates/mahjong-net-server/src/room.rs
+++ b/crates/mahjong-net-server/src/room.rs
@@ -27,6 +27,9 @@ pub struct RoomConfig {
     pub lobby_timeout: Duration,
     /// 対局中に全員切断してからルームを破棄するまでの猶予
     pub abandoned_timeout: Duration,
+    /// 1手番ごとの制限時間（None なら無制限）。
+    /// 超過するとサーバが既定アクション（ツモ切り/パス）を代行する。
+    pub action_timeout: Option<Duration>,
 }
 
 impl Default for RoomConfig {
@@ -35,6 +38,7 @@ impl Default for RoomConfig {
             ready_timeout: Duration::from_secs(60),
             lobby_timeout: Duration::from_secs(30 * 60),
             abandoned_timeout: Duration::from_secs(5 * 60),
+            action_timeout: Some(Duration::from_secs(90)),
         }
     }
 }
@@ -114,6 +118,8 @@ struct Room {
     ready_deadline: Option<Instant>,
     /// ルーム破棄の期限
     close_deadline: Option<Instant>,
+    /// 手番の制限時間の期限
+    action_deadline: Option<Instant>,
     /// ルームを閉じるフラグ
     closing: bool,
     /// 次に割り当てる接続の世代番号
@@ -139,6 +145,7 @@ pub async fn run_room(
         game_over_sent: false,
         ready_deadline: None,
         close_deadline: Some(Instant::now() + config.lobby_timeout),
+        action_deadline: None,
         closing: false,
         next_conn_gen: 0,
     };
@@ -146,6 +153,7 @@ pub async fn run_room(
     loop {
         let ready_at = deadline_or_far(room.ready_deadline);
         let close_at = deadline_or_far(room.close_deadline);
+        let action_at = deadline_or_far(room.action_deadline);
 
         tokio::select! {
             msg = rx.recv() => match msg {
@@ -155,6 +163,10 @@ pub async fn run_room(
             _ = tokio::time::sleep_until(ready_at), if room.ready_deadline.is_some() => {
                 tracing::debug!(code = room.code, "ready timeout; auto-advancing round");
                 room.advance_round().await;
+            }
+            _ = tokio::time::sleep_until(action_at), if room.action_deadline.is_some() => {
+                tracing::debug!(code = room.code, "action timeout; forcing default action");
+                room.on_action_timeout().await;
             }
             _ = tokio::time::sleep_until(close_at), if room.close_deadline.is_some() => {
                 tracing::info!(code = room.code, "room expired");
@@ -300,6 +312,8 @@ impl Room {
         if let Some(tx) = self.seats[seat].as_ref().and_then(|s| s.tx.clone()) {
             let _ = tx.send(ServerMessage::Resync { events: history }).await;
         }
+        // 再接続で操作待ちの主体が変わった可能性があるため期限を張り直す
+        self.refresh_action_deadline().await;
     }
 
     async fn handle_client_message(&mut self, seat: usize, msg: ClientMessage) {
@@ -386,6 +400,69 @@ impl Room {
         }
         self.flush_events().await;
         self.check_round_end();
+        self.refresh_action_deadline().await;
+    }
+
+    /// 指定した座席が接続中の人間か
+    fn is_connected_human(&self, seat: usize) -> bool {
+        self.seats[seat].as_ref().is_some_and(|s| s.tx.is_some())
+    }
+
+    /// 手番の制限時間を再設定する
+    ///
+    /// 接続中の人間の操作待ちなら期限を張り直し、対象座席へ残り秒数を通知する。
+    /// それ以外（CPU進行中・確認待ち・局終了）は期限を解除する。
+    async fn refresh_action_deadline(&mut self) {
+        let Some(timeout) = self.config.action_timeout else {
+            self.action_deadline = None;
+            return;
+        };
+        if self.awaiting_ready || self.game_over_sent {
+            self.action_deadline = None;
+            return;
+        }
+
+        let seats: Vec<usize> = self
+            .driver
+            .as_ref()
+            .map(|d| d.pending_action_seats())
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|&s| self.is_connected_human(s))
+            .collect();
+
+        if seats.is_empty() {
+            self.action_deadline = None;
+            return;
+        }
+
+        self.action_deadline = Some(Instant::now() + timeout);
+        // 端数は切り上げる（短い制限でも 0 秒表示にならないように）
+        let seconds = timeout.as_secs_f64().ceil() as u32;
+        for seat in seats {
+            if let Some(tx) = self.seats[seat].as_ref().and_then(|s| s.tx.clone()) {
+                let _ = tx.send(ServerMessage::TurnTimer { seconds }).await;
+            }
+        }
+    }
+
+    /// 手番の制限時間切れ: 待っている接続中の人間に既定アクションを代行する
+    async fn on_action_timeout(&mut self) {
+        let seats: Vec<usize> = self
+            .driver
+            .as_ref()
+            .map(|d| d.pending_action_seats())
+            .unwrap_or_default();
+        for seat in seats {
+            if self.is_connected_human(seat)
+                && let Some(driver) = self.driver.as_mut()
+            {
+                tracing::info!(code = self.code, seat, "action timed out; auto-acting");
+                driver.force_default_action(seat);
+            }
+        }
+        self.action_deadline = None;
+        self.progress_game().await;
     }
 
     /// 各座席のイベントを履歴へ記録し、接続中の座席へ送信する
@@ -471,6 +548,7 @@ impl Room {
             self.broadcast(ServerMessage::GameOver { final_scores })
                 .await;
             self.game_over_sent = true;
+            self.action_deadline = None;
             // 全員が切断したら閉じる。念のため期限も設定する
             self.close_deadline = Some(Instant::now() + self.config.abandoned_timeout);
             tracing::info!(code = self.code, "game over");

--- a/crates/mahjong-net-server/tests/integration.rs
+++ b/crates/mahjong-net-server/tests/integration.rs
@@ -21,6 +21,8 @@ fn fast_config() -> RoomConfig {
         ready_timeout: Duration::from_millis(200),
         lobby_timeout: Duration::from_secs(30),
         abandoned_timeout: Duration::from_secs(5),
+        // 既存テストの自動進行を阻害しないよう長めにする
+        action_timeout: Some(Duration::from_secs(30)),
     }
 }
 
@@ -29,7 +31,12 @@ async fn start_server(config: RoomConfig) -> SocketAddr {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
-        axum::serve(listener, app(config)).await.unwrap();
+        axum::serve(
+            listener,
+            app(config).into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .unwrap();
     });
     addr
 }
@@ -479,6 +486,69 @@ async fn test_disconnect_mid_game_cpu_takes_over() {
     })
     .await
     .expect("テスト全体がタイムアウトした");
+}
+
+/// 操作しない（AFK）プレイヤーがいてもタイムアウトで対局が完走することを確認する
+#[tokio::test]
+async fn test_action_timeout_auto_acts() {
+    tokio::time::timeout(Duration::from_secs(120), async {
+        let config = RoomConfig {
+            action_timeout: Some(Duration::from_millis(100)),
+            ..fast_config()
+        };
+        let addr = start_server(config).await;
+
+        let mut host = TestClient::connect(addr).await;
+        host.hello("AFKホスト").await;
+        host.create_room().await;
+        host.send(&ClientMessage::StartGame).await;
+
+        // ホストは一切操作せず受信し続ける。
+        // サーバが既定アクション（ツモ切り/パス）を代行して対局が進む。
+        // 制限時間は 100ms なので表示秒数は 0 に丸められる（サーバは実時間で強制）
+        let mut saw_turn_timer = false;
+        loop {
+            match host.recv().await {
+                ServerMessage::TurnTimer { .. } => {
+                    saw_turn_timer = true;
+                }
+                ServerMessage::GameOver { final_scores } => {
+                    assert_scores_consistent(final_scores);
+                    break;
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_turn_timer, "TurnTimer が一度も届かなかった");
+    })
+    .await
+    .expect("テスト全体がタイムアウトした");
+}
+
+/// 同一IPからの入室試行が多すぎると RateLimited で拒否されることを確認する
+#[tokio::test]
+async fn test_join_rate_limit() {
+    let addr = start_server(fast_config()).await;
+    let mut client = TestClient::connect(addr).await;
+    client.hello("スパマー").await;
+
+    // 上限（10回）までは存在しないルームとして RoomNotFound
+    for _ in 0..10 {
+        client
+            .send(&ClientMessage::JoinRoom {
+                code: "ZZZZZZ".to_string(),
+            })
+            .await;
+        assert_eq!(client.recv_error().await, ErrorCode::RoomNotFound);
+    }
+
+    // 11回目はレート制限で拒否される
+    client
+        .send(&ClientMessage::JoinRoom {
+            code: "ZZZZZZ".to_string(),
+        })
+        .await;
+    assert_eq!(client.recv_error().await, ErrorCode::RateLimited);
 }
 
 /// 切断したプレイヤーがトークンで再入室し、Resync で状態を再同期できることを確認する

--- a/crates/mahjong-server/src/driver.rs
+++ b/crates/mahjong-server/src/driver.rs
@@ -298,6 +298,30 @@ impl GameDriver {
         }
     }
 
+    /// 現在アクションが待たれている座席の一覧を返す
+    ///
+    /// 打牌/九種九牌の選択中は手番のプレイヤー、鳴き待ち中は未応答の
+    /// プレイヤーを返す。それ以外（ツモ前・局終了）は空。行動タイムアウトの
+    /// 対象座席を求めるのに使う。
+    pub fn pending_action_seats(&self) -> Vec<usize> {
+        let Some(round) = self.table.current_round() else {
+            return Vec::new();
+        };
+        if round.is_over() {
+            return Vec::new();
+        }
+        match round.phase {
+            TurnPhase::WaitForDiscard | TurnPhase::WaitForNineTerminals => {
+                vec![round.current_player]
+            }
+            TurnPhase::WaitForCalls => match &round.call_state {
+                Some(cs) => (0..4).filter(|&i| !cs.responded[i]).collect(),
+                None => Vec::new(),
+            },
+            TurnPhase::Draw | TurnPhase::RoundOver => Vec::new(),
+        }
+    }
+
     /// 次の局を開始する
     pub fn next_round(&mut self) {
         self.next_round_impl(None);

--- a/crates/mahjong-server/src/protocol/net.rs
+++ b/crates/mahjong-server/src/protocol/net.rs
@@ -97,6 +97,15 @@ pub enum ServerMessage {
         connected: bool,
     },
 
+    /// 手番の制限時間の通知（自分の操作が待たれている座席に送る）
+    ///
+    /// 制限時間内に操作しないとサーバが既定アクション（ツモ切り/パス）を
+    /// 代行する。クライアントはこの秒数からカウントダウンを表示する。
+    TurnTimer {
+        /// 制限時間（秒）
+        seconds: u32,
+    },
+
     /// エラー通知
     Error {
         /// エラーコード
@@ -271,6 +280,7 @@ mod tests {
                 seat: 2,
                 connected: false,
             },
+            ServerMessage::TurnTimer { seconds: 90 },
             ServerMessage::Error {
                 code: ErrorCode::RoomNotFound,
                 message: "no such room".to_string(),


### PR DESCRIPTION
## Summary

Phase 6 of online multiplayer (#213, part of #207): hardening — action timeouts, abuse limits, and a turn countdown.

### Action timeout (prevents AFK stalls)
- `RoomConfig.action_timeout` (default **90s**). When the game is blocked on a connected human, the room arms a deadline; on expiry it forces the seat's default action (tsumogiri / pass / decline) via the shadow CPU and progresses. `GameDriver::pending_action_seats()` tells the room which seats are awaited (current player for discard/nine-terminals, unresponded seats for calls).
- New `ServerMessage::TurnTimer{seconds}` is sent to the awaited human seat(s); the client shows a "残り N 秒" countdown during its own actionable turn (red under 10s), cleared when it acts.

### Abuse protection
- **Per-IP room-entry rate limit** (10 attempts / 60s sliding window) in a new `ratelimit` module; `CreateRoom`/`JoinRoom` over the limit get `Error{RateLimited}`. Requires `ConnectInfo<SocketAddr>`, so the server is now served with `into_make_service_with_connect_info`.
- WebSocket **max frame/message size capped at 4 KB**.
- **Per-connection message-rate cap** (20/s) and a strike counter: malformed frames, binary frames, and rate violations accrue strikes; 10 strikes closes the connection.

### Client
- `RemoteAdapter` gains an injected **clock** (production: macroquad `get_time`; tests/E2E: std elapsed) used for both reconnect backoff and the turn countdown.
- `error_code_message` already covers **every `ErrorCode`** incl. `RateLimited`; leave-room semantics (host leaving pre-game closes the room) shipped in Phase 2.

## Test plan

- [x] `ratelimit` unit tests: allows up to limit then blocks; window expiry resets; per-IP isolation
- [x] `RemoteAdapter` unit tests: turn-timer counts down, clears on action, floors at zero
- [x] Integration: an AFK host completes a full game purely via action timeouts (and sees `TurnTimer`); the 11th room-entry attempt from one IP is `RateLimited`. Suite run **10× clean**
- [x] **E2E** against a live server still passes (with a std-time clock injected for the headless adapter)
- [x] `cargo test` workspace green (client 21 / core 257 / ratelimit 5 / integration 15 / server 356); `cargo fmt` / `cargo clippy --all-targets` clean; `wasm32-unknown-unknown` release build passes

### Manual E2E checklist (GUI)

- [ ] 2 native clients + local server; one player goes idle on their turn → "残り N 秒" counts down, then the server auto-tsumogiris and play continues
- [ ] Countdown turns red in the last 10 seconds and disappears when you act

🤖 Generated with [Claude Code](https://claude.com/claude-code)
