### PR TITLE
Add core i18n primitives for localization (#242, 1/3)

### DIFF
--- a/crates/mahjong-core/src/scoring/score.rs
+++ b/crates/mahjong-core/src/scoring/score.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 
 use crate::hand::Hand;
 use crate::hand_info::hand_analyzer::HandAnalyzer;
 use crate::hand_info::status::Status;
 use crate::scoring::fu::{FuResult, calculate_fu};
-use crate::settings::Settings;
+use crate::settings::{Lang, Settings};
 use crate::winning_hand::checker;
 use crate::winning_hand::name::Kind;
 
@@ -36,7 +37,7 @@ pub struct ScoreResult {
 }
 
 /// 点数の等級
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub enum ScoreRank {
     /// 通常（満貫未満）
     Normal,
@@ -50,6 +51,65 @@ pub enum ScoreRank {
     Sanbaiman,
     /// 役満（13翻以上）
     Yakuman,
+}
+
+impl ScoreRank {
+    /// 点数等級の表示名を返す（`Normal` は空文字列）
+    ///
+    /// 英語名は WRC Rules 2025 準拠（docs/glossary.md を参照）。
+    pub fn name(&self, lang: Lang) -> &'static str {
+        match lang {
+            Lang::En => match self {
+                ScoreRank::Normal => "",
+                ScoreRank::Mangan => "Mangan",
+                ScoreRank::Haneman => "Haneman",
+                ScoreRank::Baiman => "Baiman",
+                ScoreRank::Sanbaiman => "Sanbaiman",
+                ScoreRank::Yakuman => "Yakuman",
+            },
+            Lang::Ja => match self {
+                ScoreRank::Normal => "",
+                ScoreRank::Mangan => "満貫",
+                ScoreRank::Haneman => "跳満",
+                ScoreRank::Baiman => "倍満",
+                ScoreRank::Sanbaiman => "三倍満",
+                ScoreRank::Yakuman => "役満",
+            },
+        }
+    }
+}
+
+/// ドラの種別（リザルト画面で役と並べて翻数を表示するために用いる）
+///
+/// 翻数を生む通常の役ではないが、和了結果の内訳として役と同様に扱う。
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize)]
+pub enum DoraLabel {
+    /// ドラ
+    Dora,
+    /// 赤ドラ
+    RedDora,
+    /// 裏ドラ
+    UraDora,
+}
+
+impl DoraLabel {
+    /// ドラ種別の表示名を返す
+    ///
+    /// 英語名は WRC Rules 2025 準拠（docs/glossary.md を参照）。
+    pub fn name(&self, lang: Lang) -> &'static str {
+        match lang {
+            Lang::En => match self {
+                DoraLabel::Dora => "Dora",
+                DoraLabel::RedDora => "Red Five",
+                DoraLabel::UraDora => "Ura Dora",
+            },
+            Lang::Ja => match self {
+                DoraLabel::Dora => "ドラ",
+                DoraLabel::RedDora => "赤ドラ",
+                DoraLabel::UraDora => "裏ドラ",
+            },
+        }
+    }
 }
 
 /// 点数を計算する
@@ -513,5 +573,43 @@ mod tests {
         let riichi_pos = names.iter().position(|&n| n == "立直").unwrap();
         let pinfu_pos = names.iter().position(|&n| n == "平和").unwrap();
         assert!(riichi_pos < pinfu_pos, "立直はKind定義順で平和より先に来る");
+    }
+
+    /// 点数等級名（日本語）
+    #[test]
+    fn rank_name_ja() {
+        assert_eq!(ScoreRank::Normal.name(Lang::Ja), "");
+        assert_eq!(ScoreRank::Mangan.name(Lang::Ja), "満貫");
+        assert_eq!(ScoreRank::Haneman.name(Lang::Ja), "跳満");
+        assert_eq!(ScoreRank::Baiman.name(Lang::Ja), "倍満");
+        assert_eq!(ScoreRank::Sanbaiman.name(Lang::Ja), "三倍満");
+        assert_eq!(ScoreRank::Yakuman.name(Lang::Ja), "役満");
+    }
+
+    /// 点数等級名（英語、WRC 準拠）
+    #[test]
+    fn rank_name_en() {
+        assert_eq!(ScoreRank::Normal.name(Lang::En), "");
+        assert_eq!(ScoreRank::Mangan.name(Lang::En), "Mangan");
+        assert_eq!(ScoreRank::Haneman.name(Lang::En), "Haneman");
+        assert_eq!(ScoreRank::Baiman.name(Lang::En), "Baiman");
+        assert_eq!(ScoreRank::Sanbaiman.name(Lang::En), "Sanbaiman");
+        assert_eq!(ScoreRank::Yakuman.name(Lang::En), "Yakuman");
+    }
+
+    /// ドラ種別名（日本語）
+    #[test]
+    fn dora_label_name_ja() {
+        assert_eq!(DoraLabel::Dora.name(Lang::Ja), "ドラ");
+        assert_eq!(DoraLabel::RedDora.name(Lang::Ja), "赤ドラ");
+        assert_eq!(DoraLabel::UraDora.name(Lang::Ja), "裏ドラ");
+    }
+
+    /// ドラ種別名（英語）
+    #[test]
+    fn dora_label_name_en() {
+        assert_eq!(DoraLabel::Dora.name(Lang::En), "Dora");
+        assert_eq!(DoraLabel::RedDora.name(Lang::En), "Red Five");
+        assert_eq!(DoraLabel::UraDora.name(Lang::En), "Ura Dora");
     }
 }

