### PR TITLE
Fix native wss connection: install rustls crypto provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,7 @@ dependencies = [
  "macroquad",
  "mahjong-core",
  "mahjong-server",
+ "rustls",
  "serde",
  "tungstenite 0.27.0",
 ]
@@ -972,6 +973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",

--- a/README.ja.md
+++ b/README.ja.md
@@ -137,7 +137,7 @@ cargo run -p mahjong-net-server
 
 - `PORT`: リッスンポート（デフォルト `8080`）
 - `RUST_LOG`: ログフィルタ（例: `mahjong_net_server=debug`）
-- `ALLOWED_ORIGIN`: 設定すると、`Origin` ヘッダが一致する WebSocket 接続のみ許可（例: `https://your-app.vercel.app`）。未設定なら全許可
+- `ALLOWED_ORIGIN`: 設定すると、`Origin` ヘッダが一致する WebSocket 接続のみ許可（例: `https://your-app.vercel.app`）。未設定なら全許可。**ネイティブクライアントは `Origin` ヘッダを送らないため、設定中は弾かれます（HTTP 403）** — ネイティブから接続したい場合は未設定にし、ブラウザクライアント + 組み込みのレート制限で運用してください
 
 `GET /healthz` は `ok` を返します（ヘルスチェック用）。WebSocket は `GET /ws`。
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Environment variables:
 
 - `PORT`: listen port (default `8080`).
 - `RUST_LOG`: log filter (for example `mahjong_net_server=debug`).
-- `ALLOWED_ORIGIN`: if set, only WebSocket connections with a matching `Origin` header are accepted (for example `https://your-app.vercel.app`). If unset, all origins are allowed.
+- `ALLOWED_ORIGIN`: if set, only WebSocket connections with a matching `Origin` header are accepted (for example `https://your-app.vercel.app`). If unset, all origins are allowed. Note that **native clients do not send an `Origin` header and are rejected (HTTP 403) while this is set** — leave it unset if you need native clients to connect, and rely on browser clients plus the built-in rate limiting otherwise.
 
 `GET /healthz` returns `ok` for health checks. The WebSocket endpoint is `GET /ws`.
 

--- a/crates/mahjong-client/Cargo.toml
+++ b/crates/mahjong-client/Cargo.toml
@@ -14,3 +14,5 @@ getrandom = "0.4"
 # ネイティブのみ: WebSocket クライアント（WASM はフェーズ4で手書きJSグルーを使う）
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tungstenite = { version = "0.27", features = ["rustls-tls-webpki-roots"] }
+# wss 接続前に rustls のプロセス既定 CryptoProvider を用意するために使う
+rustls = { version = "0.23", default-features = false, features = ["ring"] }

--- a/crates/mahjong-client/src/transport.rs
+++ b/crates/mahjong-client/src/transport.rs
@@ -83,12 +83,26 @@ mod native {
 
     impl NativeTransport {
         pub fn connect(url: &str) -> Self {
+            ensure_crypto_provider();
             let (out_tx, out_rx) = channel::<String>();
             let (in_tx, in_rx) = channel::<WsEvent>();
             let url = url.to_string();
             std::thread::spawn(move || run_socket(&url, &out_rx, &in_tx));
             NativeTransport { out_tx, in_rx }
         }
+    }
+
+    /// rustls のプロセス既定 CryptoProvider を一度だけ用意する
+    ///
+    /// rustls 0.23 は wss 接続前にプロセス既定のプロバイダが必要で、
+    /// 未設定だと tungstenite が接続時に panic する。複数の機能で rustls を
+    /// 引き込んでも安全なよう、`install_default` の失敗（設定済み）は無視する。
+    fn ensure_crypto_provider() {
+        use std::sync::Once;
+        static INIT: Once = Once::new();
+        INIT.call_once(|| {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+        });
     }
 
     impl Transport for NativeTransport {


### PR DESCRIPTION
## Problem

Connecting a native client to a `wss://` URL panicked in the WebSocket thread:

```
panicked at rustls-0.23/src/crypto/mod.rs: no process-level CryptoProvider available
```

tungstenite uses rustls 0.23, which requires a process-default `CryptoProvider` to be installed before any TLS handshake. The native transport never installed one, so the connection thread died and native clients could not reach a TLS (wss) server. Local `ws://` was unaffected.

## Fix

- Add the `rustls` (ring) dependency on native targets and install the ring default provider exactly once (`std::sync::Once`) before opening a socket. WASM is unaffected — it uses the hand-written JS WebSocket glue and does not pull in rustls.
- README / README.ja: note that a **native client sends no `Origin` header and is rejected (HTTP 403) while `ALLOWED_ORIGIN` is set**; leave it unset to allow native clients.

## Verification

- `cargo build -p mahjong-client` (native) and `--target wasm32-unknown-unknown --release` both pass; `cargo clippy --all-targets` clean; client tests green.
- Ran the ignored E2E against the live wss server (`wss://riichi-mahjong-rs.fly.dev/ws`): **the rustls panic is gone**. The TLS handshake now completes and the request reaches the server, which returns `403 Forbidden` because `ALLOWED_ORIGIN` is currently set on that server — proving TLS works end-to-end. (A native client can connect to a wss server that does not set `ALLOWED_ORIGIN`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
