### PR TITLE
Add hosting: Dockerfile, fly.toml, Origin check, and deploy docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# ビルド成果物・VCS・サーバビルドに不要なものを除外してコンテキストを小さくする
+/target
+/public
+.git
+.github
+# サーバ（mahjong-net-server）のビルドには不要（クライアントはビルドしない）
+/assets
+*.md
+index.html
+mq_js_bundle.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# mahjong-net-server（オンライン対戦サーバ）のコンテナイメージ
+#
+# クライアント（macroquad）はビルドしない。`-p mahjong-net-server` で
+# 対象を絞るため、依存グラフ上の mahjong-server / mahjong-core のみ
+# コンパイルされる。
+
+# --- ビルドステージ ---
+FROM rust:1-slim-bookworm AS builder
+WORKDIR /app
+# ワークスペース全体をコピーしてサーバだけをリリースビルドする
+COPY . .
+RUN cargo build --release -p mahjong-net-server
+
+# --- 実行ステージ ---
+FROM debian:bookworm-slim
+WORKDIR /app
+COPY --from=builder /app/target/release/mahjong-net-server /usr/local/bin/mahjong-net-server
+
+# PORT で待ち受ける（ホスティング側が割り当てる）。TLS は前段のプロキシが終端する。
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["mahjong-net-server"]

--- a/README.ja.md
+++ b/README.ja.md
@@ -14,8 +14,10 @@
 - ネイティブ版と WASM 版の両方で動かせるプレイ可能なクライアントを同梱
   - 現在のクライアントは仮の簡易版
   - CPU 対戦を実装済み（現在の実装は仮実装）
-  - 将来的なネットワーク対戦の実装も考慮した設計
-- 同梱スクリプトを使った Vercel デプロイに対応
+- `mahjong-net-server` によるオンライン対戦（ルームコード制）に対応
+  - ホストがルームを作成し 6 文字のコードを共有、友人が参加。空席は CPU が埋める
+  - 切断したプレイヤーは CPU が代打ちし、再入室で状態を再同期できる
+- 同梱スクリプトを使った Vercel デプロイに対応（静的 Web クライアント）
 
 ## 構成
 
@@ -26,6 +28,7 @@
 - `mahjong-core`: 手牌表現やシャンテン数計算、役判定、符計算、点数計算などのコアロジック
 - `mahjong-server`: ローカル対局で使う進行管理やルール処理
 - `mahjong-client`: ネイティブ実行とブラウザ実行の両方に対応した、Macroquad ベースの 4 人打ち麻雀クライアント
+- `mahjong-net-server`: オンラインのルームコード対戦をホストする単一バイナリの WebSocket サーバ（tokio + axum）
 
 ### ディレクトリ構成
 
@@ -117,3 +120,60 @@ Vercel のビルドでは次の処理を行います。
 - デプロイ用の Web アセットを `public/` 配下に配置
 
 同じ流れをローカルで再現する場合は、Bash、curl、Rust、および WASM ターゲットが利用できる環境で同等の手順を実行してください。