--- a/crates/mahjong-core/src/tile.rs
+++ b/crates/mahjong-core/src/tile.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+use crate::settings::Lang;
+
 /// 牌の種類を示す型
 pub type TileType = u32;
 
@@ -329,6 +331,24 @@ impl Wind {
             _ => unreachable!(),
         }
     }
+
+    /// 風の表示名を返す（英語名は WRC Rules 2025 準拠、docs/glossary.md を参照）
+    pub fn name(&self, lang: Lang) -> &'static str {
+        match lang {
+            Lang::En => match self {
+                Wind::East => "East",
+                Wind::South => "South",
+                Wind::West => "West",
+                Wind::North => "North",
+            },
+            Lang::Ja => match self {
+                Wind::East => "東",
+                Wind::South => "南",
+                Wind::West => "西",
+                Wind::North => "北",
+            },
+        }
+    }
 }
 
 /// 三元牌
@@ -353,6 +373,22 @@ impl Dragon {
     }
     pub fn is_tile(tile: &Tile) -> Option<Dragon> {
         Dragon::is_tile_type(tile.get())
+    }
+
+    /// 三元牌の表示名を返す（英語名は WRC Rules 2025 準拠、docs/glossary.md を参照）
+    pub fn name(&self, lang: Lang) -> &'static str {
+        match lang {
+            Lang::En => match self {
+                Dragon::White => "White",
+                Dragon::Green => "Green",
+                Dragon::Red => "Red",
+            },
+            Lang::Ja => match self {
+                Dragon::White => "白",
+                Dragon::Green => "發",
+                Dragon::Red => "中",
+            },
+        }
     }
 }
 
@@ -508,6 +544,30 @@ mod tests {
         assert_eq!(Wind::East.to_index(), 0);
         assert_eq!(Wind::from_index(2), Wind::West);
         assert_eq!(Wind::from_index(4), Wind::East);
+    }
+
+    /// 風の表示名
+    #[test]
+    fn wind_name_test() {
+        assert_eq!(Wind::East.name(Lang::Ja), "東");
+        assert_eq!(Wind::South.name(Lang::Ja), "南");
+        assert_eq!(Wind::West.name(Lang::Ja), "西");
+        assert_eq!(Wind::North.name(Lang::Ja), "北");
+        assert_eq!(Wind::East.name(Lang::En), "East");
+        assert_eq!(Wind::South.name(Lang::En), "South");
+        assert_eq!(Wind::West.name(Lang::En), "West");
+        assert_eq!(Wind::North.name(Lang::En), "North");
+    }
+
+    /// 三元牌の表示名
+    #[test]
+    fn dragon_name_test() {
+        assert_eq!(Dragon::White.name(Lang::Ja), "白");
+        assert_eq!(Dragon::Green.name(Lang::Ja), "發");
+        assert_eq!(Dragon::Red.name(Lang::Ja), "中");
+        assert_eq!(Dragon::White.name(Lang::En), "White");
+        assert_eq!(Dragon::Green.name(Lang::En), "Green");
+        assert_eq!(Dragon::Red.name(Lang::En), "Red");
     }
 
     #[test]

--- a/crates/mahjong-core/src/winning_hand/name.rs
+++ b/crates/mahjong-core/src/winning_hand/name.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 
 use crate::settings::Lang;
@@ -17,7 +18,20 @@ pub enum Form {
 ///
 /// 英語名は WRC Rules 2025 に準拠する（docs/glossary.md を参照）
 /// ここでの定義順で同翻役のリザルト画面の役の表示順も決定する
-#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, EnumCountMacro, EnumIter)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    EnumCountMacro,
+    EnumIter,
+    Serialize,
+    Deserialize,
+)]
 pub enum Kind {
     /// 立直
     Riichi,


### PR DESCRIPTION
## Summary
Part 1 of 3 of the client internationalization work (#242). Additive, type-level
groundwork in `mahjong-core` so domain types can be localized and later sent as
structured data. No existing behavior changes.

## Changes
- Derive `Clone, Copy, Serialize, Deserialize` on `winning_hand::name::Kind` so
  yaku can travel over the protocol as data.
- Add `Serialize/Deserialize` to `ScoreRank` plus `ScoreRank::name(Lang)`.
- Add `Wind::name(Lang)` and `Dragon::name(Lang)` (English per the WRC 2025
  glossary, `docs/glossary.md`).
- Add a `DoraLabel` enum (Dora / RedDora / UraDora) with localized names for
  representing dora lines as data rather than pre-formatted strings.
- Unit tests for every new `name()` in both languages.

## Test plan
- `cargo test -p mahjong-core` (263 passing)
- `cargo clippy` / `cargo fmt --check` clean
- WASM target builds

## Stacked PRs (#242)
Merge in order:
1. **this PR** (core primitives) -> `main`
2. protocol structured results -> this branch
3. client i18n strings + persistence -> protocol branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
