### PR TITLE
Scale WASM canvas to fit the browser window

### DIFF
--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -1273,7 +1273,7 @@ impl GameState {
             return None;
         }
 
-        let (mx, my) = mouse_position();
+        let (mx, my) = crate::renderer::mouse_position_design();
 
         // 手牌クリック
         let hand_start_x = 100.0;

--- a/crates/mahjong-client/src/main.rs
+++ b/crates/mahjong-client/src/main.rs
@@ -145,6 +145,9 @@ async fn main() {
     loop {
         clear_background(Color::from_rgba(0, 100, 0, 255));
 
+        // 設計座標系(DESIGN_W×DESIGN_H)を実キャンバスに合わせて拡大縮小して描画する
+        renderer::set_design_camera();
+
         let overlay_click = renderer::draw_game(&game_state, font.as_ref(), &tile_textures);
 
         // ロビー段階のリモート接続を進める

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -25,6 +25,12 @@ const FONT_SIZE: u16 = 20;
 const SMALL_FONT: u16 = 16;
 const AGARI_FONT: u16 = 32;
 
+/// 設計上の基準解像度。すべての UI 座標はこの仮想キャンバス上で定義され、
+/// 実際のウィンドウ／キャンバスサイズに合わせて一様に拡大・縮小される。
+/// （HTML 側でキャンバスのアスペクト比を DESIGN_W:DESIGN_H に固定しているため歪まない）
+pub const DESIGN_W: f32 = 1280.0;
+pub const DESIGN_H: f32 = 800.0;
+
 /// 盤面の中心点 — 捨て牌・他家手牌の回転の軸
 const BOARD_CENTER_X: f32 = 500.0;
 const BOARD_CENTER_Y: f32 = 380.0;
@@ -32,17 +38,48 @@ const BOARD_CENTER_Y: f32 = 380.0;
 /// Camera2D の回転角度（度）— 自分(0°)、下家(-90°)、対面(180°)、上家(90°)
 const PLAYER_ROTATIONS: [f32; 4] = [0.0, -90.0, 180.0, 90.0];
 
+/// 設計座標 (0,0)-(DESIGN_W,DESIGN_H) をキャンバス全体に写すカメラ。
+/// 実バッファ解像度に依存しないため、ウィンドウサイズが変わっても
+/// レイアウトはそのまま拡大・縮小される。
+///
+/// 画面へ直接描画する場合、`Camera2D::from_display_rect`（zoom.y が負）だと
+/// 上下反転してしまうため、盤面カメラと同じく zoom.y を正にして上向きに合わせる。
+fn design_camera() -> Camera2D {
+    Camera2D {
+        target: vec2(DESIGN_W / 2.0, DESIGN_H / 2.0),
+        zoom: vec2(2.0 / DESIGN_W, 2.0 / DESIGN_H),
+        ..Default::default()
+    }
+}
+
+/// フレーム冒頭やオーバーレイ描画で使う、設計座標系のデフォルトカメラを適用する。
+pub fn set_design_camera() {
+    set_camera(&design_camera());
+}
+
+/// 設計座標 → 実バッファ座標の拡大率。キャンバスはアスペクト比固定なので
+/// 横・縦どちらで割っても同じ値になる（横を採用）。
+fn design_scale() -> f32 {
+    screen_width() / DESIGN_W
+}
+
+/// マウス座標を実バッファ座標から設計座標へ変換して返す。
+/// クリック判定はすべて設計座標で行うため、入力側もここで合わせる。
+pub fn mouse_position_design() -> (f32, f32) {
+    let (mx, my) = mouse_position();
+    let scale = design_scale();
+    (mx / scale, my / scale)
+}
+
 /// 盤面中心を軸に回転する Camera2D を生成する
 fn make_board_camera(rotation_deg: f32) -> Camera2D {
-    let sw = screen_width();
-    let sh = screen_height();
     Camera2D {
         target: vec2(BOARD_CENTER_X, BOARD_CENTER_Y),
         rotation: rotation_deg,
-        zoom: vec2(2.0 / sw, 2.0 / sh),
+        zoom: vec2(2.0 / DESIGN_W, 2.0 / DESIGN_H),
         offset: vec2(
-            2.0 * BOARD_CENTER_X / sw - 1.0,
-            1.0 - 2.0 * BOARD_CENTER_Y / sh,
+            2.0 * BOARD_CENTER_X / DESIGN_W - 1.0,
+            1.0 - 2.0 * BOARD_CENTER_Y / DESIGN_H,
         ),
         ..Default::default()
     }
@@ -325,7 +362,7 @@ fn draw_center_panel(state: &GameState, font: Option<&Font>) {
             );
         }
 
-        set_default_camera();
+        set_design_camera();
     }
 
     // 局情報（プレイヤー＝自分に読める方向で描画）
@@ -437,7 +474,7 @@ fn draw_discards(state: &GameState, tile_textures: &TileTextures) {
             }
         }
 
