### PR TITLE
喰い替え（kuikae / swap-calling）禁止ルールの実装 (#247)

### DIFF
--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -199,6 +199,11 @@ pub struct GameState {
     pub riichi_selectable_tiles: Vec<usize>,
     /// ツモ牌切りでリーチ可能か
     pub riichi_selectable_drawn: bool,
+    /// 喰い替え禁止により、鳴き直後の打牌で捨てられない牌種
+    /// （チー・ポン直後にのみ設定され、打牌・ツモで解除される）
+    pub forbidden_discards: Vec<TileType>,
+    /// 喰い替え禁止牌を選択しようとしたか（「喰い替えです！」警告の表示用）
+    pub selected_forbidden_swap: bool,
     /// 局の結果メッセージ
     pub result_message: Option<String>,
     /// 和了結果一覧（ダブロン・トリロン時は複数）
@@ -408,6 +413,8 @@ impl GameState {
             riichi_selection_mode: false,
             riichi_selectable_tiles: Vec::new(),
             riichi_selectable_drawn: false,
+            forbidden_discards: Vec::new(),
+            selected_forbidden_swap: false,
             result_message: None,
             win_results: Vec::new(),
             win_result_index: 0,
@@ -555,6 +562,9 @@ impl GameState {
                 self.available_calls.clear();
                 self.call_target_tile = None;
                 self.refresh_self_kan_options();
+                // ツモ後は喰い替え制限が解除される
+                self.forbidden_discards.clear();
+                self.selected_forbidden_swap = false;
             }
 
             ServerEvent::NineTerminalsAvailable => {
@@ -609,6 +619,9 @@ impl GameState {
                     self.selected_drawn = false;
                     self.clear_riichi_selection();
                     self.self_kan_options.clear();
+                    // 打牌が完了したので喰い替え制限を解除する
+                    self.forbidden_discards.clear();
+                    self.selected_forbidden_swap = false;
                 }
             }
 
@@ -740,6 +753,16 @@ impl GameState {
                             self.drawn = None;
                             self.clear_riichi_selection();
                             self.self_kan_options.clear();
+                            // チー・ポン直後の打牌では喰い替え牌を捨てられない。
+                            // （大明槓は嶺上ツモになるため対象外）
+                            self.forbidden_discards = match call_type {
+                                CallType::Pon | CallType::Chi => self
+                                    .melds
+                                    .last()
+                                    .map(|meld| meld.forbidden_swap_tiles())
+                                    .unwrap_or_default(),
+                                _ => Vec::new(),
+                            };
                         }
                         CallType::Ankan => {
                             self.melds.push(Meld {
@@ -1390,6 +1413,16 @@ impl GameState {
                     return None;
                 }
 
+                // 喰い替え禁止牌は打牌できない。選択された見た目（少し上に表示）に
+                // しつつ「喰い替えです！」警告を出し、打牌アクションは発行しない。
+                if self.forbidden_discards.contains(&self.hand[i].get()) {
+                    self.selected_tile = Some(i);
+                    self.selected_drawn = false;
+                    self.selected_would_cause_furiten = false;
+                    self.selected_forbidden_swap = true;
+                    return None;
+                }
+
                 if self.selected_tile == Some(i) {
                     let discarded_tile = self.apply_local_discard_from_hand(i);
                     if self.riichi_selection_mode {
@@ -1405,6 +1438,7 @@ impl GameState {
 
                 self.selected_tile = Some(i);
                 self.selected_drawn = false;
+                self.selected_forbidden_swap = false;
                 self.selected_would_cause_furiten =
                     self.would_discard_cause_furiten(Some(self.hand[i]));
                 return None;
@@ -1430,6 +1464,7 @@ impl GameState {
 
                 self.selected_drawn = true;
                 self.selected_tile = None;
+                self.selected_forbidden_swap = false;
                 self.selected_would_cause_furiten = self.would_discard_cause_furiten(None);
                 return None;
             }
@@ -1584,6 +1619,69 @@ mod tests {
             tiles: vec![Tile::new(Tile::S6), Tile::new(Tile::S7)],
         });
         assert!(state.discards[1][0].is_called);
+    }
+
+    #[test]
+    fn test_self_chi_sets_forbidden_swap_discards_and_clears_on_discard() {
+        let mut state = GameState::new();
+        state.seat_wind = Some(Wind::East);
+        state.last_discarder = Some(Wind::North);
+
+        // 上家が捨てた 3m を 4m,5m でチー（順子 3-4-5）
+        state.handle_event(ServerEvent::PlayerCalled {
+            player: Wind::East,
+            call_type: CallType::Chi,
+            called_tile: Tile::new(Tile::M3),
+            tiles: vec![
+                Tile::new(Tile::M3),
+                Tile::new(Tile::M4),
+                Tile::new(Tile::M5),
+            ],
+        });
+
+        // 現物(3m)とスジ(6m)が打牌禁止になる
+        assert!(state.forbidden_discards.contains(&Tile::M3));
+        assert!(state.forbidden_discards.contains(&Tile::M6));
+
+        // 打牌が完了すると制限が解除される
+        state.handle_event(ServerEvent::TileDiscarded {
+            player: Wind::East,
+            tile: Tile::new(Tile::P1),
+            is_tsumogiri: false,
+        });
+        assert!(state.forbidden_discards.is_empty());
+    }
+
+    #[test]
+    fn test_self_pon_forbids_only_called_tile() {
+        let mut state = GameState::new();
+        state.seat_wind = Some(Wind::East);
+        state.last_discarder = Some(Wind::North);
+
+        state.handle_event(ServerEvent::PlayerCalled {
+            player: Wind::East,
+            call_type: CallType::Pon,
+            called_tile: Tile::new(Tile::S1),
+            tiles: vec![Tile::new(Tile::S1); 3],
+        });
+
+        assert_eq!(state.forbidden_discards, vec![Tile::S1]);
+    }
+
+    #[test]
+    fn test_self_daiminkan_has_no_forbidden_discards() {
+        let mut state = GameState::new();
+        state.seat_wind = Some(Wind::East);
+        state.last_discarder = Some(Wind::North);
+
+        state.handle_event(ServerEvent::PlayerCalled {
+            player: Wind::East,
+            call_type: CallType::Daiminkan,
+            called_tile: Tile::new(Tile::S1),
+            tiles: vec![Tile::new(Tile::S1); 4],
+        });
+
+        assert!(state.forbidden_discards.is_empty());
     }
 
     #[test]

--- a/crates/mahjong-client/src/i18n/mod.rs
+++ b/crates/mahjong-client/src/i18n/mod.rs
@@ -294,6 +294,8 @@ pub enum Key {
     SelectDiscard,
     /// 選択牌で振聴になる警告バッジ
     WillBeFuriten,
+    /// 禁止牌を選択したときの「喰い替えです！」警告バッジ
+    IsSwapCalling,
     /// ツモ（自摸和了／ツモ牌ラベル）
     Tsumo,
     /// ロン（出和了）
@@ -435,6 +437,10 @@ impl Key {
             Key::WillBeFuriten => match lang {
                 Lang::Ja => "振聴になります！",
                 Lang::En => "Will cause furiten!",
+            },
+            Key::IsSwapCalling => match lang {
+                Lang::Ja => "喰い替えです！",
+                Lang::En => "That's swap-calling!",
             },
             Key::Tsumo => match lang {
                 Lang::Ja => "ツモ",

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -757,9 +757,61 @@ fn draw_badge(
 fn draw_hand(state: &GameState, font: Option<&Font>, tile_textures: &TileTextures) {
     let hand_start_x = player_hand_start_x(state.hand.len());
     let hand_y = HAND_Y;
-
-    // 状態バッジ（フリテン・リーチ中・リーチ打牌選択中）
     let tr = state.tr();
+
+    // 先に手牌を描画する（バッジは牌に隠れないよう後で描画する）。
+    for (i, tile) in state.hand.iter().enumerate() {
+        let x = hand_start_x + i as f32 * TILE_W;
+        let selected = state.selected_tile == Some(i);
+        let riichi_selectable =
+            state.riichi_selection_mode && state.riichi_selectable_tiles.contains(&i);
+        let y_offset = if selected { -14.0 } else { 0.0 };
+        let riichi_disabled = state.riichi_selection_mode && !riichi_selectable;
+        // 喰い替え禁止牌は打牌できないので無効表示する
+        let swap_forbidden = state.forbidden_discards.contains(&tile.get());
+        if selected {
+            draw_tile_highlight(x, hand_y + y_offset);
+        }
+        draw_tile(
+            x,
+            hand_y + y_offset,
+            tile,
+            riichi_disabled || swap_forbidden,
+            tile_textures,
+        );
+    }
+
+    if let Some(drawn) = &state.drawn {
+        let drawn_x = hand_start_x + state.hand.len() as f32 * TILE_W + DRAWN_GAP;
+        let selected = state.selected_drawn;
+        let riichi_selectable = state.riichi_selection_mode && state.riichi_selectable_drawn;
+        let y_offset = if selected { -14.0 } else { 0.0 };
+        let riichi_disabled = state.riichi_selection_mode && !riichi_selectable;
+
+        // 「ツモ」ラベル
+        theme::draw_text_centered(
+            font,
+            tr.get(Key::Tsumo),
+            drawn_x + TILE_W / 2.0,
+            hand_y + y_offset - 8.0,
+            11,
+            theme::GOLD_LT,
+        );
+
+        if selected {
+            draw_tile_highlight(drawn_x, hand_y + y_offset);
+        }
+        draw_tile(
+            drawn_x,
+            hand_y + y_offset,
+            drawn,
+            riichi_disabled,
+            tile_textures,
+        );
+    }
+
+    // 状態バッジ（フリテン・リーチ中・リーチ打牌選択中・喰い替え警告）は
+    // 牌に隠れないよう、手牌を描画したあとに重ねて描く。
     let badge_y = hand_y - 26.0;
     let mut bx = hand_start_x;
     if state.is_furiten {
@@ -795,6 +847,17 @@ fn draw_hand(state: &GameState, font: Option<&Font>, tile_textures: &TileTexture
             theme::GOLD_LT,
         );
     }
+    if state.selected_forbidden_swap {
+        bx = draw_badge(
+            font,
+            bx,
+            badge_y,
+            tr.get(Key::IsSwapCalling),
+            theme::rgba(0xcc2828, 0.18),
+            theme::RED,
+            theme::RED_LT,
+        );
+    }
     if state.selected_would_cause_furiten && (state.selected_tile.is_some() || state.selected_drawn)
     {
         draw_badge(
@@ -805,48 +868,6 @@ fn draw_hand(state: &GameState, font: Option<&Font>, tile_textures: &TileTexture
             theme::rgba(0xcc6411, 0.18),
             theme::rgba(0xe88a1a, 0.6),
             Color::new(1.0, 0.7, 0.3, 1.0),
-        );
-    }
-
-    for (i, tile) in state.hand.iter().enumerate() {
-        let x = hand_start_x + i as f32 * TILE_W;
-        let selected = state.selected_tile == Some(i);
-        let riichi_selectable =
-            state.riichi_selection_mode && state.riichi_selectable_tiles.contains(&i);
-        let y_offset = if selected { -14.0 } else { 0.0 };
-        let riichi_disabled = state.riichi_selection_mode && !riichi_selectable;
-        if selected {
-            draw_tile_highlight(x, hand_y + y_offset);
-        }
-        draw_tile(x, hand_y + y_offset, tile, riichi_disabled, tile_textures);
-    }
-
-    if let Some(drawn) = &state.drawn {
-        let drawn_x = hand_start_x + state.hand.len() as f32 * TILE_W + DRAWN_GAP;
-        let selected = state.selected_drawn;
-        let riichi_selectable = state.riichi_selection_mode && state.riichi_selectable_drawn;
-        let y_offset = if selected { -14.0 } else { 0.0 };
-        let riichi_disabled = state.riichi_selection_mode && !riichi_selectable;
-
-        // 「ツモ」ラベル
-        theme::draw_text_centered(
-            font,
-            tr.get(Key::Tsumo),
-            drawn_x + TILE_W / 2.0,
-            hand_y + y_offset - 8.0,
-            11,
-            theme::GOLD_LT,
-        );
-
-        if selected {
-            draw_tile_highlight(drawn_x, hand_y + y_offset);
-        }
-        draw_tile(
-            drawn_x,
-            hand_y + y_offset,
-            drawn,
-            riichi_disabled,
-            tile_textures,
         );
     }
 }

--- a/crates/mahjong-core/src/hand_info/meld.rs
+++ b/crates/mahjong-core/src/hand_info/meld.rs
@@ -78,4 +78,137 @@ impl Meld {
         }
         tiles
     }
+
+    /// 喰い替え（swap-calling）で、この副露の直後に打牌が禁止される牌種を返す。
+    ///
+    /// - ポン: 鳴いた牌と同種（現物喰い替え）。
+    /// - チー: 鳴いた牌と同種（現物喰い替え）に加え、鳴いた牌が順子の端にある場合は
+    ///   反対側の外側の牌（スジ喰い替え）。
+    ///   例: 4-5 を持ち 3 をチー（順子 3-4-5） → 6 を禁止。
+    ///   5-6 を持ち 7 をチー（順子 5-6-7） → 4 を禁止。
+    ///   鳴いた牌が順子の中央（嵌張）の場合はスジ喰い替えは発生しない。
+    /// - カン系・暗カン: 喰い替えは発生しないため空を返す。
+    pub fn forbidden_swap_tiles(&self) -> Vec<TileType> {
+        let Some(called) = self.called_tile else {
+            return Vec::new();
+        };
+        let called_tt = called.get();
+
+        match self.category {
+            MeldType::Pon => vec![called_tt],
+            MeldType::Chi => {
+                // 現物喰い替え（鳴いた牌と同種）は常に禁止
+                let mut forbidden = vec![called_tt];
+
+                // self.tiles はソート済みの順子 [low, low+1, low+2]
+                let low = self.tiles[0].get();
+                let high = self.tiles[2].get();
+                let suit_start = (called_tt / 9) * 9;
+                let suit_end = suit_start + 9;
+
+                if called_tt == low && high + 1 < suit_end {
+                    // 鳴いた牌が下端: 上端の1つ上を禁止（例: 3 をチーして 4-5 使用 → 6）
+                    forbidden.push(high + 1);
+                } else if called_tt == high && low > suit_start {
+                    // 鳴いた牌が上端: 下端の1つ下を禁止（例: 7 をチーして 5-6 使用 → 4）
+                    forbidden.push(low - 1);
+                }
+
+                forbidden
+            }
+            MeldType::Kan | MeldType::Kakan => Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chi(tiles: [TileType; 3], called: TileType) -> Meld {
+        Meld {
+            tiles: tiles.iter().map(|&t| Tile::new(t)).collect(),
+            category: MeldType::Chi,
+            from: MeldFrom::Previous,
+            called_tile: Some(Tile::new(called)),
+        }
+    }
+
+    #[test]
+    fn pon_forbids_only_the_called_tile() {
+        let meld = Meld {
+            tiles: vec![Tile::new(Tile::S1); 3],
+            category: MeldType::Pon,
+            from: MeldFrom::Opposite,
+            called_tile: Some(Tile::new(Tile::S1)),
+        };
+        assert_eq!(meld.forbidden_swap_tiles(), vec![Tile::S1]);
+    }
+
+    #[test]
+    fn chi_low_end_forbids_genbutsu_and_upper_suji() {
+        // 4-5 を持ち 3 をチー（順子 3-4-5）→ 3（現物）と 6（スジ）を禁止
+        let meld = chi([Tile::M3, Tile::M4, Tile::M5], Tile::M3);
+        let forbidden = meld.forbidden_swap_tiles();
+        assert!(forbidden.contains(&Tile::M3));
+        assert!(forbidden.contains(&Tile::M6));
+        assert_eq!(forbidden.len(), 2);
+    }
+
+    #[test]
+    fn chi_high_end_forbids_genbutsu_and_lower_suji() {
+        // 5-6 を持ち 7 をチー（順子 5-6-7）→ 7（現物）と 4（スジ）を禁止
+        let meld = chi([Tile::M5, Tile::M6, Tile::M7], Tile::M7);
+        let forbidden = meld.forbidden_swap_tiles();
+        assert!(forbidden.contains(&Tile::M7));
+        assert!(forbidden.contains(&Tile::M4));
+        assert_eq!(forbidden.len(), 2);
+    }
+
+    #[test]
+    fn chi_middle_forbids_only_genbutsu() {
+        // 4-6 を持ち 5 をチー（嵌張 4-5-6）→ 5（現物）のみ禁止、スジ喰い替えなし
+        let meld = chi([Tile::M4, Tile::M5, Tile::M6], Tile::M5);
+        assert_eq!(meld.forbidden_swap_tiles(), vec![Tile::M5]);
+    }
+
+    #[test]
+    fn chi_suji_does_not_cross_suit_boundary() {
+        // 8-9p を持ち 7p をチー（順子 7-8-9p）→ スジ側(10p)は存在しないので 7p のみ
+        let meld = chi([Tile::P7, Tile::P8, Tile::P9], Tile::P7);
+        assert_eq!(meld.forbidden_swap_tiles(), vec![Tile::P7]);
+
+        // 1-2s を持ち 3s をチー（順子 1-2-3s）→ スジ側(0s)は存在しないので 3s のみ
+        let meld = chi([Tile::S1, Tile::S2, Tile::S3], Tile::S3);
+        assert_eq!(meld.forbidden_swap_tiles(), vec![Tile::S3]);
+    }
+
+    #[test]
+    fn red_five_called_tile_normalizes_to_tile_type() {
+        // 赤5を含むチーでも、禁止は牌種で判定する
+        let meld = Meld {
+            tiles: vec![
+                Tile::new(Tile::M3),
+                Tile::new(Tile::M4),
+                Tile::new_red(Tile::M5),
+            ],
+            category: MeldType::Chi,
+            from: MeldFrom::Previous,
+            called_tile: Some(Tile::new(Tile::M3)),
+        };
+        let forbidden = meld.forbidden_swap_tiles();
+        assert!(forbidden.contains(&Tile::M3));
+        assert!(forbidden.contains(&Tile::M6));
+    }
+
+    #[test]
+    fn kan_has_no_swap_restriction() {
+        let meld = Meld {
+            tiles: vec![Tile::new(Tile::M1); 3],
+            category: MeldType::Kan,
+            from: MeldFrom::Myself,
+            called_tile: None,
+        };
+        assert!(meld.forbidden_swap_tiles().is_empty());
+    }
 }

--- a/crates/mahjong-core/src/settings.rs
+++ b/crates/mahjong-core/src/settings.rs
@@ -37,6 +37,10 @@ pub struct Settings {
     /// なしの場合: 打順が最も早い1人のみ和了を認める（上家取り）
     /// ※ triple_ron_draw=true かつ 3人ロンの場合は、こちらより三家和流局が優先される
     pub multiple_ron: bool,
+    /// 喰い替え禁止ありかなしか（デフォルトはあり＝禁止する）
+    /// ありの場合: チー・ポン直後の打牌で、鳴いた牌と同種（現物喰い替え）や
+    /// チーで作った順子の反対端の牌（スジ喰い替え）を捨てられない
+    pub forbid_swap_calling: bool,
 }
 
 impl Default for Settings {
@@ -56,6 +60,7 @@ impl Settings {
             nine_terminals_draw: true,
             triple_ron_draw: false,
             multiple_ron: true,
+            forbid_swap_calling: true,
         }
     }
 }

--- a/crates/mahjong-server/src/cpu/client.rs
+++ b/crates/mahjong-server/src/cpu/client.rs
@@ -246,15 +246,32 @@ impl CpuClient {
 
     /// 鳴き後の打牌を選択する
     fn decide_discard_after_call(&self) -> ClientAction {
+        // 喰い替え禁止牌（直前の鳴きが対象）。これらは捨てるとサーバに拒否されるため除外する。
+        let forbidden = self
+            .state
+            .my_melds()
+            .last()
+            .map(|meld| meld.forbidden_swap_tiles())
+            .unwrap_or_default();
+
         // 鳴き後はツモ牌がないので、手牌から選ぶ
-        let candidates = evaluator::evaluate_discards(&self.state, &self.config);
+        let candidates: Vec<_> = evaluator::evaluate_discards(&self.state, &self.config)
+            .into_iter()
+            .filter(|c| !forbidden.contains(&c.tile.get()))
+            .collect();
         let attacking = self.should_attack();
 
         if let Some(tile) =
             evaluator::select_best_discard(&candidates, &self.config, attacking, &self.state)
         {
             ClientAction::Discard { tile: Some(tile) }
-        } else if let Some(&tile) = self.state.my_hand.last() {
+        } else if let Some(&tile) = self
+            .state
+            .my_hand
+            .iter()
+            .rev()
+            .find(|t| !forbidden.contains(&t.get()))
+        {
             ClientAction::Discard { tile: Some(tile) }
         } else {
             ClientAction::Discard { tile: None }

--- a/crates/mahjong-server/src/player.rs
+++ b/crates/mahjong-server/src/player.rs
@@ -33,6 +33,9 @@ pub struct Player {
     pub is_riichi_furiten: bool,
     /// 同巡フリテン（ロン見逃し → 自分のツモ番で解除）
     pub is_temporary_furiten: bool,
+    /// 喰い替え禁止により、直後の打牌で捨てられない牌種
+    /// （チー・ポン直後にのみ設定され、打牌またはツモで解除される）
+    forbidden_discards: Vec<TileType>,
 }
 
 /// 捨て牌1枚の情報
@@ -64,18 +67,38 @@ impl Player {
             first_turn_interrupted: false,
             is_riichi_furiten: false,
             is_temporary_furiten: false,
+            forbidden_discards: Vec::new(),
         }
     }
 
     /// ツモ牌をセットする
     pub fn draw(&mut self, tile: Tile) {
         self.hand.set_drawn(Some(tile));
+        // ツモ後は喰い替え制限が解除される（鳴き直後の打牌のみが対象のため）
+        self.forbidden_discards.clear();
+    }
+
+    /// 喰い替え禁止で次の打牌に限り捨てられない牌種を設定する
+    pub fn set_forbidden_discards(&mut self, tile_types: Vec<TileType>) {
+        self.forbidden_discards = tile_types;
+    }
+
+    /// 指定牌が喰い替え禁止により打牌できないかを返す
+    pub fn is_swap_call_forbidden(&self, tile: Tile) -> bool {
+        self.forbidden_discards.contains(&tile.get())
     }
 
     /// 手牌から指定牌を捨てる
     /// tile が Some(牌) なら手牌からその牌を探して捨てる（手出し）
     /// tile が None ならツモ切り
     pub fn try_discard(&mut self, tile: Option<Tile>) -> Option<Tile> {
+        // 喰い替え禁止: 鳴き直後に禁止された牌種は捨てられない
+        if let Some(target) = tile
+            && self.is_swap_call_forbidden(target)
+        {
+            return None;
+        }
+
         let drawn = self.hand.drawn();
 
         let (discarded, is_tsumogiri) = match tile {
@@ -112,6 +135,8 @@ impl Player {
 
         self.is_ippatsu = false;
         self.is_first_turn = false;
+        // 鳴き直後の打牌が完了したので喰い替え制限を解除する
+        self.forbidden_discards.clear();
 
         Some(discarded)
     }
@@ -981,5 +1006,42 @@ mod tests {
     fn test_is_furiten_none() {
         let player = Player::new(Wind::East, make_test_tiles(), 25000);
         assert!(!player.is_furiten());
+    }
+
+    #[test]
+    fn test_forbidden_discard_is_rejected() {
+        let mut player = Player::new(Wind::East, make_test_tiles(), 25000);
+        // 1m を喰い替え禁止に設定
+        player.set_forbidden_discards(vec![Tile::M1]);
+
+        assert!(player.is_swap_call_forbidden(Tile::new(Tile::M1)));
+        // 禁止牌の打牌は拒否され、手牌は変化しない
+        assert!(player.try_discard(Some(Tile::new(Tile::M1))).is_none());
+        assert_eq!(player.hand.tiles().len(), 13);
+        assert!(player.discards.is_empty());
+    }
+
+    #[test]
+    fn test_non_forbidden_discard_still_allowed_then_clears() {
+        let mut player = Player::new(Wind::East, make_test_tiles(), 25000);
+        player.set_forbidden_discards(vec![Tile::M1]);
+
+        // 禁止されていない牌は通常どおり捨てられる
+        let discarded = player.try_discard(Some(Tile::new(Tile::M2)));
+        assert_eq!(discarded.map(|t| t.get()), Some(Tile::M2));
+        // 打牌完了で制限が解除され、以後は 1m も捨てられる
+        assert!(!player.is_swap_call_forbidden(Tile::new(Tile::M1)));
+        assert_eq!(player.discard(Some(Tile::new(Tile::M1))).get(), Tile::M1);
+    }
+
+    #[test]
+    fn test_draw_clears_forbidden_discards() {
+        let mut player = Player::new(Wind::East, make_test_tiles(), 25000);
+        player.set_forbidden_discards(vec![Tile::M1]);
+
+        // ツモで喰い替え制限は解除される
+        player.draw(Tile::new(Tile::Z5));
+        assert!(!player.is_swap_call_forbidden(Tile::new(Tile::M1)));
+        assert_eq!(player.discard(Some(Tile::new(Tile::M1))).get(), Tile::M1);
     }
 }

--- a/crates/mahjong-server/src/round/mod.rs
+++ b/crates/mahjong-server/src/round/mod.rs
@@ -868,7 +868,8 @@ impl Round {
             },
         ));
 
-        // ポンしたプレイヤーの打牌待ちへ
+        // 喰い替え禁止牌を設定し、ポンしたプレイヤーの打牌待ちへ
+        self.apply_swap_call_restriction(caller);
         self.current_player = caller;
         self.phase = TurnPhase::WaitForDiscard;
     }
@@ -955,9 +956,24 @@ impl Round {
             },
         ));
 
-        // チーしたプレイヤーの打牌待ちへ
+        // 喰い替え禁止牌を設定し、チーしたプレイヤーの打牌待ちへ
+        self.apply_swap_call_restriction(caller);
         self.current_player = caller;
         self.phase = TurnPhase::WaitForDiscard;
+    }
+
+    /// チー・ポン直後の喰い替え禁止牌を、設定が有効なら当該プレイヤーに設定する
+    fn apply_swap_call_restriction(&mut self, caller: usize) {
+        if !self.settings.forbid_swap_calling {
+            return;
+        }
+        let forbidden = self.players[caller]
+            .hand
+            .melds()
+            .last()
+            .map(|meld| meld.forbidden_swap_tiles())
+            .unwrap_or_default();
+        self.players[caller].set_forbidden_discards(forbidden);
     }
 
     fn execute_kakan(&mut self, caller: usize, tile_type: TileType) {

--- a/crates/mahjong-server/src/round/tests.rs
+++ b/crates/mahjong-server/src/round/tests.rs
@@ -1239,3 +1239,86 @@ fn test_auto_pass_cpu_skips_human_player() {
     );
     assert_eq!(round.phase, TurnPhase::WaitForCalls);
 }
+
+// ===== 喰い替え禁止（#247） =====
+
+use mahjong_core::hand::Hand;
+
+#[test]
+fn test_swap_calling_forbids_genbutsu_after_chi() {
+    let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
+    // 3m4m5m を含む手牌。捨てられた 3m を [4m,5m] でチーすると 3m が手牌に残る。
+    round.players[1].hand = Hand::from("345m234567p678s1z");
+
+    round.execute_chi(
+        1,
+        0,
+        Tile::new(Tile::M3),
+        [Tile::new(Tile::M4), Tile::new(Tile::M5)],
+    );
+
+    assert_eq!(round.current_player, 1);
+    assert_eq!(round.phase, TurnPhase::WaitForDiscard);
+    // 現物喰い替え（鳴いた 3m と同種）の打牌は拒否される
+    assert!(!round.do_discard(Some(Tile::new(Tile::M3))));
+    // 喰い替えにならない打牌は許可される
+    assert!(round.do_discard(Some(Tile::new(Tile::P2))));
+}
+
+#[test]
+fn test_swap_calling_forbids_suji_after_chi() {
+    let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
+    // 4m5m6m を含む手牌。捨てられた 3m を [4m,5m] でチーすると 6m が手牌に残る。
+    round.players[1].hand = Hand::from("456m234567p678s1z");
+
+    round.execute_chi(
+        1,
+        0,
+        Tile::new(Tile::M3),
+        [Tile::new(Tile::M4), Tile::new(Tile::M5)],
+    );
+
+    // スジ喰い替え（順子 3-4-5 の反対端 6m）の打牌は拒否される
+    assert!(!round.do_discard(Some(Tile::new(Tile::M6))));
+    // 喰い替えにならない打牌は許可される
+    assert!(round.do_discard(Some(Tile::new(Tile::P2))));
+}
+
+#[test]
+fn test_swap_calling_forbids_genbutsu_after_pon() {
+    let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
+    // 1s を3枚含む手牌。2枚を使ってポンすると 1s が手牌に残る。
+    round.players[1].hand = Hand::from("111s234567p678m1z");
+
+    round.execute_pon(
+        1,
+        0,
+        Tile::new(Tile::S1),
+        [Tile::new(Tile::S1), Tile::new(Tile::S1)],
+    );
+
+    // 現物喰い替え（鳴いた 1s と同種）の打牌は拒否される
+    assert!(!round.do_discard(Some(Tile::new(Tile::S1))));
+    // 喰い替えにならない打牌は許可される
+    assert!(round.do_discard(Some(Tile::new(Tile::P2))));
+}
+
+#[test]
+fn test_swap_calling_disabled_allows_genbutsu_discard() {
+    let settings = Settings {
+        forbid_swap_calling: false,
+        ..Settings::new()
+    };
+    let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, settings);
+    round.players[1].hand = Hand::from("456m234567p678s1z");
+
+    round.execute_chi(
+        1,
+        0,
+        Tile::new(Tile::M3),
+        [Tile::new(Tile::M4), Tile::new(Tile::M5)],
+    );
+
+    // 設定で喰い替え禁止を無効化している場合は、スジ牌でも打牌できる
+    assert!(round.do_discard(Some(Tile::new(Tile::M6))));
+}

--- a/docs/glossary.ja.md
+++ b/docs/glossary.ja.md
@@ -123,7 +123,7 @@
 | 本場 | honba | continuance counter | — | 次局の和了に 300 点加算。サーバ側で管理。 |
 | 供託 / リーチ棒 | kyōtaku / riichi-bō | riichi deposit | — | リーチ時に払う 1,000 点。次の和了者が取得。 |
 | 包 / 責任払い | pao / sekinin-barai | liability payment | — | 大三元・大四喜・四槓子で確定牌を放銃した者が全額払い。 |
-| 喰い替え | kuikae | swap-calling | — | 鳴いた牌と同/同等の牌を即捨てすること。未実装。 |
+| 喰い替え | kuikae | swap-calling | `Settings::forbid_swap_calling` | 鳴いた牌と同/同等の牌を即捨てすること。デフォルトで禁止。 |
 | 喰いタン | kuitan | Open Tan'yao | `Settings::opened_all_inside` | 副露した手で断么九（All Inside）を認めるか否か。 |
 | 四槓散了 | sūkan sanra | four-quads abortive draw | `Settings::four_kans_draw` | オプション。 |
 | 四風連打 | sūfon renda | four-winds abortive draw | `Settings::four_winds_draw` | オプション。 |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -124,7 +124,7 @@ A Japanese-language edition of this document is maintained in parallel at
 | 本場 | honba | continuance counter | — | Adds 300 points to the next win. Tracked server-side. |
 | 供託 / リーチ棒 | kyōtaku / riichi-bō | riichi deposit | — | The 1,000-point fee paid on riichi; taken by the next winner. |
 | 包 / 責任払い | pao / sekinin-barai | liability payment | — | A feeder pays the full value of Big Dragons / Big Winds / Four Quads. |
-| 喰い替え | kuikae | swap-calling | — | Calling then discarding the same/equivalent tile. Not yet implemented. |
+| 喰い替え | kuikae | swap-calling | `Settings::forbid_swap_calling` | Calling then discarding the same/equivalent tile; forbidden by default. |
 | 喰いタン | kuitan | Open Tan'yao | `Settings::opened_all_inside` | Whether All Inside (Tan'yao) is allowed on an open hand. |
 | 四槓散了 | sūkan sanra | four-quads abortive draw | `Settings::four_kans_draw` | Optional rule. |
 | 四風連打 | sūfon renda | four-winds abortive draw | `Settings::four_winds_draw` | Optional rule. |


### PR DESCRIPTION
## 概要

チー・ポン直後の打牌における**喰い替え（swap-calling）禁止ルール**を実装します。Closes #247。

後でルールのあり／なしを切り替えられるよう、`Settings` にトグル（`forbid_swap_calling`, デフォルト `true`）を追加しています。

## 実装内容

### ルールロジック（`mahjong-core`）
- `Settings::forbid_swap_calling`（デフォルト `true`）を追加。
- `Meld::forbidden_swap_tiles()` を新設。鳴き種別から禁止牌種を算出（サーバ・CPU・クライアントで共有）。
  - **ポン**: 鳴いた牌と同種（現物喰い替え）。
  - **チー**: 現物 ＋ 鳴いた牌が順子の端なら反対端の外側牌（スジ喰い替え）。中央（嵌張）はスジ喰い替えなし。スーツ境界も考慮。
  - カン類: 制限なし。

### サーバ（`mahjong-server`）
- `Player` が禁止牌種を保持。`try_discard` で拒否し、打牌・ツモで解除。
- `execute_chi` / `execute_pon` で設定が有効なときのみ禁止牌を設定。
- CPU は鳴き後に禁止牌を除外して選択（進行が止まらないように）。

### クライアントUI（`mahjong-client`）
- 禁止牌はグレーアウト表示し、打牌できない。
- 禁止牌を選択すると、他の牌と同様にせり上がり＋ハイライトし、打牌の代わりに「**喰い替えです！ / That's swap-calling!**」警告バッジを表示。
- 手牌の状態バッジは牌より後に描画し、牌に隠れないように修正。
- 日英の i18n キーを追加。

### ドキュメント
- `docs/glossary.md` / `glossary.ja.md` の喰い替え行を「実装済み・`Settings::forbid_swap_calling`」に更新。

## テスト
- core: ポン／チー両端／嵌張／スーツ境界／赤5正規化／カンの7ケース。
- server(player): 禁止牌拒否・非禁止許可と解除・ツモでの解除。
- server(round): チー現物・チースジ・ポン現物の拒否、トグルOFFで許可される回帰テスト。
- client: 自チー／自ポン／大明槓時の禁止牌セットと打牌での解除。
- `cargo test` 全パス、`cargo fmt`・`cargo clippy --all-targets` 警告なし。ネイティブ・WASM 両ビルド成功。

## 補足
- クライアントは自分の鳴き牌からローカルに禁止牌を計算します（CPU と同方式）。`forbid_swap_calling` を OFF にできる設定画面（GUI）はまだ無いため、ルール OFF をクライアントへ伝える経路は未実装です。将来 GUI を追加する場合は設定のクライアント同期が別途必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)