+
+デプロイした Web クライアントをオンラインサーバへ接続させるには、Vercel プロジェクトの環境変数 `MAHJONG_SERVER_URL` を設定します（例: `wss://your-app.fly.dev/ws`）。ビルド時に `window.MAHJONG_SERVER_URL` へ注入されます。未設定の場合は `ws://127.0.0.1:8080/ws`（ローカル開発用）にフォールバックします。
+
+## オンライン対戦サーバ
+
+`mahjong-net-server` はルームコード制のオンライン対戦をホストします。静的 Web クライアントとゲームサーバは別々にデプロイします（Vercel は静的配信のみのため、WebSocket サーバは別ホストが必要）。
+
+### ローカルで動かす
+
+~~~sh
+cargo run -p mahjong-net-server
+~~~
+
+環境変数:
+
+- `PORT`: リッスンポート（デフォルト `8080`）
+- `RUST_LOG`: ログフィルタ（例: `mahjong_net_server=debug`）
+- `ALLOWED_ORIGIN`: 設定すると、`Origin` ヘッダが一致する WebSocket 接続のみ許可（例: `https://your-app.vercel.app`）。未設定なら全許可
+
+`GET /healthz` は `ok` を返します（ヘルスチェック用）。WebSocket は `GET /ws`。
+
+ローカルサーバと対戦するには、`MAHJONG_SERVER_URL` を指定してネイティブクライアントを起動します。
+
+~~~sh
+MAHJONG_SERVER_URL=ws://127.0.0.1:8080/ws cargo run -p mahjong-client
+~~~
+
+### Fly.io へのデプロイ
+
+リポジトリに `Dockerfile` と `fly.toml` を同梱しています。TLS（`wss://`）は Fly のプロキシが終端するため、サーバ自体は `PORT` で平文 WebSocket を待ち受けます。
+
+~~~sh
+# 初回: アプリを作成（fly.toml の app 名を変更するか fly launch に任せる）
+fly launch --no-deploy
+
+# （任意）接続を許可する Origin を Web クライアントに制限
+fly secrets set ALLOWED_ORIGIN=https://your-app.vercel.app
+
+# デプロイ
+fly deploy
+~~~
+
+デプロイ後、Vercel の `MAHJONG_SERVER_URL` を `wss://<your-app>.fly.dev/ws` に設定して Web クライアントを再デプロイします。
+
+Docker が動く環境ならコンテナとしてどこでも実行できます。
+
+~~~sh
+docker build -t mahjong-net-server .
+docker run -e PORT=8080 -p 8080:8080 mahjong-net-server
+~~~
+
+### 運用メモ
+
+- **ルームはメモリ上のみ**。再デプロイやマシン再起動で進行中のルームは消えます（参加者は新しいルームを作り直して再開）。在席プレイ向けの割り切りで、永続化層はありません。
+- `fly.toml` の `min_machines_running = 0` では無接続時にマシンが停止し、次の接続でコールドスタートします。常時起動したい場合は `1` にします。
+- `GET /healthz` を監視します（Fly は 15 秒ごとにチェックする設定）。
+- サーバは IP 単位の入室レート制限と接続ごとのメッセージ/フレームサイズ上限を適用します。カジュアル用途では追加の WAF は不要です。

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Implementation for Japanese Riichi Mahjong in Rust.
 - A playable client that runs in both native and WASM builds is included.
   - The current client is a temporary simplified version.
   - A CPU opponent is implemented. The current CPU is a provisional implementation.
-  - The design also takes future networked multiplayer implementation into consideration.
-- Vercel deployment using the included scripts is supported.
+- Online multiplayer (room-code based) is supported via `mahjong-net-server`.
+  - Host creates a room, shares a 6-character code, and friends join; empty seats are filled by the CPU.
+  - Disconnected players are taken over by the CPU and can rejoin to resync.
+- Vercel deployment using the included scripts is supported (static web client).
 
 ## Structure
 
@@ -26,6 +28,7 @@ This repository is currently composed of the following crates.
 - `mahjong-core`: core logic such as hand representation, shanten calculation, yaku evaluation, fu calculation, and score calculation
 - `mahjong-server`: progression management and rule handling used for local matches
 - `mahjong-client`: a Macroquad-based four-player Riichi Mahjong client that supports both native and browser execution
+- `mahjong-net-server`: a single-binary WebSocket server (tokio + axum) that hosts online room-code matches
 
 ### Directory structure
 
@@ -117,3 +120,60 @@ The Vercel build performs the following steps.
 - places deployable web assets under `public/`
 
 To reproduce the same flow locally, run equivalent steps in an environment where Bash, curl, Rust, and the WASM target are available.
