### PR TITLE
Add core primitives for three-player mahjong (sanma) (#257, 1/6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,7 @@ dependencies = [
  "rand 0.10.1",
  "rstest",
  "serde",
+ "serde_json",
  "strum",
  "strum_macros",
 ]

--- a/crates/mahjong-core/Cargo.toml
+++ b/crates/mahjong-core/Cargo.toml
@@ -12,3 +12,4 @@ anyhow = "1.0"
 serde = { version = "1", features = ["derive"] }
 [dev-dependencies]
 rstest = "0.26"
+serde_json = "1"

--- a/crates/mahjong-core/src/scoring/score.rs
+++ b/crates/mahjong-core/src/scoring/score.rs
@@ -117,6 +117,8 @@ pub enum DoraLabel {
     RedDora,
     /// 裏ドラ
     UraDora,
+    /// 北ドラ（三麻の北抜き。抜いた北風牌1枚につき1翻）
+    Kita,
 }
 
 impl DoraLabel {
@@ -129,11 +131,13 @@ impl DoraLabel {
                 DoraLabel::Dora => "Dora",
                 DoraLabel::RedDora => "Red Five",
                 DoraLabel::UraDora => "Ura Dora",
+                DoraLabel::Kita => "Kita",
             },
             Lang::Ja => match self {
                 DoraLabel::Dora => "ドラ",
                 DoraLabel::RedDora => "赤ドラ",
                 DoraLabel::UraDora => "裏ドラ",
+                DoraLabel::Kita => "北ドラ",
             },
         }
     }
@@ -639,6 +643,7 @@ mod tests {
         assert_eq!(DoraLabel::Dora.name(Lang::Ja), "ドラ");
         assert_eq!(DoraLabel::RedDora.name(Lang::Ja), "赤ドラ");
         assert_eq!(DoraLabel::UraDora.name(Lang::Ja), "裏ドラ");
+        assert_eq!(DoraLabel::Kita.name(Lang::Ja), "北ドラ");
     }
 
     /// ドラ種別名（英語）
@@ -647,5 +652,6 @@ mod tests {
         assert_eq!(DoraLabel::Dora.name(Lang::En), "Dora");
         assert_eq!(DoraLabel::RedDora.name(Lang::En), "Red Five");
         assert_eq!(DoraLabel::UraDora.name(Lang::En), "Ura Dora");
+        assert_eq!(DoraLabel::Kita.name(Lang::En), "Kita");
     }
 }

--- a/crates/mahjong-core/src/settings.rs
+++ b/crates/mahjong-core/src/settings.rs
@@ -41,6 +41,20 @@ pub struct Settings {
     /// ありの場合: チー・ポン直後の打牌で、鳴いた牌と同種（現物喰い替え）や
     /// チーで作った順子の反対端の牌（スジ喰い替え）を捨てられない
     pub forbid_swap_calling: bool,
+    /// 三人麻雀（サンマ）かどうか（デフォルトは false = 四人麻雀）
+    /// ありの場合: 萬子2〜8を除外した108枚で3人で打つ。チーは提供されない。
+    /// ツモはツモ損（1人あたりの支払額は四麻と同じで、いない北家分は貰えない）。
+    #[serde(default)]
+    pub three_player: bool,
+    /// 北抜きドラありかなしか（三人麻雀のみ有効。デフォルトはあり）
+    /// ありの場合: 手番中に北風牌を晒して1枚につきドラ1として扱い、牌山から補充する。
+    #[serde(default = "default_true")]
+    pub nuki_dora: bool,
+}
+
+/// serde デフォルト用: true を返す
+fn default_true() -> bool {
+    true
 }
 
 impl Default for Settings {
@@ -61,6 +75,50 @@ impl Settings {
             triple_ron_draw: false,
             multiple_ron: true,
             forbid_swap_calling: true,
+            three_player: false,
+            nuki_dora: true,
         }
+    }
+
+    /// プレイヤー人数を返す（三麻なら3、四麻なら4）
+    pub fn player_count(&self) -> usize {
+        if self.three_player { 3 } else { 4 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// デフォルトは四麻・北抜きあり
+    #[test]
+    fn default_is_four_player() {
+        let settings = Settings::new();
+        assert!(!settings.three_player);
+        assert!(settings.nuki_dora);
+        assert_eq!(settings.player_count(), 4);
+    }
+
+    /// 三麻フラグでプレイヤー人数が3になる
+    #[test]
+    fn three_player_count() {
+        let settings = Settings {
+            three_player: true,
+            ..Settings::new()
+        };
+        assert_eq!(settings.player_count(), 3);
+    }
+
+    /// 旧形式（三麻フィールドなし）の JSON からデシリアライズできる
+    #[test]
+    fn deserialize_without_sanma_fields() {
+        let json = serde_json::to_string(&Settings::new()).unwrap();
+        // three_player / nuki_dora を取り除いた旧形式を模擬
+        let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        value.as_object_mut().unwrap().remove("three_player");
+        value.as_object_mut().unwrap().remove("nuki_dora");
+        let settings: Settings = serde_json::from_value(value).unwrap();
+        assert!(!settings.three_player);
+        assert!(settings.nuki_dora);
     }
 }

--- a/crates/mahjong-core/src/tile.rs
+++ b/crates/mahjong-core/src/tile.rs
@@ -252,6 +252,24 @@ pub fn suit_rank(tile: TileType) -> Option<u32> {
     }
 }
 
