### PR TITLE
Apply CPU action delay in online matches

### DIFF
--- a/crates/mahjong-net-server/src/room.rs
+++ b/crates/mahjong-net-server/src/room.rs
@@ -30,6 +30,10 @@ pub struct RoomConfig {
     /// 1手番ごとの制限時間（None なら無制限）。
     /// 超過するとサーバが既定アクション（ツモ切り/パス）を代行する。
     pub action_timeout: Option<Duration>,
+    /// CPUの打牌間隔（思考時間の演出）。0 なら即時に進行する。
+    pub cpu_action_delay: Duration,
+    /// ゲーム進行ティックの間隔。CPU遅延を計りながら進める粒度。
+    pub tick_interval: Duration,
 }
 
 impl Default for RoomConfig {
@@ -39,6 +43,8 @@ impl Default for RoomConfig {
             lobby_timeout: Duration::from_secs(30 * 60),
             abandoned_timeout: Duration::from_secs(5 * 60),
             action_timeout: Some(Duration::from_secs(90)),
+            cpu_action_delay: Duration::from_secs(1),
+            tick_interval: Duration::from_millis(100),
         }
     }
 }
@@ -120,6 +126,8 @@ struct Room {
     close_deadline: Option<Instant>,
     /// 手番の制限時間の期限
     action_deadline: Option<Instant>,
+    /// ゲーム進行の時刻基準（対局開始時刻）。CPU遅延の計測に使う
+    game_clock: Option<Instant>,
     /// ルームを閉じるフラグ
     closing: bool,
     /// 次に割り当てる接続の世代番号
@@ -146,9 +154,14 @@ pub async fn run_room(
         ready_deadline: None,
         close_deadline: Some(Instant::now() + config.lobby_timeout),
         action_deadline: None,
+        game_clock: None,
         closing: false,
         next_conn_gen: 0,
     };
+
+    // CPU遅延を計りながらゲームを進めるためのティック
+    let mut game_tick = tokio::time::interval(config.tick_interval);
+    game_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
     loop {
         let ready_at = deadline_or_far(room.ready_deadline);
@@ -160,6 +173,9 @@ pub async fn run_room(
                 Some(msg) => room.handle_msg(msg).await,
                 None => break,
             },
+            _ = game_tick.tick(), if room.needs_game_tick() => {
+                room.game_tick().await;
+            }
             _ = tokio::time::sleep_until(ready_at), if room.ready_deadline.is_some() => {
                 tracing::debug!(code = room.code, "ready timeout; auto-advancing round");
                 room.advance_round().await;
@@ -325,8 +341,9 @@ impl Room {
                         .await;
                     return;
                 }
+                let now = self.now_secs();
                 let driver = self.driver.as_mut().expect("checked above");
-                let accepted = driver.handle_action(seat, action.clone());
+                let accepted = driver.handle_action_at(seat, action.clone(), now);
                 if !accepted {
                     let phase = driver
                         .table()
@@ -383,8 +400,11 @@ impl Room {
                 driver.set_cpu(s, config);
             }
         }
+        driver.set_cpu_action_delay(self.config.cpu_action_delay.as_secs_f64());
         driver.start_game();
         self.driver = Some(driver);
+        // CPU遅延を計る時刻基準を起動。以降は now_secs() で経過秒を渡す
+        self.game_clock = Some(Instant::now());
         // 開始したのでロビーの生存期限は解除
         self.close_deadline = None;
 
@@ -393,14 +413,43 @@ impl Room {
         self.progress_game().await;
     }
 
-    /// 入力待ちまでゲームを進め、イベントを配信し、局終了を確認する
+    /// 直前のアクション結果を配信し、局終了の確認・期限の再設定を行う
+    ///
+    /// CPUの進行は [`game_tick`](Self::game_tick) が遅延を計りながら進めるため、
+    /// ここではツモまで一気に進めない（イベントの送出と状態更新のみ）。
     async fn progress_game(&mut self) {
+        self.flush_events().await;
+        self.check_round_end();
+        self.refresh_action_deadline().await;
+    }
+
+    /// CPU遅延を計りながらゲームを1ティック進める
+    ///
+    /// 待機中のCPUアクションが期限を迎えれば適用し、ツモフェーズなら牌を引く。
+    /// `needs_game_tick` が true の間だけ呼ばれる。
+    async fn game_tick(&mut self) {
+        let now = self.now_secs();
         if let Some(driver) = self.driver.as_mut() {
-            driver.run_until_blocked();
+            driver.tick_at(now);
         }
         self.flush_events().await;
         self.check_round_end();
         self.refresh_action_deadline().await;
+    }
+
+    /// CPUの進行（ツモ・遅延待ちの打牌など）のために tick が必要か
+    fn needs_game_tick(&self) -> bool {
+        if self.awaiting_ready || self.game_over_sent {
+            return false;
+        }
+        self.driver.as_ref().is_some_and(|d| d.needs_tick())
+    }
+
+    /// ゲーム時刻基準からの経過秒（CPU遅延の計測に渡す）
+    fn now_secs(&self) -> f64 {
+        self.game_clock
+            .map(|c| c.elapsed().as_secs_f64())
+            .unwrap_or(0.0)
     }
 
     /// 指定した座席が接続中の人間か
@@ -448,6 +497,7 @@ impl Room {
 
     /// 手番の制限時間切れ: 待っている接続中の人間に既定アクションを代行する
     async fn on_action_timeout(&mut self) {
+        let now = self.now_secs();
         let seats: Vec<usize> = self
             .driver
             .as_ref()
@@ -458,7 +508,7 @@ impl Room {
                 && let Some(driver) = self.driver.as_mut()
             {
                 tracing::info!(code = self.code, seat, "action timed out; auto-acting");
-                driver.force_default_action(seat);
+                driver.force_default_action_at(seat, now);
             }
         }
         self.action_deadline = None;
@@ -473,10 +523,12 @@ impl Room {
         if self.driver.is_none() {
             return;
         }
-        // 先に全座席のイベントを取り出す（driver の借用をここで手放す）
+        // 先に全座席のイベントを取り出す（driver の借用をここで手放す）。
+        // drain_events_at は CPU遅延を計りながらイベントを処理する。
+        let now = self.now_secs();
         let per_seat: [Vec<ServerEvent>; 4] = {
             let driver = self.driver.as_mut().expect("checked above");
-            std::array::from_fn(|seat| driver.drain_events(seat))
+            std::array::from_fn(|seat| driver.drain_events_at(seat, now))
         };
 
         for (seat, events) in per_seat.into_iter().enumerate() {
@@ -538,10 +590,11 @@ impl Room {
         self.awaiting_ready = false;
         self.ready_deadline = None;
 
+        let now = self.now_secs();
         let Some(driver) = self.driver.as_mut() else {
             return;
         };
-        driver.next_round();
+        driver.next_round_at(now);
 
         if driver.is_game_over() {
             let final_scores = driver.table().scores;
@@ -595,10 +648,11 @@ impl Room {
             seat,
             "player disconnected; CPU takes over"
         );
+        let now = self.now_secs();
         if let Some(driver) = self.driver.as_mut() {
             driver.set_cpu_controlled(seat, true);
             // 切断した座席の入力待ちで止まっていたら既定アクションで進める
-            driver.force_default_action(seat);
+            driver.force_default_action_at(seat, now);
         }
         // 残りの接続者へ切断を通知する
         self.broadcast(ServerMessage::PlayerConnectionChanged {

--- a/crates/mahjong-net-server/tests/integration.rs
+++ b/crates/mahjong-net-server/tests/integration.rs
@@ -23,6 +23,9 @@ fn fast_config() -> RoomConfig {
         abandoned_timeout: Duration::from_secs(5),
         // 既存テストの自動進行を阻害しないよう長めにする
         action_timeout: Some(Duration::from_secs(30)),
+        // テストは遅延なし・細かいティックでほぼ即時に進める
+        cpu_action_delay: Duration::ZERO,
+        tick_interval: Duration::from_millis(1),
     }
 }
 
@@ -226,6 +229,13 @@ impl TestClient {
                         _ => {}
                     },
                     ServerMessage::GameOver { final_scores } => return final_scores,
+                    ServerMessage::Error {
+                        code: ErrorCode::InvalidAction,
+                        ..
+                    } => {
+                        // 鳴き解決などのレースで無効になったアクション。
+                        // ツモ切りボットでは無害なので無視する。
+                    }
                     ServerMessage::Error { code, message } => {
                         panic!("予期しないエラー: {code:?} {message}");
                     }
@@ -558,7 +568,14 @@ async fn test_join_rate_limit() {
 #[tokio::test]
 async fn test_reconnect_resyncs_and_resumes() {
     tokio::time::timeout(Duration::from_secs(120), async {
-        let addr = start_server(fast_config()).await;
+        // CPU をわずかに遅延させ、再入室するまで対局が終わらないようにする
+        // （即時進行だと 300ms のスリープ中に終局してしまう）
+        let config = RoomConfig {
+            cpu_action_delay: Duration::from_millis(50),
+            tick_interval: Duration::from_millis(10),
+            ..fast_config()
+        };
+        let addr = start_server(config).await;
 
         let mut host = TestClient::connect(addr).await;
         host.hello("ホスト").await;

--- a/crates/mahjong-server/src/driver.rs
+++ b/crates/mahjong-server/src/driver.rs
@@ -258,6 +258,15 @@ impl GameDriver {
     /// CPU代打ちへの切り替え直後や行動タイムアウト時に、入力待ちで
     /// 停止したゲームを進めるために使う。実行したら true を返す。
     pub fn force_default_action(&mut self, seat: usize) -> bool {
+        self.force_default_action_impl(seat, None)
+    }
+
+    /// 現在時刻を渡して既定アクションを実行する（CPU遅延が有効な場合に使う）
+    pub fn force_default_action_at(&mut self, seat: usize, now: f64) -> bool {
+        self.force_default_action_impl(seat, Some(now))
+    }
+
+    fn force_default_action_impl(&mut self, seat: usize, now: Option<f64>) -> bool {
         let action = {
             let round = match self.table.current_round() {
                 Some(r) => r,
@@ -287,7 +296,35 @@ impl GameDriver {
                 _ => return false,
             }
         };
-        self.handle_action(seat, action)
+        self.handle_action_impl(seat, action, now)
+    }
+
+    /// CPU進行やツモのために tick が必要か（人間の入力待ちなら false）
+    ///
+    /// 待機中のCPUアクション、ツモフェーズ、CPU操作中の座席の手番では true。
+    /// CPU遅延を効かせながら進行させるネットワークサーバが、`tick_at` を
+    /// 呼ぶべきかの判定に使う。人間の入力待ちでは false を返し、無駄な tick を避ける。
+    pub fn needs_tick(&self) -> bool {
+        if !self.pending_cpu_batches.is_empty() {
+            return true;
+        }
+        let Some(round) = self.table.current_round() else {
+            return false;
+        };
+        if round.is_over() {
+            return false;
+        }
+        match round.phase {
+            TurnPhase::Draw => true,
+            TurnPhase::WaitForDiscard | TurnPhase::WaitForNineTerminals => {
+                self.is_cpu_controlled(round.current_player)
+            }
+            TurnPhase::WaitForCalls => round
+                .call_state
+                .as_ref()
+                .is_some_and(|cs| (0..4).any(|i| !cs.responded[i] && self.is_cpu_controlled(i))),
+            TurnPhase::RoundOver => false,
+        }
     }
 
     /// 現在の局が終了しているか
@@ -675,6 +712,37 @@ mod tests {
             driver.drain_events(1).is_empty(),
             "純粋なCPU席にイベントがバッファされている"
         );
+    }
+
+    /// needs_tick が人間の打牌待ちで false、CPU進行が必要なら true を返すことを確認
+    #[test]
+    fn test_needs_tick_distinguishes_human_wait_from_cpu_progress() {
+        let mut driver = driver_with_three_cpus();
+        driver.start_game_with_seed(42);
+        driver.run_until_blocked();
+
+        // 座席0（人間）の打牌待ちで停止 → tick 不要
+        let round = driver.table().current_round().unwrap();
+        assert_eq!(round.current_player, 0);
+        assert_eq!(round.phase, TurnPhase::WaitForDiscard);
+        assert!(!driver.needs_tick(), "人間の打牌待ちでは tick 不要");
+
+        // 人間が打牌 → 次は CPU の進行（ツモ/pending）→ tick 必要
+        driver.handle_action(0, ClientAction::Discard { tile: None });
+        // 即時処理だと CPU まで一気に進むので、遅延を入れて pending を残す
+        let mut paced = driver_with_three_cpus();
+        paced.set_cpu_action_delay(1.0);
+        paced.start_game_with_seed(42);
+        // 人間の打牌待ちまで時刻ベースで進める
+        for _ in 0..50 {
+            if !paced.needs_tick() {
+                break;
+            }
+            paced.tick_at(0.0);
+        }
+        assert!(!paced.needs_tick(), "人間の打牌待ちで停止するはず");
+        paced.handle_action_at(0, ClientAction::Discard { tile: None }, 0.0);
+        assert!(paced.needs_tick(), "打牌後は CPU 進行のため tick が必要");
     }
 
     /// CPUクライアント未割り当ての座席は操作切り替えできないことを確認


### PR DESCRIPTION
## Summary

Local matches already pace CPU discards by ~1s (PR #217 / the `GameDriver` delay machinery), but the online server drove the game with `run_until_blocked`, which ignores the delay and applies all CPU actions immediately. This switches the room actor to a clock-based tick so online CPU play is paced the same way.

### GameDriver
- `needs_tick()`: true while CPU progress is due (a pending action batch, the Draw phase, or a CPU-controlled seat's turn), false while waiting on a human — so the server only ticks when there is work.
- `force_default_action_at(seat, now)`: clock-injected variant used for timeout / disconnect takeover so those follow-up CPU actions are also paced.

### mahjong-net-server
- `RoomConfig` gains `cpu_action_delay` (default **1s**) and `tick_interval` (default 100ms). The room sets the delay on start, tracks a `game_clock`, and feeds elapsed seconds to `handle_action_at` / `drain_events_at` / `next_round_at` / `force_default_action_at`.
- A `select!` game-tick branch (gated by `needs_game_tick`) advances the game while CPUs "think"; `progress_game` no longer runs to quiescence.

## Test plan

- [x] `fast_config` uses delay 0 / 1ms tick to keep the suite fast; integration suite green (15 tests), run 4x clean.
- [x] The reconnect-resync test pins a small CPU delay so the game does not finish during its 300ms sleep (the immediate-progress version relied on the bot's 50ms batching to throttle play).
- [x] The headless bot now ignores `InvalidAction`, which can occur when a call is resolved by another seat's higher-priority meld before the bot's pass arrives — a harmless race the real client also tolerates.
- [x] `GameDriver::needs_tick` unit test.
- [x] `cargo test` workspace green (server 357 / net unit 7 / integration 15 / client 21); `cargo fmt` / `cargo clippy --all-targets` clean; wasm release build unaffected.

Note: local play is unchanged (it already paced CPUs via the macroquad frame loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