+
+To point the deployed web client at your online server, set the `MAHJONG_SERVER_URL` environment variable in the Vercel project (for example `wss://your-app.fly.dev/ws`). The build injects it into `window.MAHJONG_SERVER_URL`. If it is unset, the client falls back to `ws://127.0.0.1:8080/ws` (local development only).
+
+## Online multiplayer server
+
+`mahjong-net-server` hosts room-code online matches. The static web client (above) and the game server are deployed separately: Vercel only serves static files, so the WebSocket server needs its own host.
+
+### Run locally
+
+~~~sh
+cargo run -p mahjong-net-server
+~~~
+
+Environment variables:
+
+- `PORT`: listen port (default `8080`).
+- `RUST_LOG`: log filter (for example `mahjong_net_server=debug`).
+- `ALLOWED_ORIGIN`: if set, only WebSocket connections with a matching `Origin` header are accepted (for example `https://your-app.vercel.app`). If unset, all origins are allowed.
+
+`GET /healthz` returns `ok` for health checks. The WebSocket endpoint is `GET /ws`.
+
+To play against a local server, run a native client with `MAHJONG_SERVER_URL` pointed at it:
+
+~~~sh
+MAHJONG_SERVER_URL=ws://127.0.0.1:8080/ws cargo run -p mahjong-client
+~~~
+
+### Deploy to Fly.io
+
+The repository includes a `Dockerfile` and `fly.toml`. TLS (`wss://`) is terminated by Fly's proxy, so the server itself speaks plain WebSocket on `PORT`.
+
+~~~sh
+# one-time: create the app (edit the app name in fly.toml or let fly launch set it)
+fly launch --no-deploy
+
+# (optional) restrict accepted origins to your web client
+fly secrets set ALLOWED_ORIGIN=https://your-app.vercel.app
+
+# deploy
+fly deploy
+~~~
+
+After deploying, set `MAHJONG_SERVER_URL` in Vercel to `wss://<your-app>.fly.dev/ws` and redeploy the web client.
+
+A container image can also be built and run anywhere Docker runs:
+
+~~~sh
+docker build -t mahjong-net-server .
+docker run -e PORT=8080 -p 8080:8080 mahjong-net-server
+~~~
+
+### Operational notes
+
+- **Rooms are in-memory.** A redeploy or machine restart drops all active rooms; players reconnect by creating/joining a new room. This is acceptable for friends-play; there is no persistence layer.
+- With `min_machines_running = 0` in `fly.toml`, the machine stops when idle and cold-starts on the next connection. Set it to `1` for an always-on server.
+- Monitor `GET /healthz` (Fly is configured to check it every 15s).
+- The server applies a per-IP room-entry rate limit and per-connection message/frame-size caps; no additional WAF is required for casual use.

--- a/crates/mahjong-net-server/src/connection.rs
+++ b/crates/mahjong-net-server/src/connection.rs
@@ -11,7 +11,8 @@ use std::time::{Duration, Instant};
 use axum::extract::State;
 use axum::extract::connect_info::ConnectInfo;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
-use axum::response::Response;
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::{IntoResponse, Response};
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use mahjong_server::protocol::net::{ClientMessage, ErrorCode, PROTOCOL_VERSION, ServerMessage};
@@ -53,12 +54,30 @@ pub async fn ws_handler(
     ws: WebSocketUpgrade,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Response {
+    // Origin 制限（ALLOWED_ORIGIN 設定時のみ）
+    let origin = headers.get(header::ORIGIN).and_then(|v| v.to_str().ok());
+    if !origin_allowed(state.allowed_origin.as_deref(), origin) {
+        tracing::warn!(?origin, "rejected connection from disallowed origin");
+        return StatusCode::FORBIDDEN.into_response();
+    }
+
     // フレーム/メッセージサイズを制限して巨大ペイロードを防ぐ
     let ws = ws
         .max_message_size(MAX_MESSAGE_SIZE)
         .max_frame_size(MAX_MESSAGE_SIZE);
     ws.on_upgrade(move |socket| handle_socket(socket, addr.ip(), state))
+}
+
+/// 接続元 Origin が許可されるか判定する
+///
+/// `allowed` が None なら全許可。Some なら Origin ヘッダが一致した場合のみ許可。
+fn origin_allowed(allowed: Option<&str>, origin: Option<&str>) -> bool {
+    match allowed {
+        None => true,
+        Some(allowed) => origin == Some(allowed),
+    }
 }
 
 async fn handle_socket(socket: WebSocket, peer_ip: IpAddr, state: AppState) {
@@ -396,5 +415,25 @@ impl Connection {
             message: message.to_string(),
         })
         .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::origin_allowed;
+
+    #[test]
+    fn test_origin_allowed_when_unset_allows_all() {
+        assert!(origin_allowed(None, Some("https://example.com")));
+        assert!(origin_allowed(None, None));
+    }
+
+    #[test]
+    fn test_origin_allowed_requires_exact_match() {
+        let allowed = Some("https://mahjong.example.com");
+        assert!(origin_allowed(allowed, Some("https://mahjong.example.com")));
+        // 不一致・欠落は拒否
+        assert!(!origin_allowed(allowed, Some("https://evil.example.com")));
+        assert!(!origin_allowed(allowed, None));
     }
 }

--- a/crates/mahjong-net-server/src/lib.rs
+++ b/crates/mahjong-net-server/src/lib.rs
@@ -28,15 +28,23 @@ pub struct AppState {
     pub lobby: Lobby,
     /// IPごとの入室レート制限
     pub rate_limiter: RateLimiter,
+    /// 接続を許可する Origin（None なら全許可）
+    pub allowed_origin: Option<String>,
 }
 
 /// ルーターを構築する
 ///
 /// `/ws` が WebSocket エンドポイント、`/healthz` がヘルスチェック。