+/// ドラ表示牌から実際のドラを返す（三麻対応版）
+///
+/// 三麻では萬子は1mと9mしか存在しないため、
+/// 萬子のドラチェーンは 1m→9m、9m→1m とラップする（天鳳準拠）。
+/// それ以外の牌は四麻と同じチェーンを使う。
+pub fn dora_indicator_to_dora_in(indicator: TileType, three_player: bool) -> TileType {
+    if three_player {
+        match indicator {
+            // 三麻の萬子: 1m→9m、9m→1m（2m〜8mは存在しない）
+            Tile::M1 => Tile::M9,
+            Tile::M9 => Tile::M1,
+            _ => dora_indicator_to_dora(indicator),
+        }
+    } else {
+        dora_indicator_to_dora(indicator)
+    }
+}
+
 /// ドラ表示牌から実際のドラを返す
 pub fn dora_indicator_to_dora(indicator: TileType) -> TileType {
     match indicator {
@@ -521,6 +539,24 @@ mod tests {
         assert_eq!(dora_indicator_to_dora(Tile::Z4), Tile::Z1);
         assert_eq!(dora_indicator_to_dora(Tile::Z5), Tile::Z6);
         assert_eq!(dora_indicator_to_dora(Tile::Z7), Tile::Z5);
+    }
+
+    /// 三麻のドラ表示牌テスト
+    #[test]
+    fn dora_indicator_three_player_test() {
+        // 三麻の萬子: 1m→9m、9m→1m にラップ（2m〜8mは存在しない）
+        assert_eq!(dora_indicator_to_dora_in(Tile::M1, true), Tile::M9);
+        assert_eq!(dora_indicator_to_dora_in(Tile::M9, true), Tile::M1);
+        // 萬子以外は四麻と同じチェーン
+        assert_eq!(dora_indicator_to_dora_in(Tile::P5, true), Tile::P6);
+        assert_eq!(dora_indicator_to_dora_in(Tile::P9, true), Tile::P1);
+        assert_eq!(dora_indicator_to_dora_in(Tile::S9, true), Tile::S1);
+        assert_eq!(dora_indicator_to_dora_in(Tile::Z1, true), Tile::Z2);
+        assert_eq!(dora_indicator_to_dora_in(Tile::Z4, true), Tile::Z1);
+        assert_eq!(dora_indicator_to_dora_in(Tile::Z7, true), Tile::Z5);
+        // 四麻フラグでは既存の挙動と一致
+        assert_eq!(dora_indicator_to_dora_in(Tile::M1, false), Tile::M2);
+        assert_eq!(dora_indicator_to_dora_in(Tile::M9, false), Tile::M1);
     }
 
     /// 赤ドラテスト

--- a/docs/glossary.ja.md
+++ b/docs/glossary.ja.md
@@ -51,6 +51,7 @@
 | 裏ドラ | ura dora | ura dora | — | リーチ和了時のみ公開される裏のドラ。 |
 | 槓ドラ | kan dora | kan dora | — | カン成立時に追加で公開されるドラ表示牌。 |
 | 赤ドラ / 赤五 | aka dora / aka five | red five | `Tile::new_red`, `Tile::is_red_dora` | +1 翻の赤い `5`。 |
+| 抜きドラ / 北ドラ | nuki-dora / kita-dora | kita dora | `DoraLabel::Kita` | 三人麻雀で抜いた北風牌。1枚につき +1 翻。 |
 
 ---
 
@@ -130,6 +131,9 @@
 | 四家立直 | sūcha riichi | four-riichi abortive draw | `Settings::four_riichi_draw` | オプション。 |
 | 九種九牌 | kyūshu kyūhai | nine terminals abortive draw | `Settings::nine_terminals_draw` | オプション。 |
 | 三家和 | sanchahō | triple-ron abortive draw | `Settings::triple_ron_draw` | オプション。 |
+| 三人麻雀 / 三麻 | sanma | three-player mahjong | `Settings::three_player` | 萬子2〜8を除外した108枚・チーなし・ツモ損で3人で打つ。 |
+| 北抜き | kita-nuki | kita (North extraction) | `Settings::nuki_dora` | 三麻専用。北風牌を晒して抜きドラとし、牌山から1枚補充する。 |
+| ツモ損 | tsumo-zon | tsumo loss | — | 三麻のツモ支払い方式。1人あたりの支払額は四麻と同じで、いない北家の分は貰えない。 |
 
 ---
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -52,6 +52,7 @@ A Japanese-language edition of this document is maintained in parallel at
 | 裏ドラ | ura dora | ura dora | — | Hidden dora revealed only on a riichi win. |
 | 槓ドラ | kan dora | kan dora | — | Extra dora indicator revealed when a quad is made. |
 | 赤ドラ / 赤五 | aka dora / aka five | red five | `Tile::new_red`, `Tile::is_red_dora` | A red `5` worth +1 han. |
+| 抜きドラ / 北ドラ | nuki-dora / kita-dora | kita dora | `DoraLabel::Kita` | In three-player mahjong: each extracted North tile is worth +1 han. |
 
 ---
 
@@ -131,6 +132,9 @@ A Japanese-language edition of this document is maintained in parallel at
 | 四家立直 | sūcha riichi | four-riichi abortive draw | `Settings::four_riichi_draw` | Optional rule. |
 | 九種九牌 | kyūshu kyūhai | nine terminals abortive draw | `Settings::nine_terminals_draw` | Optional rule. |
 | 三家和 | sanchahō | triple-ron abortive draw | `Settings::triple_ron_draw` | Optional rule. |
+| 三人麻雀 / 三麻 | sanma | three-player mahjong | `Settings::three_player` | Characters 2–8 removed (108 tiles); no chii; tsumo loss payments. |
+| 北抜き | kita-nuki | kita (North extraction) | `Settings::nuki_dora` | Three-player only: set aside a North tile as a kita dora and draw a replacement tile. |
+| ツモ損 | tsumo-zon | tsumo loss | — | Three-player tsumo payment style: per-person amounts are unchanged and the missing player's share is simply not received. |
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 1 of 6 for three-player mahjong (sanma) support (#257). Adds the core-crate primitives with **zero behavior change for four-player games**.

- Add `three_player` / `nuki_dora` flags and `player_count()` helper to `Settings`
  - `#[serde(default)]` keeps previously serialized settings deserializable
- Add `dora_indicator_to_dora_in(indicator, three_player)`: sanma manzu dora chain wraps 1m→9m and 9m→1m (Tenhou-style) since manzu 2-8 do not exist; all other tiles delegate to the existing chain
- Add `DoraLabel::Kita` ("北ドラ" / "Kita") for the kita dora line on result screens
- Add sanma / kita / tsumo-loss entries to `docs/glossary.md` and `docs/glossary.ja.md` as the canonical terminology for later phases

## Test plan

- [x] New unit tests: sanma dora chain, settings defaults & `player_count()`, backward-compatible deserialization, `DoraLabel::Kita` names
- [x] `cargo build && cargo test` (367 tests passed)
- [x] `cargo fmt` / `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)