### PR TITLE
Send win results as structured data over the protocol (#242, 2/3)

### DIFF
--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -6,6 +6,7 @@ use macroquad::prelude::*;
 use mahjong_core::hand::Hand;
 use mahjong_core::hand_info::hand_analyzer::HandAnalyzer;
 use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
+use mahjong_core::settings::Lang;
 use mahjong_core::tile::{Tile, TileType, Wind};
 use mahjong_server::cpu::client::{CpuConfig, CpuLevel, CpuPersonality};
 use mahjong_server::protocol::net::CpuSpec;
@@ -796,7 +797,8 @@ impl GameState {
                 han,
                 fu,
                 score_points,
-                rank_name,
+                rank,
+                has_opened,
                 uradora_indicators,
                 riichi_sticks,
                 player_hands,
@@ -841,8 +843,17 @@ impl GameState {
                     String::new()
                 };
 
+                // 構造化された役・ドラ・等級を表示言語へ解決する。
+                // 表示言語の切り替えは後続フェーズで対応予定（現状は日本語固定）。
+                let lang = Lang::Ja;
+                let yaku: Vec<(String, u32)> = yaku_list
+                    .iter()
+                    .map(|(item, y_han)| (item.name(has_opened, lang).to_string(), *y_han))
+                    .collect();
+                let rank_name = rank.name(lang).to_string();
+
                 let mut yaku_text = String::new();
-                for (name, y_han) in &yaku_list {
+                for (name, y_han) in &yaku {
                     if !yaku_text.is_empty() {
                         yaku_text.push_str("  ");
                     }
@@ -881,11 +892,11 @@ impl GameState {
                     result_message: msg,
                     winner_name,
                     loser_name,
-                    yaku: yaku_list.clone(),
+                    yaku,
                     han,
                     fu,
                     score_points,
-                    rank_name: rank_name.clone(),
+                    rank_name,
                     riichi_sticks,
                 });
 

--- a/crates/mahjong-core/src/scoring/score.rs
+++ b/crates/mahjong-core/src/scoring/score.rs
@@ -30,10 +30,37 @@ pub struct ScoreResult {
     pub non_dealer_tsumo_dealer: u32,
     /// 子の場合のツモ和了点（子の支払い）
     pub non_dealer_tsumo_non_dealer: u32,
-    /// 成立した役の一覧
-    pub yaku_list: Vec<(&'static str, u32)>,
+    /// 成立した役・ドラの一覧（各項目, 翻数）
+    pub yaku_list: Vec<(ScoreItem, u32)>,
+    /// 副露しているか（役名の喰い下がり表記を再構築するために保持する）
+    pub has_opened: bool,
     /// 符の内訳
     pub fu_result: FuResult,
+}
+
+/// リザルトに表示する得点内訳の項目（役またはドラ）
+///
+/// 役名やドラ名を整形済み文字列で持つのではなく、種別を表す値として保持する。
+/// これにより表示側（クライアント）が任意の言語へローカライズできる。
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize)]
+pub enum ScoreItem {
+    /// 役
+    Yaku(Kind),
+    /// ドラ（通常・赤・裏）
+    Dora(DoraLabel),
+}
+
+impl ScoreItem {
+    /// 項目の表示名を返す
+    ///
+    /// * `has_opened` - 副露しているか（役の喰い下がり表記に用いる。ドラでは無視される）
+    /// * `lang` - 言語
+    pub fn name(&self, has_opened: bool, lang: Lang) -> &'static str {
+        match self {
+            ScoreItem::Yaku(kind) => crate::winning_hand::name::get(*kind, has_opened, lang),
+            ScoreItem::Dora(label) => label.name(lang),
+        }
+    }
 }
 
 /// 点数の等級
@@ -171,6 +198,7 @@ pub fn calculate_score(
         non_dealer_tsumo_dealer,
         non_dealer_tsumo_non_dealer,
         yaku_list,
+        has_opened: status.has_claimed_open,
         fu_result,
     }))
 }