-        set_default_camera();
+        set_design_camera();
     }
 }
 
@@ -851,7 +888,7 @@ fn draw_other_player_hands(state: &GameState, tile_textures: &TileTextures) {
             x += calc_meld_width(meld, tw, th);
         }
 
-        set_default_camera();
+        set_design_camera();
     }
 }
 
@@ -1236,7 +1273,7 @@ pub fn handle_setup_input(state: &mut GameState, _font: Option<&Font>) -> Option
         return None;
     }
 
-    let (mx, my) = mouse_position();
+    let (mx, my) = mouse_position_design();
     let setup = &mut state.setup_state;
     let col_x = [250.0, 520.0, 790.0];
     let base_y = 180.0;

--- a/crates/mahjong-client/src/renderer/online.rs
+++ b/crates/mahjong-client/src/renderer/online.rs
@@ -229,7 +229,7 @@ pub fn handle_online_menu_input(state: &mut GameState) -> Option<OnlineMenuActio
     if !is_mouse_button_pressed(MouseButton::Left) {
         return None;
     }
-    let (mx, my) = mouse_position();
+    let (mx, my) = super::mouse_position_design();
 
     if NAME_BOX.contains(mx, my) {
         online.code_focused = false;
@@ -335,7 +335,7 @@ pub fn handle_online_lobby_input(state: &GameState) -> Option<OnlineLobbyAction>
     if !is_mouse_button_pressed(MouseButton::Left) {
         return None;
     }
-    let (mx, my) = mouse_position();
+    let (mx, my) = super::mouse_position_design();
 
     let is_host = state
         .online_state

--- a/crates/mahjong-client/src/renderer/overlay.rs
+++ b/crates/mahjong-client/src/renderer/overlay.rs
@@ -77,7 +77,7 @@ pub(super) fn draw_action_buttons(
     tile_textures: &TileTextures,
 ) -> Option<OverlayClick> {
     let clicked = is_mouse_button_pressed(MouseButton::Left);
-    let (mx, my) = mouse_position();
+    let (mx, my) = super::mouse_position_design();
 
     // 九種九牌選択オーバーレイ
     if state.nine_terminals_pending {

--- a/index.html
+++ b/index.html
@@ -7,12 +7,19 @@
         html, body {
             margin: 0;
             padding: 0;
+            width: 100%;
+            height: 100%;
             overflow: hidden;
             background: #000;
         }
+        /* キャンバスをウィンドウ中央にレターボックス表示する */
+        body {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
         canvas {
             display: block;
-            margin: 0 auto;
         }
     </style>
 </head>
@@ -23,6 +30,29 @@
         // 未設定なら ws://127.0.0.1:8080/ws（ローカル開発用）が使われる。
         // 本番デプロイ時はビルドスクリプトがここを差し替える。
         // window.MAHJONG_SERVER_URL = "wss://example.com/ws";
+    </script>
+    <script>
+        // 設計解像度。クライアント側(DESIGN_W/DESIGN_H)と一致させること。
+        var MAHJONG_DESIGN_W = 1280;
+        var MAHJONG_DESIGN_H = 800;
+        // アスペクト比を保ったままウィンドウの縦横どちらかに収まるよう
+        // キャンバスの表示サイズを調整する。
+        // macroquad は canvas の clientWidth/clientHeight に描画バッファを合わせるため、
+        // ここで CSS サイズを変えるだけで内部解像度も追従する。
+        function fitMahjongCanvas() {
+            var canvas = document.getElementById("glcanvas");
+            if (!canvas) return;
+            var scale = Math.min(
+                window.innerWidth / MAHJONG_DESIGN_W,
+                window.innerHeight / MAHJONG_DESIGN_H
+            );
+            canvas.style.width = Math.round(MAHJONG_DESIGN_W * scale) + "px";
+            canvas.style.height = Math.round(MAHJONG_DESIGN_H * scale) + "px";
+        }
+        // macroquad が window.onresize を設定するより前にリスナーを登録しておくと、
+        // リサイズ時にこちらが先に走り、描画バッファのサイズずれを防げる。
+        window.addEventListener("resize", fitMahjongCanvas);
+        fitMahjongCanvas();
     </script>
     <script src="mq_js_bundle.js"></script>
     <script src="crates/mahjong-client/js/ws.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -8,18 +8,49 @@
         html, body {
             margin: 0;
             padding: 0;
+            width: 100%;
+            height: 100%;
             overflow: hidden;
             background: #000;
         }
 
+        /* キャンバスをウィンドウ中央にレターボックス表示する */
+        body {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
         canvas {
             display: block;
-            margin: 0 auto;
         }
     </style>
 </head>
 <body>
     <canvas id="glcanvas" tabindex="1" width="1280" height="800"></canvas>
+    <script>
+        // 設計解像度。クライアント側(DESIGN_W/DESIGN_H)と一致させること。
+        var MAHJONG_DESIGN_W = 1280;
+        var MAHJONG_DESIGN_H = 800;
+        // アスペクト比を保ったままウィンドウの縦横どちらかに収まるよう
+        // キャンバスの表示サイズを調整する。
+        // macroquad は canvas の clientWidth/clientHeight に描画バッファを合わせるため、
+        // ここで CSS サイズを変えるだけで内部解像度も追従する。
+        function fitMahjongCanvas() {
+            var canvas = document.getElementById("glcanvas");
+            if (!canvas) return;
+            var scale = Math.min(
+                window.innerWidth / MAHJONG_DESIGN_W,
+                window.innerHeight / MAHJONG_DESIGN_H
+            );
+            canvas.style.width = Math.round(MAHJONG_DESIGN_W * scale) + "px";
+            canvas.style.height = Math.round(MAHJONG_DESIGN_H * scale) + "px";
+        }
+        // macroquad が window.onresize を設定するより前にリスナーを登録しておくと、
+        // リサイズ時にこちらが先に走り、描画バッファのサイズずれを防げる。
+        window.addEventListener("resize", fitMahjongCanvas);
+        fitMahjongCanvas();
+    </script>
     <script src="mq_js_bundle.js"></script>
     <script>
         if (typeof load === "function") {


### PR DESCRIPTION
## What

Make the WASM client scale to fit the browser window. The fixed 1280×800 layout is now treated as a virtual canvas that is uniformly scaled to fit the window's width or height while preserving the aspect ratio, with black letterbox bars filling the remainder.

## Why

Previously the canvas was a fixed 1280×800 element, so on smaller browser windows the board was cut off and on larger ones it sat in a corner. Now it always fits and stays centered.

## How

- **HTML** (`index.html`, `public/index.html`): center the canvas with flexbox and recompute its CSS size on window resize using `min(winW/1280, winH/800)`. macroquad syncs the drawing buffer to `clientWidth/clientHeight`, so changing the CSS size also updates the internal render resolution (kept crisp).
- **Renderer** (`renderer/mod.rs`): introduce `DESIGN_W/DESIGN_H` (1280×800) and base `make_board_camera` and the new `design_camera` on these constants instead of `screen_width()/screen_height()`, so the layout always maps to the full canvas regardless of buffer resolution. Apply the design camera at the start of each frame and in place of `set_default_camera()`.
- **Input**: route all 5 mouse-read sites through a new `mouse_position_design()` helper that maps buffer-pixel coordinates back to design space for hit-testing.

## Notes for reviewers

- **Why not `transform: scale`?** macroquad maps the mouse via `getBoundingClientRect` (transform-aware) while the drawing buffer follows `clientWidth` (transform-agnostic). Scaling the canvas with a CSS transform would desync the two and break click handling, so the canvas CSS size itself is resized instead.
- `design_camera` uses a **positive** `zoom.y` (matching the existing board camera) rather than `Camera2D::from_display_rect`, whose negative `zoom.y` flips the image upside down when rendering directly to the screen.
- `index.html` loads `target/wasm32-unknown-unknown/release/mahjong-client.wasm`, so a release WASM rebuild is needed to see the change deployed.

## Verification

Verified in-browser with a freshly rebuilt release WASM:
- Portrait window → fits to width, top/bottom letterbox, content upright and centered.
- Landscape window (1400×560) → fits to height, equal left/right letterbox (measured `left:252, w:896` in a 1400px window).
- Mouse mapping confirmed by clicking "対局開始" at its design-space location and reaching the game board.
- `cargo build` (native + wasm), `cargo clippy`, `cargo test -p mahjong-client` (23 passed) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)