+/// `ALLOWED_ORIGIN` 環境変数が設定されていれば、その Origin からの
+/// WebSocket 接続のみを許可する（未設定なら全許可）。
 pub fn app(config: RoomConfig) -> Router {
+    let allowed_origin = std::env::var("ALLOWED_ORIGIN")
+        .ok()
+        .filter(|s| !s.is_empty());
     let state = AppState {
         lobby: Lobby::new(config),
         rate_limiter: RateLimiter::new(),
+        allowed_origin,
     };
     Router::new()
         .route("/healthz", get(|| async { "ok" }))

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,30 @@
+# Fly.io デプロイ設定（mahjong-net-server）
+#
+# `fly launch` で生成・調整できる雛形。app 名は自分のものに変更すること。
+# 詳細な手順は README の「Deployment」を参照。
+
+app = "mahjong-rs-server"       # ← 自分のアプリ名に変更する
+primary_region = "nrt"          # 東京（必要に応じて変更）
+
+[build]
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 8080
+  force_https = true            # http を https にリダイレクトし wss を強制する
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  # 無接続時にマシンを止めると進行中のルームは失われる（在席プレイなら許容）。
+  # 常時起動したい場合は 1 にする。
+  min_machines_running = 0
+
+  [[http_service.checks]]
+    interval = "15s"
+    timeout = "2s"
+    grace_period = "5s"
+    method = "GET"
+    path = "/healthz"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"


### PR DESCRIPTION
## Summary

Phase 7 (final) of online multiplayer (#214, part of #207): deployment artifacts and an optional Origin allowlist for `mahjong-net-server`. Hosting target is **Fly.io** (per the design decision), with a generic Docker path for any host.

- **`Dockerfile`**: multi-stage build that compiles only `mahjong-net-server` (`-p` limits the dep graph to `mahjong-server`/`mahjong-core`; the macroquad client is not built) into a slim Debian runtime listening on `PORT`.
- **`.dockerignore`** trims the build context (`target`/`public`/`assets`/`.git`).
- **`fly.toml`**: Fly.io service config with `force_https` (wss), internal port 8080, a `/healthz` check, and a 256MB shared-cpu-1x VM. Rooms are in-memory, so `min_machines_running` is left at 0 for friends-play.
- **Origin allowlist**: `AppState.allowed_origin` from the `ALLOWED_ORIGIN` env var (unset = allow all). `ws_handler` reads the `Origin` header and returns 403 on mismatch, with a pure `origin_allowed()` helper + unit tests. TLS/`wss://` is terminated by the hosting proxy.
- **README / README.ja**: add `mahjong-net-server` to the crate list and status; document running it locally (`PORT`/`RUST_LOG`/`ALLOWED_ORIGIN`, `/healthz`, `/ws`), Fly.io deploy steps, the generic `docker build`/`run`, wiring `MAHJONG_SERVER_URL` in Vercel for the web client, and ops notes (in-memory rooms die on redeploy, health monitoring).

## Test plan

- [x] `origin_allowed` unit tests: unset allows all; set requires exact match (mismatch/missing rejected)
- [x] `cargo build --release -p mahjong-net-server` passes locally — this is exactly the command the Dockerfile runs
- [x] `cargo test` workspace green (client 21 / core 257 / net unit 7 / integration 15 / server 356); `cargo fmt` / `cargo clippy --all-targets` clean; `wasm32-unknown-unknown` release build passes
- [ ] **Not exercised:** `docker build` (no local Docker daemon available) and an actual Fly.io deploy (requires the maintainer's account/billing). The image only wraps the verified release build.

## Deploy checklist (maintainer)

- [ ] `fly launch --no-deploy` (set the app name), then `fly deploy`
- [ ] `fly secrets set ALLOWED_ORIGIN=https://<your-app>.vercel.app` (optional hardening)
- [ ] Set `MAHJONG_SERVER_URL=wss://<your-app>.fly.dev/ws` in Vercel and redeploy the web client
- [ ] Verify a browser client connects and completes a match

---

This is the **final phase** of the online multiplayer line (#207). Once #208–#214 are merged into `feat/#207-online-multiplayer`, the integration branch can be merged into `main` to ship the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