@@ -178,8 +206,8 @@ pub fn calculate_score(
 /// 役判定結果から成立した役のリストを抽出する
 fn extract_yaku_list(
     yaku_result: &HashMap<Kind, (&'static str, bool, u32)>,
-) -> Vec<(&'static str, u32)> {
-    let mut list: Vec<(&Kind, &'static str, u32)> = Vec::new();
+) -> Vec<(ScoreItem, u32)> {
+    let mut list: Vec<(&Kind, u32)> = Vec::new();
     let mut has_yakuman = false;
 
     // まず役満があるか確認
@@ -190,19 +218,21 @@ fn extract_yaku_list(
         }
     }
 
-    for (kind, (name, is_valid, han)) in yaku_result {
+    for (kind, (_name, is_valid, han)) in yaku_result {
         if *is_valid && *han > 0 {
             // 役満がある場合は通常役を除外
             if has_yakuman && *han < 13 {
                 continue;
             }
-            list.push((kind, name, *han));
+            list.push((kind, *han));
         }
     }
 
     // 翻数の昇順でソートし、同じ翻数の場合はKind列挙型の定義順でソート
-    list.sort_by(|a, b| a.2.cmp(&b.2).then(a.0.cmp(b.0)));
-    list.into_iter().map(|(_, name, han)| (name, han)).collect()
+    list.sort_by(|a, b| a.1.cmp(&b.1).then(a.0.cmp(b.0)));
+    list.into_iter()
+        .map(|(kind, han)| (ScoreItem::Yaku(*kind), han))
+        .collect()
 }
 
 /// 等級を決定する
@@ -550,8 +580,8 @@ mod tests {
             .unwrap()
             .unwrap();
         // 翻数昇順: 断么九(1翻) → 七対子(2翻)
-        assert_eq!(result.yaku_list[0], ("断么九", 1));
-        assert_eq!(result.yaku_list[1], ("七対子", 2));
+        assert_eq!(result.yaku_list[0], (ScoreItem::Yaku(Kind::AllInside), 1));
+        assert_eq!(result.yaku_list[1], (ScoreItem::Yaku(Kind::SevenPairs), 2));
     }
 
     /// 同翻の役はKind列挙型の定義順に並ぶ: 立直(Riichi)が平和(Pinfu)より先
@@ -569,9 +599,15 @@ mod tests {
         let result = calculate_score(&analyzer, &hand, &status, &settings)
             .unwrap()
             .unwrap();
-        let names: Vec<&str> = result.yaku_list.iter().map(|(n, _)| *n).collect();
-        let riichi_pos = names.iter().position(|&n| n == "立直").unwrap();
-        let pinfu_pos = names.iter().position(|&n| n == "平和").unwrap();
+        let items: Vec<ScoreItem> = result.yaku_list.iter().map(|(item, _)| *item).collect();
+        let riichi_pos = items
+            .iter()
+            .position(|&i| i == ScoreItem::Yaku(Kind::Riichi))
+            .unwrap();
+        let pinfu_pos = items
+            .iter()
+            .position(|&i| i == ScoreItem::Yaku(Kind::Pinfu))
+            .unwrap();
         assert!(riichi_pos < pinfu_pos, "立直はKind定義順で平和より先に来る");
     }
 

--- a/crates/mahjong-server/src/cpu/state.rs
+++ b/crates/mahjong-server/src/cpu/state.rs
@@ -425,6 +425,7 @@ mod tests {
     use super::*;
     use crate::protocol::{DrawReason, ServerEvent};
     use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
+    use mahjong_core::scoring::score::ScoreRank;
     use mahjong_core::tile::{Tile, Wind};
 
     #[test]
@@ -818,7 +819,8 @@ mod tests {
             han: 1,
             fu: 30,
             score_points: 1000,
-            rank_name: String::new(),
+            rank: ScoreRank::Normal,
+            has_opened: false,
             uradora_indicators: Vec::new(),
             riichi_sticks: 0,
             player_hands: Vec::new(),

--- a/crates/mahjong-server/src/protocol/mod.rs
+++ b/crates/mahjong-server/src/protocol/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod net;
 
+use mahjong_core::scoring::score::{ScoreItem, ScoreRank};
 use mahjong_core::tile::{Tile, Wind};
 use serde::{Deserialize, Serialize};
 
@@ -186,16 +187,18 @@ pub enum ServerEvent {
         winning_tile: Tile,
         /// 点数移動後の各プレイヤーの点数
         scores: [i32; 4],
-        /// 成立した役の一覧（役名, 翻数）
-        yaku_list: Vec<(String, u32)>,
+        /// 成立した役・ドラの一覧（項目, 翻数）。表示名はクライアントがローカライズする
+        yaku_list: Vec<(ScoreItem, u32)>,
         /// 翻数
         han: u32,
         /// 符
         fu: u32,
         /// 和了者が得た点数
         score_points: i32,
-        /// 点数等級名（満貫、跳満など。通常は空文字列）
-        rank_name: String,
+        /// 点数等級（満貫、跳満など。通常は `ScoreRank::Normal`）
+        rank: ScoreRank,
+        /// 和了手が副露していたか（役名の喰い下がり表記の再構築に用いる）
+        has_opened: bool,
         /// 裏ドラ表示牌（リーチ和了時のみ公開）
         uradora_indicators: Vec<Tile>,
         /// 和了前に場に出ていた供託リーチ棒の本数

--- a/crates/mahjong-server/src/protocol/net.rs
+++ b/crates/mahjong-server/src/protocol/net.rs
@@ -383,4 +383,36 @@ mod tests {
         assert!(ClientMessage::from_json("not json").is_err());
         assert!(ServerMessage::from_json("{\"Unknown\":{}}").is_err());
     }
+
+    /// RoundWon が構造化された役・ドラ・等級を保ったまま JSON ラウンドトリップできること
+    /// （i18n のため整形済み文字列ではなく enum を送る #242 の回帰テスト）
+    #[test]
+    fn test_round_won_structured_roundtrip() {
+        use mahjong_core::scoring::score::{DoraLabel, ScoreItem, ScoreRank};
+        use mahjong_core::winning_hand::name::Kind;
+
+        let msg = ServerMessage::Event(ServerEvent::RoundWon {
+            winner: Wind::East,
+            loser: Some(Wind::South),
+            winning_tile: Tile::new(Tile::M1),
+            scores: [35000, 15000, 25000, 25000],
+            yaku_list: vec![
+                (ScoreItem::Yaku(Kind::Riichi), 1),
+                (ScoreItem::Yaku(Kind::AllInside), 1),
+                (ScoreItem::Dora(DoraLabel::Dora), 2),
+                (ScoreItem::Dora(DoraLabel::RedDora), 1),
+            ],
+            han: 5,
+            fu: 40,
+            score_points: 8000,
+            rank: ScoreRank::Mangan,
+            has_opened: true,
+            uradora_indicators: vec![Tile::new(Tile::P3)],
+            riichi_sticks: 1,
+            player_hands: Vec::new(),
+        });
+
+        let decoded = roundtrip_server(msg.clone());
+        assert_eq!(format!("{:?}", decoded), format!("{:?}", msg));
+    }
 }

--- a/crates/mahjong-server/src/round/diagnostics.rs
+++ b/crates/mahjong-server/src/round/diagnostics.rs
@@ -3,6 +3,7 @@
 //! `#[cfg(debug_assertions)]` でのみ有効なログ出力機能。
 
 use mahjong_core::hand_info::hand_analyzer::HandAnalyzer;
+use mahjong_core::settings::Lang;
 
 use crate::scoring;
 
@@ -52,7 +53,9 @@ impl Round {
                         score
                             .yaku_list
                             .iter()
-                            .map(|(name, han)| format!("{}:{}", name, han))
+                            .map(|(item, han)| {
+                                format!("{}:{}", item.name(score.has_opened, Lang::Ja), han)
+                            })
                             .collect::<Vec<_>>()
                             .join(",")
                     })

--- a/crates/mahjong-server/src/round/mod.rs
+++ b/crates/mahjong-server/src/round/mod.rs
@@ -786,13 +786,9 @@ impl Round {
         // 各和了者にRoundWonイベントを送信
         for (idx, wd) in winner_data.iter().enumerate() {
             let winner_wind = self.players[wd.winner].seat_wind;
-            let yaku_list: Vec<(String, u32)> = wd
-                .score_result
-                .yaku_list
-                .iter()
-                .map(|(name, han)| (name.to_string(), *han))
-                .collect();
-            let rank_name = scoring::rank_to_string(&wd.score_result.rank).to_string();
+            let yaku_list = wd.score_result.yaku_list.clone();
+            let rank = wd.score_result.rank;
+            let has_opened = wd.score_result.has_opened;
             let event_riichi_sticks = if idx == 0 { riichi_sticks } else { 0 };
 
             for i in 0..4 {
@@ -807,7 +803,8 @@ impl Round {
                         han: wd.score_result.han,
                         fu: wd.score_result.fu,
                         score_points: wd.score_points,
-                        rank_name: rank_name.clone(),
+                        rank,
+                        has_opened,
                         uradora_indicators: wd.uradora_indicators.clone(),
                         riichi_sticks: event_riichi_sticks,
                         player_hands: player_hands.clone(),
@@ -1462,12 +1459,9 @@ impl Round {
         let winner_wind = self.players[winner].seat_wind;
 
         // 役情報を構築
-        let yaku_list: Vec<(String, u32)> = score_result
-            .yaku_list
-            .iter()
-            .map(|(name, han)| (name.to_string(), *han))
-            .collect();
-        let rank_name = scoring::rank_to_string(&score_result.rank).to_string();
+        let yaku_list = score_result.yaku_list.clone();
+        let rank = score_result.rank;
+        let has_opened = score_result.has_opened;
         let player_hands = self.build_player_hands();
 
         // 全プレイヤーに和了イベントを送信
@@ -1483,7 +1477,8 @@ impl Round {
                     han: score_result.han,
                     fu: score_result.fu,
                     score_points: deltas[winner] + (riichi_sticks as i32) * RIICHI_STICK_VALUE,
-                    rank_name: rank_name.clone(),
+                    rank,
+                    has_opened,
                     uradora_indicators: uradora_indicators.clone(),
                     riichi_sticks,
                     player_hands: player_hands.clone(),

--- a/crates/mahjong-server/src/scoring.rs
+++ b/crates/mahjong-server/src/scoring.rs
@@ -8,7 +8,8 @@ use mahjong_core::hand::Hand;
 use mahjong_core::hand_info::hand_analyzer::{self, HandAnalyzer};
 use mahjong_core::hand_info::status::Status;
 use mahjong_core::scoring::score::{
-    ScoreRank, ScoreResult, calculate_base_points, calculate_score, determine_rank, round_up_to_100,
+    DoraLabel, ScoreItem, ScoreResult, calculate_base_points, calculate_score, determine_rank,
+    round_up_to_100,
 };
 use mahjong_core::settings::Settings;
 use mahjong_core::tile::{Tile, TileType, Wind, dora_indicator_to_dora};
@@ -271,18 +272,6 @@ pub fn calculate_tsumo_score_deltas(
     deltas
 }
 
-/// 点数等級を日本語文字列に変換する
-pub fn rank_to_string(rank: &ScoreRank) -> &'static str {
-    match rank {
-        ScoreRank::Normal => "",
-        ScoreRank::Mangan => "満貫",
-        ScoreRank::Haneman => "跳満",
-        ScoreRank::Baiman => "倍満",
-        ScoreRank::Sanbaiman => "三倍満",
-        ScoreRank::Yakuman => "役満",
-    }
-}
-
 /// 和了結果にドラ・赤ドラ・裏ドラの翻を加算する
 ///
 /// 役判定後の点数計算結果にドラ関連の翻を追加し、
@@ -354,13 +343,19 @@ pub fn add_dora_to_score(
 
     // ドラ・赤ドラ・裏ドラをこの順で末尾に追加
     if dora_count > 0 {
-        score_result.yaku_list.push(("ドラ", dora_count));
+        score_result
+            .yaku_list
+            .push((ScoreItem::Dora(DoraLabel::Dora), dora_count));
     }
     if red_dora_count > 0 {
-        score_result.yaku_list.push(("赤ドラ", red_dora_count));
+        score_result
+            .yaku_list
+            .push((ScoreItem::Dora(DoraLabel::RedDora), red_dora_count));
     }
     if uradora_count > 0 {
-        score_result.yaku_list.push(("裏ドラ", uradora_count));
+        score_result
+            .yaku_list
+            .push((ScoreItem::Dora(DoraLabel::UraDora), uradora_count));
     }
 }
 
@@ -406,8 +401,9 @@ mod tests {
     use mahjong_core::hand::Hand;
     use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
     use mahjong_core::scoring::fu::{FuDetail, FuResult};
-    use mahjong_core::scoring::score::ScoreRank;
+    use mahjong_core::scoring::score::{DoraLabel, ScoreItem, ScoreRank};
     use mahjong_core::tile::Tile;
+    use mahjong_core::winning_hand::name::Kind;
 
     fn make_mangan_score() -> ScoreResult {
         ScoreResult {
@@ -420,6 +416,7 @@ mod tests {
             non_dealer_tsumo_dealer: 4000,
             non_dealer_tsumo_non_dealer: 2000,
             yaku_list: vec![],
+            has_opened: false,
             fu_result: FuResult {
                 total: 30,
                 details: vec![FuDetail {
@@ -669,7 +666,8 @@ mod tests {
             non_dealer_ron: 1000,
             non_dealer_tsumo_dealer: 500,
             non_dealer_tsumo_non_dealer: 300,
-            yaku_list: vec![("断么九", 1)],
+            yaku_list: vec![(ScoreItem::Yaku(Kind::AllInside), 1)],
+            has_opened: false,
             fu_result,
         };
 
@@ -707,10 +705,10 @@ mod tests {
         );
 
         assert_eq!(score.yaku_list.len(), 4);
-        assert_eq!(score.yaku_list[0], ("断么九", 1));
-        assert_eq!(score.yaku_list[1], ("ドラ", 1));
-        assert_eq!(score.yaku_list[2], ("赤ドラ", 1));
-        assert_eq!(score.yaku_list[3], ("裏ドラ", 1));
+        assert_eq!(score.yaku_list[0], (ScoreItem::Yaku(Kind::AllInside), 1));
+        assert_eq!(score.yaku_list[1], (ScoreItem::Dora(DoraLabel::Dora), 1));
+        assert_eq!(score.yaku_list[2], (ScoreItem::Dora(DoraLabel::RedDora), 1));
+        assert_eq!(score.yaku_list[3], (ScoreItem::Dora(DoraLabel::UraDora), 1));
     }
 
     #[test]
@@ -731,7 +729,8 @@ mod tests {
             non_dealer_ron: 1000,
             non_dealer_tsumo_dealer: 500,
             non_dealer_tsumo_non_dealer: 300,
-            yaku_list: vec![("立直", 1)],
+            yaku_list: vec![(ScoreItem::Yaku(Kind::Riichi), 1)],
+            has_opened: false,
             fu_result,
         };
         let hand = Hand::new_with_melds(
@@ -747,7 +746,10 @@ mod tests {
 
         add_dora_to_score(&mut score, &hand, None, &[], &[]);
 
-        assert_eq!(score.yaku_list.last(), Some(&("赤ドラ", 1)));
+        assert_eq!(
+            score.yaku_list.last(),
+            Some(&(ScoreItem::Dora(DoraLabel::RedDora), 1))
+        );
         assert_eq!(score.han, 2);
     }
 
@@ -769,7 +771,8 @@ mod tests {
             non_dealer_ron: 1000,
             non_dealer_tsumo_dealer: 500,
             non_dealer_tsumo_non_dealer: 300,
-            yaku_list: vec![("立直", 1)],
+            yaku_list: vec![(ScoreItem::Yaku(Kind::Riichi), 1)],
+            has_opened: false,
             fu_result,
         };
         let hand = Hand::new_with_melds(
@@ -789,7 +792,10 @@ mod tests {
 
         add_dora_to_score(&mut score, &hand, None, &[], &[]);
 
-        assert_eq!(score.yaku_list.last(), Some(&("赤ドラ", 1)));
+        assert_eq!(
+            score.yaku_list.last(),
+            Some(&(ScoreItem::Dora(DoraLabel::RedDora), 1))
+        );
         assert_eq!(score.han, 2);
     }
 }


### PR DESCRIPTION
## Summary
Part 2 of 3 of the client internationalization work (#242). Stops the server from
baking Japanese strings into `RoundWon` and sends the result as structured data so
each client can localize it independently (essential for online play, where
opponents may use different languages).

> Stacked on top of `feat/#242-core-i18n-primitives` (PR part 1). Review/merge that first.

## Changes
- Add `ScoreItem` (`Yaku(Kind)` | `Dora(DoraLabel)`) in `mahjong-core`; use it for
  `ScoreResult::yaku_list`. Add `ScoreResult::has_opened` so the open/closed yaku
  name suffix can be reconstructed on the client. `ScoreItem::name(has_opened, lang)`
  centralizes resolution.
- `protocol::ServerEvent::RoundWon` now carries `Vec<(ScoreItem, u32)>`,
  `rank: ScoreRank`, and `has_opened: bool` instead of pre-formatted strings; drop
  the now-unused `scoring::rank_to_string`.
- Server `round`/`scoring`/`diagnostics` build the structured event; the client
  resolves it to Japanese for display (the live language switch arrives in part 3,
  so output is unchanged here).
- Regression test: `RoundWon` survives a JSON round-trip with structured
  yaku/dora/rank.

## Test plan
- `cargo test` (workspace green)
- `cargo clippy` / `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
