### PR TITLE
Fix latent bugs and design inconsistencies in online multiplayer

### DIFF
--- a/crates/mahjong-client/js/ws.js
+++ b/crates/mahjong-client/js/ws.js
@@ -104,17 +104,24 @@ function mahjong_ws_read_msg(handle, buf_ptr) {
     new Uint8Array(wasm_memory.buffer, buf_ptr, msg.length).set(msg);
 }
 
-// 接続を閉じる
+// 接続を閉じ、保持しているリソースを解放する
+// （再接続のたびにハンドルが増えるため、古い接続の参照とキューは残さない）
 function mahjong_ws_close(handle) {
     const entry = mahjong_ws.sockets[handle];
-    if (entry && entry.ws) {
+    if (!entry) {
+        return;
+    }
+    if (entry.ws) {
         try {
             entry.ws.close();
         } catch (_err) {
             // 既に閉じている場合などは無視
         }
+        entry.ws.onopen = entry.ws.onmessage = entry.ws.onclose = entry.ws.onerror = null;
+        entry.ws = null;
     }
-    if (entry && entry.status !== MAHJONG_WS_ERROR) {
+    entry.queue = [];
+    if (entry.status !== MAHJONG_WS_ERROR) {
         entry.status = MAHJONG_WS_CLOSED;
     }
 }

--- a/crates/mahjong-client/src/adapter/remote.rs
+++ b/crates/mahjong-client/src/adapter/remote.rs
@@ -55,7 +55,9 @@ impl RoomView {
 pub struct RemoteError {
     /// サーバが返したエラーコード（通信層のエラーは None）
     pub code: Option<ErrorCode>,
-    /// 説明（UI 表示用）
+    /// 技術的な詳細（ログ向け）。UI 表示用の文言は `code` から
+    /// [`error_code_message`] で、`code` が無い場合は汎用の通信エラー文言を
+    /// クライアント側でローカライズして組み立てる。
     pub message: String,
 }
 
@@ -222,7 +224,7 @@ impl RemoteAdapter {
                     Err(_) => {
                         self.last_error = Some(RemoteError {
                             code: None,
-                            message: "サーバからの応答を解釈できません".to_string(),
+                            message: "invalid server message".to_string(),
                         });
                     }
                 },
@@ -237,6 +239,8 @@ impl RemoteAdapter {
     /// 対局中は自動再接続を試みる（エラーは表に出さず「再接続中」を表示）。
     /// ロビーや対局終了後は通常の切断として扱う。
     fn handle_disconnect(&mut self, message: Option<String>) {
+        // 切断中は手番のカウントダウン表示を止める（再接続後にサーバが再送する）
+        self.turn_deadline = None;
         if self.should_auto_reconnect() {
             // 一時的な切断: 再接続モードへ（既に再接続中なら継続）
             if !self.reconnecting {
@@ -415,7 +419,7 @@ impl RemoteAdapter {
             Err(e) => {
                 self.last_error = Some(RemoteError {
                     code: None,
-                    message: format!("メッセージの作成に失敗しました: {e}"),
+                    message: format!("failed to encode message: {e}"),
                 });
             }
         }

--- a/crates/mahjong-client/src/i18n/mod.rs
+++ b/crates/mahjong-client/src/i18n/mod.rs
@@ -386,6 +386,8 @@ pub enum Key {
     Reconnecting,
     /// 他プレイヤー切断・CPU代打ちの表示
     PeerDisconnected,
+    /// 通信エラーの汎用表示（技術的な詳細はログに出す）
+    NetworkError,
 }
 
 impl Key {
@@ -621,6 +623,10 @@ impl Key {
             Key::PeerDisconnected => match lang {
                 Lang::Ja => "他のプレイヤーが切断中（CPUが代打ち）",
                 Lang::En => "A player disconnected (a CPU is filling in)",
+            },
+            Key::NetworkError => match lang {
+                Lang::Ja => "通信エラーが発生しました",
+                Lang::En => "A network error occurred",
             },
         }
     }

--- a/crates/mahjong-client/src/main.rs
+++ b/crates/mahjong-client/src/main.rs
@@ -104,7 +104,11 @@ fn sync_online_ui(remote: &mut RemoteAdapter, state: &mut GameState) {
     if let Some(err) = remote.take_error() {
         let message = match err.code {
             Some(code) => error_code_message(code, lang).to_string(),
-            None => err.message,
+            None => {
+                // 通信層のエラー: 詳細はログに残し、表示は汎用文言にする
+                macroquad::logging::warn!("network error: {}", err.message);
+                i18n::Key::NetworkError.text(lang).to_string()
+            }
         };
         set_status(state, &message, true);
         return;
@@ -188,7 +192,7 @@ async fn main() {
             }
             // 対局中の接続バナー（ローカル対戦では常に None）
             game_state.online_state.status_line = adp.status_text(game_state.lang);
-            game_state.online_state.status_is_error = true;
+            game_state.online_state.status_is_error = game_state.online_state.status_line.is_some();
             // 手番の残り時間（オンラインのみ）
             game_state.online_state.turn_remaining = adp.turn_remaining_secs();
         }

--- a/crates/mahjong-client/src/transport.rs
+++ b/crates/mahjong-client/src/transport.rs
@@ -19,6 +19,9 @@ pub enum WsEvent {
     /// 接続が閉じられた
     Closed,
     /// エラーが発生した（接続失敗・通信エラー）
+    ///
+    /// 文字列はログ向けの技術的な詳細。UI に表示する文言は
+    /// クライアント側でローカライズして組み立てる。
     Error(String),
 }
 
@@ -126,14 +129,14 @@ mod native {
         let (mut socket, _) = match tungstenite::connect(url) {
             Ok(ok) => ok,
             Err(e) => {
-                let _ = in_tx.send(WsEvent::Error(format!("接続に失敗しました: {e}")));
+                let _ = in_tx.send(WsEvent::Error(format!("connect failed: {e}")));
                 return;
             }
         };
 
         // 送受信を1ループで回すためノンブロッキングにする
         if let Err(e) = set_nonblocking(socket.get_mut()) {
-            let _ = in_tx.send(WsEvent::Error(format!("ソケット設定に失敗しました: {e}")));
+            let _ = in_tx.send(WsEvent::Error(format!("socket setup failed: {e}")));
             return;
         }
 
@@ -146,9 +149,16 @@ mod native {
             loop {
                 match out_rx.try_recv() {
                     Ok(text) => {
-                        if let Err(e) = socket.write(Message::text(text)) {
-                            let _ = in_tx.send(WsEvent::Error(format!("送信エラー: {e}")));
-                            return;
+                        match socket.write(Message::text(text)) {
+                            Ok(()) => {}
+                            // WouldBlock でもフレームは内部バッファに積まれて
+                            // いるため、後続の flush が再送を試みる
+                            Err(tungstenite::Error::Io(ref e))
+                                if e.kind() == std::io::ErrorKind::WouldBlock => {}
+                            Err(e) => {
+                                let _ = in_tx.send(WsEvent::Error(format!("send failed: {e}")));
+                                return;
+                            }
                         }
                     }
                     Err(TryRecvError::Empty) => break,
@@ -171,7 +181,7 @@ mod native {
                     return;
                 }
                 Err(e) => {
-                    let _ = in_tx.send(WsEvent::Error(format!("送信エラー: {e}")));
+                    let _ = in_tx.send(WsEvent::Error(format!("flush failed: {e}")));
                     return;
                 }
             }
@@ -200,7 +210,7 @@ mod native {
                     return;
                 }
                 Err(e) => {
-                    let _ = in_tx.send(WsEvent::Error(format!("通信エラー: {e}")));
+                    let _ = in_tx.send(WsEvent::Error(format!("receive failed: {e}")));
                     return;
                 }
             }
@@ -309,9 +319,7 @@ mod wasm {
                 }
                 match String::from_utf8(buf) {
                     Ok(text) => events.push(WsEvent::Message(text)),
-                    Err(_) => events.push(WsEvent::Error(
-                        "サーバからのメッセージを解釈できません".to_string(),
-                    )),
+                    Err(_) => events.push(WsEvent::Error("invalid UTF-8 from server".to_string())),
                 }
             }
 
@@ -323,7 +331,7 @@ mod wasm {
                 }
                 STATUS_ERROR => {
                     self.terminated = true;
-                    events.push(WsEvent::Error("WebSocket接続エラー".to_string()));
+                    events.push(WsEvent::Error("WebSocket error".to_string()));
                 }
                 _ => {}
             }

--- a/crates/mahjong-net-server/src/ratelimit.rs
+++ b/crates/mahjong-net-server/src/ratelimit.rs
@@ -15,6 +15,12 @@ const MAX_ATTEMPTS: usize = 10;
 /// 時間窓の長さ
 const WINDOW: Duration = Duration::from_secs(60);
 
+/// 全体の掃除を始めるIP数のしきい値
+///
+/// 記録済みのIPがこの数を超えたら、時間窓を過ぎた古いIPの記録を
+/// まとめて捨てる（IPごとの記録が無限に増えるのを防ぐ）。
+const SWEEP_THRESHOLD: usize = 64;
+
 /// IPごとの入室試行レート制限
 #[derive(Clone, Default)]
 pub struct RateLimiter {
@@ -38,10 +44,18 @@ impl RateLimiter {
     /// 時刻を指定して試行を判定する（テスト用）
     fn check_at(&self, ip: IpAddr, now: Instant) -> bool {
         let mut map = self.attempts.lock().unwrap();
+        let cutoff = now.checked_sub(WINDOW);
+
+        // IPが増えすぎたら、時間窓内の記録が無いIPをまとめて捨てる
+        if map.len() > SWEEP_THRESHOLD
+            && let Some(cutoff) = cutoff
+        {
+            map.retain(|_, entry| entry.back().is_some_and(|&last| last >= cutoff));
+        }
+
         let entry = map.entry(ip).or_default();
 
         // 時間窓より古い記録を捨てる
-        let cutoff = now.checked_sub(WINDOW);
         while let Some(&front) = entry.front() {
             match cutoff {
                 Some(cutoff) if front < cutoff => {
@@ -56,6 +70,12 @@ impl RateLimiter {
         }
         entry.push_back(now);
         true
+    }
+
+    /// 記録されているIP数（テスト用）
+    #[cfg(test)]
+    fn tracked_ips(&self) -> usize {
+        self.attempts.lock().unwrap().len()
     }
 }
 
@@ -90,6 +110,24 @@ mod tests {
         // 時間窓を超えて経過すると再び許可される
         let later = start + WINDOW + Duration::from_secs(1);
         assert!(limiter.check_at(ip(), later));
+    }
+
+    #[test]
+    fn test_stale_ips_are_swept() {
+        let limiter = RateLimiter::new();
+        let start = Instant::now();
+
+        // しきい値を超える数のIPを記録する
+        for i in 0..=SWEEP_THRESHOLD {
+            let ip: IpAddr = format!("10.0.{}.{}", i / 256, i % 256).parse().unwrap();
+            assert!(limiter.check_at(ip, start));
+        }
+        assert!(limiter.tracked_ips() > SWEEP_THRESHOLD);
+
+        // 時間窓を過ぎた後の試行で古いIPの記録が掃除される
+        let later = start + WINDOW + Duration::from_secs(1);
+        assert!(limiter.check_at(ip(), later));
+        assert_eq!(limiter.tracked_ips(), 1, "古いIPの記録が残っている");
     }
 
     #[test]

--- a/crates/mahjong-net-server/src/room.rs
+++ b/crates/mahjong-net-server/src/room.rs
@@ -3,6 +3,10 @@
 //! 1ルーム = 1 tokio タスク。ルームが `GameDriver`（卓 + CPU）を所有し、
 //! 接続タスクからの `RoomMsg` を mpsc で逐次処理する。
 //! 同期的な卓の操作が await をまたがないため、ゲーム状態のロックは不要。
+//!
+//! クライアントへの送信は `try_send` で行い、決してブロックしない。
+//! 受信が追いつかない接続（バッファ満杯）は切断として扱い、
+//! 1人の遅延がルーム全体の進行を止めないようにする。
 
 use std::time::Duration;
 
@@ -127,12 +131,16 @@ struct Room {
     close_deadline: Option<Instant>,
     /// 手番の制限時間の期限
     action_deadline: Option<Instant>,
+    /// 現在の制限時間が対象とする座席（操作待ちの変化検出に使う）
+    deadline_seats: Vec<usize>,
     /// ゲーム進行の時刻基準（対局開始時刻）。CPU遅延の計測に使う
     game_clock: Option<Instant>,
     /// ルームを閉じるフラグ
     closing: bool,
     /// 次に割り当てる接続の世代番号
     next_conn_gen: u64,
+    /// 送信失敗（バッファ満杯・切断）で切断処理が必要になった座席
+    pending_departures: Vec<usize>,
     /// CPU（空席・シャドー）の強さ・性格。ホストが対局開始時に指定する
     cpu_configs: [CpuConfig; 3],
 }
@@ -166,9 +174,11 @@ pub async fn run_room(
         ready_deadline: None,
         close_deadline: Some(Instant::now() + config.lobby_timeout),
         action_deadline: None,
+        deadline_seats: Vec::new(),
         game_clock: None,
         closing: false,
         next_conn_gen: 0,
+        pending_departures: Vec::new(),
         cpu_configs: default_cpu_configs(),
     };
 
@@ -183,25 +193,28 @@ pub async fn run_room(
 
         tokio::select! {
             msg = rx.recv() => match msg {
-                Some(msg) => room.handle_msg(msg).await,
+                Some(msg) => room.handle_msg(msg),
                 None => break,
             },
             _ = game_tick.tick(), if room.needs_game_tick() => {
-                room.game_tick().await;
+                room.game_tick();
             }
             _ = tokio::time::sleep_until(ready_at), if room.ready_deadline.is_some() => {
                 tracing::debug!(code = room.code, "ready timeout; auto-advancing round");
-                room.advance_round().await;
+                room.advance_round();
             }
             _ = tokio::time::sleep_until(action_at), if room.action_deadline.is_some() => {
                 tracing::debug!(code = room.code, "action timeout; forcing default action");
-                room.on_action_timeout().await;
+                room.on_action_timeout();
             }
             _ = tokio::time::sleep_until(close_at), if room.close_deadline.is_some() => {
                 tracing::info!(code = room.code, "room expired");
                 room.closing = true;
             }
         }
+
+        // 送信に失敗した接続の切断処理をまとめて行う
+        room.process_departures();
 
         if room.closing {
             break;
@@ -224,7 +237,7 @@ impl Room {
         self.driver.is_some()
     }
 
-    async fn handle_msg(&mut self, msg: RoomMsg) {
+    fn handle_msg(&mut self, msg: RoomMsg) {
         match msg {
             RoomMsg::Join {
                 name,
@@ -235,24 +248,24 @@ impl Room {
                 Ok(outcome) => {
                     let _ = reply.send(Ok((outcome.seat, outcome.conn_gen)));
                     if outcome.reconnect {
-                        self.handle_reconnect(outcome.seat).await;
+                        self.handle_reconnect(outcome.seat);
                     } else {
-                        self.broadcast_room_state().await;
+                        self.broadcast_room_state();
                     }
                 }
                 Err(code) => {
                     let _ = reply.send(Err(code));
                 }
             },
-            RoomMsg::FromSeat { seat, msg } => self.handle_client_message(seat, msg).await,
-            RoomMsg::Leave { seat } => self.handle_departure(seat).await,
+            RoomMsg::FromSeat { seat, msg } => self.handle_client_message(seat, msg),
+            RoomMsg::Leave { seat } => self.handle_departure(seat),
             RoomMsg::Disconnected { seat, conn_gen } => {
                 // 古い接続からの遅延切断通知は無視する（再接続済みなら世代が進んでいる）
                 if self.seats[seat]
                     .as_ref()
                     .is_some_and(|s| s.conn_gen == conn_gen)
                 {
-                    self.handle_departure(seat).await;
+                    self.handle_departure(seat);
                 }
             }
         }
@@ -321,7 +334,7 @@ impl Room {
     }
 
     /// 再接続した座席へ CPU 代打ちを止め、状態を再同期する
-    async fn handle_reconnect(&mut self, seat: usize) {
+    fn handle_reconnect(&mut self, seat: usize) {
         // CPU代打ちを止めて人間の操作に戻す
         if let Some(driver) = self.driver.as_mut() {
             driver.set_cpu_controlled(seat, false);
@@ -330,30 +343,24 @@ impl Room {
         self.broadcast(ServerMessage::PlayerConnectionChanged {
             seat,
             connected: true,
-        })
-        .await;
+        });
         // 再接続した座席へ最新の RoomState と現在の局の再生を送る
-        self.send_room_state_to(seat).await;
+        self.send_room_state_to(seat);
         let history = self.seats[seat]
             .as_ref()
             .map(|s| s.history.clone())
             .unwrap_or_default();
-        if let Some(tx) = self.seats[seat].as_ref().and_then(|s| s.tx.clone()) {
-            let _ = tx.send(ServerMessage::Resync { events: history }).await;
-        }
+        self.send_to_seat(seat, ServerMessage::Resync { events: history });
         // 再接続で操作待ちの主体が変わった可能性があるため期限を張り直す
-        self.refresh_action_deadline().await;
+        self.refresh_action_deadline();
     }
 
-    async fn handle_client_message(&mut self, seat: usize, msg: ClientMessage) {
+    fn handle_client_message(&mut self, seat: usize, msg: ClientMessage) {
         match msg {
-            ClientMessage::StartGame { cpu_configs } => {
-                self.handle_start_game(seat, cpu_configs).await
-            }
+            ClientMessage::StartGame { cpu_configs } => self.handle_start_game(seat, cpu_configs),
             ClientMessage::Action(action) => {
                 if !self.game_started() || self.awaiting_ready {
-                    self.send_error(seat, ErrorCode::InvalidAction, "no action expected now")
-                        .await;
+                    self.send_error(seat, ErrorCode::InvalidAction, "no action expected now");
                     return;
                 }
                 let now = self.now_secs();
@@ -368,10 +375,9 @@ impl Room {
                         seat,
                         ErrorCode::InvalidAction,
                         &format!("action rejected: seat={seat} action={action:?} phase={phase:?}"),
-                    )
-                    .await;
+                    );
                 }
-                self.progress_game().await;
+                self.progress_game();
             }
             ClientMessage::ReadyNextRound => {
                 if !self.awaiting_ready {
@@ -381,26 +387,23 @@ impl Room {
                 }
                 self.ready[seat] = true;
                 if self.all_connected_humans_ready() {
-                    self.advance_round().await;
+                    self.advance_round();
                 }
             }
             // Hello / CreateRoom / JoinRoom / LeaveRoom は接続タスク側で処理済み
             _ => {
-                self.send_error(seat, ErrorCode::BadMessage, "unexpected message")
-                    .await;
+                self.send_error(seat, ErrorCode::BadMessage, "unexpected message");
             }
         }
     }
 
-    async fn handle_start_game(&mut self, seat: usize, cpu_configs: Option<[CpuSpec; 3]>) {
+    fn handle_start_game(&mut self, seat: usize, cpu_configs: Option<[CpuSpec; 3]>) {
         if seat != HOST_SEAT {
-            self.send_error(seat, ErrorCode::NotHost, "only the host can start")
-                .await;
+            self.send_error(seat, ErrorCode::NotHost, "only the host can start");
             return;
         }
         if self.game_started() {
-            self.send_error(seat, ErrorCode::GameInProgress, "game already started")
-                .await;
+            self.send_error(seat, ErrorCode::GameInProgress, "game already started");
             return;
         }
 
@@ -428,32 +431,32 @@ impl Room {
         self.close_deadline = None;
 
         tracing::info!(code = self.code, "game started");
-        self.broadcast_room_state().await;
-        self.progress_game().await;
+        self.broadcast_room_state();
+        self.progress_game();
     }
 
     /// 直前のアクション結果を配信し、局終了の確認・期限の再設定を行う
     ///
     /// CPUの進行は [`game_tick`](Self::game_tick) が遅延を計りながら進めるため、
     /// ここではツモまで一気に進めない（イベントの送出と状態更新のみ）。
-    async fn progress_game(&mut self) {
-        self.flush_events().await;
+    fn progress_game(&mut self) {
+        self.flush_events();
         self.check_round_end();
-        self.refresh_action_deadline().await;
+        self.refresh_action_deadline();
     }
 
     /// CPU遅延を計りながらゲームを1ティック進める
     ///
     /// 待機中のCPUアクションが期限を迎えれば適用し、ツモフェーズなら牌を引く。
     /// `needs_game_tick` が true の間だけ呼ばれる。
-    async fn game_tick(&mut self) {
+    fn game_tick(&mut self) {
         let now = self.now_secs();
         if let Some(driver) = self.driver.as_mut() {
             driver.tick_at(now);
         }
-        self.flush_events().await;
+        self.flush_events();
         self.check_round_end();
-        self.refresh_action_deadline().await;
+        self.refresh_action_deadline();
     }
 
     /// CPUの進行（ツモ・遅延待ちの打牌など）のために tick が必要か
@@ -478,15 +481,17 @@ impl Room {
 
     /// 手番の制限時間を再設定する
     ///
-    /// 接続中の人間の操作待ちなら期限を張り直し、対象座席へ残り秒数を通知する。
+    /// 接続中の人間の操作待ちなら期限を設定し、対象座席へ残り秒数を通知する。
+    /// 同じ操作待ちが続いている間は期限を維持する（他プレイヤーの無効操作
+    /// などで制限時間が延長されるのを防ぐ）。
     /// それ以外（CPU進行中・確認待ち・局終了）は期限を解除する。
-    async fn refresh_action_deadline(&mut self) {
+    fn refresh_action_deadline(&mut self) {
         let Some(timeout) = self.config.action_timeout else {
-            self.action_deadline = None;
+            self.clear_action_deadline();
             return;
         };
         if self.awaiting_ready || self.game_over_sent {
-            self.action_deadline = None;
+            self.clear_action_deadline();
             return;
         }
 
@@ -500,22 +505,32 @@ impl Room {
             .collect();
 
         if seats.is_empty() {
-            self.action_deadline = None;
+            self.clear_action_deadline();
             return;
         }
 
+        // 操作待ちの座席が変わっていなければ既存の期限を使い続ける
+        if self.action_deadline.is_some() && seats == self.deadline_seats {
+            return;
+        }
+
+        self.deadline_seats = seats.clone();
         self.action_deadline = Some(Instant::now() + timeout);
         // 端数は切り上げる（短い制限でも 0 秒表示にならないように）
         let seconds = timeout.as_secs_f64().ceil() as u32;
         for seat in seats {
-            if let Some(tx) = self.seats[seat].as_ref().and_then(|s| s.tx.clone()) {
-                let _ = tx.send(ServerMessage::TurnTimer { seconds }).await;
-            }
+            self.send_to_seat(seat, ServerMessage::TurnTimer { seconds });
         }
     }
 
+    /// 手番の制限時間を解除する
+    fn clear_action_deadline(&mut self) {
+        self.action_deadline = None;
+        self.deadline_seats.clear();
+    }
+
     /// 手番の制限時間切れ: 待っている接続中の人間に既定アクションを代行する
-    async fn on_action_timeout(&mut self) {
+    fn on_action_timeout(&mut self) {
         let now = self.now_secs();
         let seats: Vec<usize> = self
             .driver
@@ -530,15 +545,15 @@ impl Room {
                 driver.force_default_action_at(seat, now);
             }
         }
-        self.action_deadline = None;
-        self.progress_game().await;
+        self.clear_action_deadline();
+        self.progress_game();
     }
 
     /// 各座席のイベントを履歴へ記録し、接続中の座席へ送信する
     ///
     /// 履歴は局開始（GameStarted）でリセットし、現在の局のイベントだけを
     /// 保持する。切断中の座席でも履歴は記録され、再接続時の再同期に使う。
-    async fn flush_events(&mut self) {
+    fn flush_events(&mut self) {
         if self.driver.is_none() {
             return;
         }
@@ -551,28 +566,19 @@ impl Room {
         };
 
         for (seat, events) in per_seat.into_iter().enumerate() {
-            // 履歴へ記録（局開始でリセット）して送信チャネルを取り出す
-            let tx = {
-                let Some(s) = self.seats[seat].as_mut() else {
-                    continue;
-                };
-                for event in &events {
+            for event in events {
+                // 履歴へ記録する（局開始でリセット）
+                {
+                    let Some(s) = self.seats[seat].as_mut() else {
+                        break;
+                    };
                     if matches!(event, ServerEvent::GameStarted { .. }) {
                         s.history.clear();
                     }
                     s.history.push(event.clone());
                 }
-                s.tx.clone()
-            };
-
-            // 接続中の座席へ送信する
-            if let Some(tx) = tx {
-                for event in events {
-                    if tx.send(ServerMessage::Event(event)).await.is_err() {
-                        // 送信失敗は切断として扱う（Disconnected が後続で届く）
-                        break;
-                    }
-                }
+                // 接続中なら送信する（切断中は send_to_seat が何もしない）
+                self.send_to_seat(seat, ServerMessage::Event(event));
             }
         }
     }
@@ -605,7 +611,7 @@ impl Room {
     }
 
     /// 次の局へ進める（ゲーム終了なら GameOver を配信する）
-    async fn advance_round(&mut self) {
+    fn advance_round(&mut self) {
         self.awaiting_ready = false;
         self.ready_deadline = None;
 
@@ -617,27 +623,41 @@ impl Room {
 
         if driver.is_game_over() {
             let final_scores = driver.table().scores;
-            self.broadcast(ServerMessage::GameOver { final_scores })
-                .await;
+            self.broadcast(ServerMessage::GameOver { final_scores });
             self.game_over_sent = true;
-            self.action_deadline = None;
+            self.clear_action_deadline();
             // 全員が切断したら閉じる。念のため期限も設定する
             self.close_deadline = Some(Instant::now() + self.config.abandoned_timeout);
             tracing::info!(code = self.code, "game over");
         } else {
-            self.progress_game().await;
+            self.progress_game();
+        }
+    }
+
+    /// 送信失敗で切断扱いになった座席の切断処理をまとめて行う
+    ///
+    /// 切断処理中の送信（切断通知など）がさらに失敗する可能性があるため、
+    /// 空になるまで繰り返す。各座席は一度切断されると送信対象から外れるので
+    /// 必ず停止する。
+    fn process_departures(&mut self) {
+        while let Some(seat) = self.pending_departures.pop() {
+            tracing::info!(
+                code = self.code,
+                seat,
+                "send failed; treating as disconnect"
+            );
+            self.handle_departure(seat);
         }
     }
 
     /// 退出または切断を処理する
-    async fn handle_departure(&mut self, seat: usize) {
+    fn handle_departure(&mut self, seat: usize) {
         // 開始前: 座席を空ける。ホストが抜けたらルームを閉じる
         if !self.game_started() {
             self.seats[seat] = None;
             tracing::info!(code = self.code, seat, "player left");
             if seat == HOST_SEAT {
-                self.broadcast_error(ErrorCode::NotInRoom, "room closed by host")
-                    .await;
+                self.broadcast_error(ErrorCode::NotInRoom, "room closed by host");
                 self.closing = true;
                 return;
             }
@@ -645,7 +665,7 @@ impl Room {
                 self.closing = true;
                 return;
             }
-            self.broadcast_room_state().await;
+            self.broadcast_room_state();
             return;
         }
 
@@ -659,8 +679,11 @@ impl Room {
         }
 
         // 対局中: 座席は保持したまま切断扱いにし、CPUが代打ちする
-        if let Some(s) = self.seats[seat].as_mut() {
-            s.tx = None;
+        match self.seats[seat].as_mut() {
+            // 既に切断処理済みなら二重に処理しない
+            // （送信失敗とソケット切断の両方から呼ばれることがある）
+            Some(s) if s.tx.is_some() => s.tx = None,
+            _ => return,
         }
         tracing::info!(
             code = self.code,
@@ -677,13 +700,12 @@ impl Room {
         self.broadcast(ServerMessage::PlayerConnectionChanged {
             seat,
             connected: false,
-        })
-        .await;
+        });
         // 確認待ち中の切断はその座席の確認を不要にする
         if self.awaiting_ready && self.all_connected_humans_ready() {
-            self.advance_round().await;
+            self.advance_round();
         } else {
-            self.progress_game().await;
+            self.progress_game();
         }
 
         if !self.any_connected_human() {
@@ -721,60 +743,67 @@ impl Room {
     }
 
     /// 全員に RoomState を送る（your_seat は受信者ごとに変わる）
-    async fn broadcast_room_state(&self) {
+    fn broadcast_room_state(&mut self) {
         let seats_info = self.seats_info();
         for seat in 0..4 {
-            self.send_room_state_with(seat, &seats_info).await;
+            self.send_room_state_with(seat, &seats_info);
         }
     }
 
     /// 特定の座席へ RoomState を送る
-    async fn send_room_state_to(&self, seat: usize) {
+    fn send_room_state_to(&mut self, seat: usize) {
         let seats_info = self.seats_info();
-        self.send_room_state_with(seat, &seats_info).await;
+        self.send_room_state_with(seat, &seats_info);
     }
 
     /// 組み立て済みの座席情報を使って特定の座席へ RoomState を送る
-    async fn send_room_state_with(&self, seat: usize, seats_info: &[SeatInfo; 4]) {
-        let Some(tx) = self.seats[seat].as_ref().and_then(|s| s.tx.clone()) else {
-            return;
-        };
+    fn send_room_state_with(&mut self, seat: usize, seats_info: &[SeatInfo; 4]) {
         let msg = ServerMessage::RoomState {
             code: self.code.clone(),
             seats: seats_info.clone(),
             host_seat: HOST_SEAT,
             your_seat: seat,
         };
-        let _ = tx.send(msg).await;
+        self.send_to_seat(seat, msg);
     }
 
     /// 接続中の全員にメッセージを送る
-    async fn broadcast(&self, msg: ServerMessage) {
-        for seat in self.seats.iter().flatten() {
-            if let Some(tx) = &seat.tx {
-                let _ = tx.send(msg.clone()).await;
-            }
+    fn broadcast(&mut self, msg: ServerMessage) {
+        for seat in 0..4 {
+            self.send_to_seat(seat, msg.clone());
         }
     }
 
     /// 接続中の全員にエラーを送る
-    async fn broadcast_error(&self, code: ErrorCode, message: &str) {
+    fn broadcast_error(&mut self, code: ErrorCode, message: &str) {
         self.broadcast(ServerMessage::Error {
             code,
             message: message.to_string(),
-        })
-        .await;
+        });
     }
 
     /// 特定の座席にエラーを送る
-    async fn send_error(&self, seat: usize, code: ErrorCode, message: &str) {
-        if let Some(tx) = self.seats[seat].as_ref().and_then(|s| s.tx.clone()) {
-            let _ = tx
-                .send(ServerMessage::Error {
-                    code,
-                    message: message.to_string(),
-                })
-                .await;
+    fn send_error(&mut self, seat: usize, code: ErrorCode, message: &str) {
+        self.send_to_seat(
+            seat,
+            ServerMessage::Error {
+                code,
+                message: message.to_string(),
+            },
+        );
+    }
+
+    /// 特定の座席へブロックせずに送信する（切断中の座席は何もしない）
+    ///
+    /// 送信バッファが満杯（受信が長時間止まっている）か接続が閉じている
+    /// 場合は失敗として座席を切断処理の対象に積む。実際の切断処理は
+    /// [`process_departures`](Self::process_departures) がまとめて行う。
+    fn send_to_seat(&mut self, seat: usize, msg: ServerMessage) {
+        let Some(tx) = self.seats[seat].as_ref().and_then(|s| s.tx.as_ref()) else {
+            return;
+        };
+        if tx.try_send(msg).is_err() && !self.pending_departures.contains(&seat) {
+            self.pending_departures.push(seat);
         }
     }
 }

--- a/crates/mahjong-net-server/tests/integration.rs
+++ b/crates/mahjong-net-server/tests/integration.rs
@@ -612,6 +612,65 @@ async fn test_action_timeout_auto_acts() {
     .expect("テスト全体がタイムアウトした");
 }
 
+/// 無効なアクションの連投で手番の制限時間が延長されないことを確認する
+///
+/// かつては任意のメッセージ処理のたびに期限を張り直していたため、
+/// 制限時間より短い間隔でメッセージを送り続けると永遠にタイムアウトせず、
+/// 対局を止められた。同じ操作待ちが続く間は期限を維持する回帰テスト。
+#[tokio::test]
+async fn test_action_timeout_not_extended_by_invalid_actions() {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        let config = RoomConfig {
+            action_timeout: Some(Duration::from_millis(500)),
+            ..fast_config()
+        };
+        let addr = start_server(config).await;
+
+        let mut host = TestClient::connect(addr).await;
+        host.hello("ホスト").await;
+        host.create_room().await;
+        host.send(&ClientMessage::StartGame { cpu_configs: None })
+            .await;
+
+        // 自分のツモ（打牌待ち）まで読み進める
+        loop {
+            if let ServerMessage::Event(ServerEvent::TileDrawn { .. }) = host.recv().await {
+                break;
+            }
+        }
+
+        // 打牌せずに、制限時間より短い間隔で無効なアクションを送り続ける。
+        // それでもタイムアウトは発火し、サーバが代行打牌（ツモ切り）する
+        let start = std::time::Instant::now();
+        loop {
+            assert!(
+                start.elapsed() < Duration::from_secs(5),
+                "制限時間が延長され続けてタイムアウトしなかった"
+            );
+            host.send(&ClientMessage::Action(ClientAction::Ron)).await;
+            let deadline = tokio::time::sleep(Duration::from_millis(100));
+            tokio::pin!(deadline);
+            let mut auto_discarded = false;
+            loop {
+                tokio::select! {
+                    msg = host.recv() => {
+                        if let ServerMessage::Event(ServerEvent::TileDiscarded { .. }) = msg {
+                            auto_discarded = true;
+                            break;
+                        }
+                    }
+                    _ = &mut deadline => break,
+                }
+            }
+            if auto_discarded {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("テスト全体がタイムアウトした");
+}
+
 /// 同一IPからの入室試行が多すぎると RateLimited で拒否されることを確認する
 #[tokio::test]
 async fn test_join_rate_limit() {

--- a/crates/mahjong-server/src/driver.rs
+++ b/crates/mahjong-server/src/driver.rs
@@ -105,6 +105,14 @@ impl GameDriver {
         match self.cpus.get_mut(seat) {
             Some(Some(cpu)) => {
                 cpu.controlled = controlled;
+                if !controlled {
+                    // 代打ち解除: 適用前のCPUアクションを破棄する
+                    // （再接続した人間の操作を代打ちが横取りしないように）
+                    for batch in &mut self.pending_cpu_batches {
+                        batch.actions.retain(|(s, _)| *s != seat);
+                    }
+                    self.pending_cpu_batches.retain(|b| !b.actions.is_empty());
+                }
                 true
             }
             _ => false,
@@ -751,6 +759,69 @@ mod tests {
         let mut driver = GameDriver::new(GameSettings::default());
         assert!(!driver.set_cpu_controlled(0, true));
         assert!(!driver.is_cpu_controlled(0));
+    }
+
+    /// 代打ち解除で適用前のCPUアクションが破棄されることを確認
+    ///
+    /// 切断→CPU代打ち中に予約された打牌が、人間の再接続後に適用されて
+    /// 操作を横取りしないための回帰テスト。
+    #[test]
+    fn test_releasing_cpu_control_discards_pending_actions() {
+        let mut driver = driver_with_three_cpus();
+        let config = default_cpu_configs()[0].clone();
+        driver.set_shadow_cpu(0, config);
+        driver.set_cpu_action_delay(1.0);
+        driver.table_mut().start_round();
+
+        {
+            let round = driver.table_mut().current_round_mut().unwrap();
+            round.current_player = 0;
+            round.phase = TurnPhase::WaitForDiscard;
+            round.players[0].draw(Tile::new(Tile::Z7));
+            round.drain_events();
+        }
+
+        // 切断をシミュレート: 代打ちに切り替え、CPUの打牌を予約する
+        assert!(driver.set_cpu_controlled(0, true));
+        driver.schedule_cpu_actions(vec![(0, ClientAction::Discard { tile: None })], 1.0, 10.0);
+
+        // 再接続: 代打ちを解除すると予約済みアクションは破棄される
+        assert!(driver.set_cpu_controlled(0, false));
+        assert!(driver.pending_cpu_batches.is_empty());
+
+        // 予約時刻を過ぎても勝手に打牌されない（人間の入力待ちのまま）
+        driver.tick_at(20.0);
+        let round = driver.table().current_round().unwrap();
+        assert_eq!(round.phase, TurnPhase::WaitForDiscard);
+        assert_eq!(round.current_player, 0);
+    }
+
+    /// 代打ち解除が他の座席の予約済みCPUアクションを巻き添えにしないことを確認
+    #[test]
+    fn test_releasing_cpu_control_keeps_other_seats_actions() {
+        let mut driver = driver_with_three_cpus();
+        let config = default_cpu_configs()[0].clone();
+        driver.set_shadow_cpu(0, config);
+        driver.set_cpu_action_delay(1.0);
+        driver.table_mut().start_round();
+
+        driver.set_cpu_controlled(0, true);
+        driver.schedule_cpu_actions(
+            vec![
+                (0, ClientAction::Pass),
+                (1, ClientAction::Discard { tile: None }),
+            ],
+            1.0,
+            10.0,
+        );
+
+        driver.set_cpu_controlled(0, false);
+        // 座席0のアクションだけが取り除かれ、座席1のアクションは残る
+        assert_eq!(driver.pending_cpu_batches.len(), 1);
+        assert_eq!(
+            driver.pending_cpu_batches.front().unwrap().actions,
+            vec![(1, ClientAction::Discard { tile: None })]
+        );
     }
 
     /// run_until_blocked が人間の打牌待ちで停止することを確認

--- a/crates/mahjong-server/src/protocol/mod.rs
+++ b/crates/mahjong-server/src/protocol/mod.rs
@@ -228,7 +228,7 @@ pub enum ServerEvent {
 }
 
 /// クライアントからサーバへのアクション
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ClientAction {
     /// 牌を捨てる
     Discard {


### PR DESCRIPTION
## Summary

Code-review pass over the whole project with a focus on the online multiplayer stack (`mahjong-net-server`, client transport/adapter, `GameDriver`). Fixes six latent bugs and a few readability/design inconsistencies.

## Bug fixes

- **Turn timer could be extended indefinitely** (`room.rs`): the action deadline was re-armed on every processed client message, so sending any message (even invalid actions) more often than the timeout kept the timer from ever firing and re-spammed `TurnTimer`. The deadline is now kept while the same set of seats is awaited. Covered by a regression test (`test_action_timeout_not_extended_by_invalid_actions`) that was verified to fail against the old behavior.
- **One stalled client could freeze the whole room** (`room.rs`): the room actor used blocking `send().await`; a client that stopped reading (full 256-message buffer) blocked game progress and all timeouts for everyone, potentially until the TCP retransmission timeout. All sends now use `try_send`, and a full/closed buffer is treated as a disconnect (CPU takes over). As a side effect most of the `Room` impl no longer needs `async`.
- **Queued CPU action hijacked a reconnecting player's turn** (`driver.rs`): CPU actions sit in a delay queue for the thinking-time effect; after a reconnect released CPU control, an already-queued discard was still applied. Releasing control now discards that seat's pending actions (2 new tests).
- **Native client dropped the connection on send backpressure** (`transport.rs`): tungstenite's `write` can return `WouldBlock` while the frame is safely queued in its internal buffer; it was treated as fatal. Now tolerated like `flush`.
- **Stale turn countdown during reconnect** (`remote.rs`): the countdown is now cleared on disconnect; the server re-sends `TurnTimer` after resync.
- **Unbounded per-IP rate-limit records** (`ratelimit.rs`): entries for IPs that never return were kept forever (slow memory leak on a public server). Stale entries are now swept once the map grows past a threshold (test included).

## Design / readability

- Transport-level error strings were hardcoded in Japanese, contradicting the i18n design from #242. The transport layer now emits technical English details for logs, and the UI shows a localized generic message via the new `Key::NetworkError`.
- `main.rs`: `status_is_error` no longer stays `true` when there is no status line.
- `ws.js`: `mahjong_ws_close` now releases socket handlers and queued messages (they leaked across reconnects).
- `ClientAction` now derives `PartialEq`/`Eq`.
- Mid-game departure handling is now idempotent (send-failure and socket-close paths can both trigger it).

## Reviewed and found OK (no changes)

- Malicious-input hardening: `Kan` `tile_index` is bounds-checked, chi/pon combinations are validated against server-computed options, and discards are validated against hand contents, so forged `Tile` values from JSON cannot cause out-of-bounds panics in the room actor.
- Reconnect protocol (session token matching, connection generations, per-round `Resync` history) is sound.

## Test plan

- `cargo test` — all 683 tests pass, including 17 net-server integration tests and the new regression tests
- `cargo clippy --all-targets` — no warnings; `cargo fmt` applied
- `cargo build -p mahjong-client --target wasm32-unknown-unknown` — WASM build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)