### PR TITLE
Add three-player room support to the online server (#257, 4/6)

### DIFF
--- a/crates/mahjong-client/src/adapter/remote.rs
+++ b/crates/mahjong-client/src/adapter/remote.rs
@@ -41,12 +41,19 @@ pub struct RoomView {
     pub host_seat: usize,
     /// 自分の座席
     pub your_seat: usize,
+    /// 三麻（3人打ち）ルームか
+    pub three_player: bool,
 }
 
 impl RoomView {
     /// 自分がホストか
     pub fn is_host(&self) -> bool {
         self.your_seat == self.host_seat
+    }
+
+    /// プレイヤー人数を返す（四麻=4、三麻=3）
+    pub fn player_count(&self) -> usize {
+        if self.three_player { 3 } else { 4 }
     }
 }
 
@@ -63,8 +70,14 @@ pub struct RemoteError {
 
 /// Welcome 受信後に送るロビー操作
 enum LobbyIntent {
-    Create { round_count: u8 },
-    Join { code: String },
+    Create {
+        round_count: u8,
+        three_player: bool,
+        nuki_dora: bool,
+    },
+    Join {
+        code: String,
+    },
 }
 
 /// 自動再接続のバックオフ間隔（秒）。試行回数で頭打ちにする。
@@ -140,14 +153,24 @@ impl RemoteAdapter {
     }
 
     /// サーバに接続してルームを作成する
-    pub fn create_room(url: &str, display_name: &str, round_count: u8) -> Self {
+    pub fn create_room(
+        url: &str,
+        display_name: &str,
+        round_count: u8,
+        three_player: bool,
+        nuki_dora: bool,
+    ) -> Self {
         let (transport, connector) = Self::connector_for(url);
         Self::build(
             transport,
             connector,
             default_clock(),
             display_name,
-            LobbyIntent::Create { round_count },
+            LobbyIntent::Create {
+                round_count,
+                three_player,
+                nuki_dora,
+            },
         )
     }
 
@@ -318,9 +341,15 @@ impl RemoteAdapter {
                 self.status = ConnStatus::Connected;
                 if let Some(intent) = self.pending_intent.take() {
                     let msg = match intent {
-                        LobbyIntent::Create { round_count } => {
-                            ClientMessage::CreateRoom { round_count }
-                        }
+                        LobbyIntent::Create {
+                            round_count,
+                            three_player,
+                            nuki_dora,
+                        } => ClientMessage::CreateRoom {
+                            round_count,
+                            three_player,
+                            nuki_dora,
+                        },
                         LobbyIntent::Join { code } => ClientMessage::JoinRoom { code },
                     };
                     self.send(&msg);
@@ -331,6 +360,7 @@ impl RemoteAdapter {
                 seats,
                 host_seat,
                 your_seat,
+                three_player,
             } => {
                 self.room_code = Some(code.clone());
                 // 座席情報から人間プレイヤーの接続状態を取り込む
@@ -345,6 +375,7 @@ impl RemoteAdapter {
                     seats,
                     host_seat,
                     your_seat,
+                    three_player,
                 });
             }
             ServerMessage::Event(event) => {
@@ -586,7 +617,14 @@ mod tests {
 
     fn create_adapter() -> (RemoteAdapter, MockHandle) {
         let (transport, handle) = mock_pair();
-        let adapter = build_test(transport, LobbyIntent::Create { round_count: 1 });
+        let adapter = build_test(
+            transport,
+            LobbyIntent::Create {
+                round_count: 1,
+                three_player: false,
+                nuki_dora: true,
+            },
+        );
         (adapter, handle)
     }
 
@@ -611,6 +649,7 @@ mod tests {
             ],
             host_seat: 0,
             your_seat,
+            three_player: false,
         }
     }
 
@@ -660,7 +699,11 @@ mod tests {
         assert_eq!(sent.len(), 2);
         assert!(matches!(
             sent[1],
-            ClientMessage::CreateRoom { round_count: 1 }
+            ClientMessage::CreateRoom {
+                round_count: 1,
+                three_player: false,
+                nuki_dora: true,
+            }
         ));
     }
 
@@ -805,7 +848,11 @@ mod tests {
             connector,
             Box::new(move || clock_start.elapsed().as_secs_f64()),
             "E2Eテスト",
-            LobbyIntent::Create { round_count: 1 },
+            LobbyIntent::Create {
+                round_count: 1,
+                three_player: false,
+                nuki_dora: true,
+            },
         );
 
         let start = std::time::Instant::now();
@@ -1097,7 +1144,11 @@ mod tests {
             Box::new(|| panic!("再接続なし")),
             Box::new(move || *now_clock.borrow()),
             "テスト",
-            LobbyIntent::Create { round_count: 1 },
+            LobbyIntent::Create {
+                round_count: 1,
+                three_player: false,
+                nuki_dora: true,
+            },
         );
 
         // 手番タイマー（90秒）を受信
@@ -1124,7 +1175,11 @@ mod tests {
             Box::new(|| panic!("再接続なし")),
             Box::new(move || *now_clock.borrow()),
             "テスト",
-            LobbyIntent::Create { round_count: 1 },
+            LobbyIntent::Create {
+                round_count: 1,
+                three_player: false,
+                nuki_dora: true,
+            },
         );
         handle.push_msg(&ServerMessage::TurnTimer { seconds: 5 });
         adapter.tick();

--- a/crates/mahjong-client/src/main.rs
+++ b/crates/mahjong-client/src/main.rs
@@ -52,6 +52,10 @@ fn set_status(state: &mut GameState, message: &str, is_error: bool) {
 fn build_seat_labels(room: &RoomView, lang: Lang) -> [String; 4] {
     let tr = i18n::Translator::new(lang);
     std::array::from_fn(|i| {
+        // 三麻ルームでは使用しないシート3を表示しない
+        if i >= room.player_count() {
+            return String::new();
+        }
         let who = match &room.seats[i] {
             SeatInfo::Empty => tr.get(i18n::Key::EmptySeat).to_string(),
             SeatInfo::Cpu { level, personality } => tr.cpu_seat_label(*level, *personality),
@@ -229,7 +233,8 @@ async fn main() {
                         OnlineMenuAction::CreateRoom => {
                             let url = transport::default_server_url();
                             let name = display_name(&game_state);
-                            online = Some(RemoteAdapter::create_room(&url, &name, 1));
+                            // 三麻ルーム作成のUIはオンライン対応フェーズ（#257 Phase 6）で追加する
+                            online = Some(RemoteAdapter::create_room(&url, &name, 1, false, true));
                             let msg = i18n::Key::Connecting.text(game_state.lang);
                             set_status(&mut game_state, msg, false);
                         }

--- a/crates/mahjong-net-server/src/connection.rs
+++ b/crates/mahjong-net-server/src/connection.rs
@@ -207,7 +207,11 @@ impl Connection {
             };
 
             let room_tx = match msg {
-                ClientMessage::CreateRoom { round_count } => {
+                ClientMessage::CreateRoom {
+                    round_count,
+                    three_player,
+                    nuki_dora,
+                } => {
                     if !self.allow_room_entry() {
                         self.send_error(ErrorCode::RateLimited, "too many room attempts")
                             .await;
@@ -218,9 +222,16 @@ impl Connection {
                             .await;
                         continue;
                     }
-                    let settings = GameSettings {
-                        round_count,
-                        ..GameSettings::default()
+                    let settings = if three_player {
+                        let mut settings = GameSettings::sanma_default();
+                        settings.round_count = round_count;
+                        settings.rules.nuki_dora = nuki_dora;
+                        settings
+                    } else {
+                        GameSettings {
+                            round_count,
+                            ..GameSettings::default()
+                        }
                     };
                     let (_code, room_tx) = self.state.lobby.create_room(settings);
                     Some(room_tx)

--- a/crates/mahjong-net-server/src/room.rs
+++ b/crates/mahjong-net-server/src/room.rs
@@ -237,6 +237,11 @@ impl Room {
         self.driver.is_some()
     }
 
+    /// プレイヤー人数を返す（四麻=4、三麻=3。三麻ではシート3は常に空席）
+    fn player_count(&self) -> usize {
+        self.settings.rules.player_count()
+    }
+
     fn handle_msg(&mut self, msg: RoomMsg) {
         match msg {
             RoomMsg::Join {
@@ -311,9 +316,8 @@ impl Room {
             });
         }
 
-        // 新規入室: 空席へ
-        let seat = self
-            .seats
+        // 新規入室: 空席へ（三麻ではシート0〜2のみ使用する）
+        let seat = self.seats[..self.player_count()]
             .iter()
             .position(|s| s.is_none())
             .ok_or(ErrorCode::RoomFull)?;
@@ -413,7 +417,7 @@ impl Room {
         }
 
         let mut driver = GameDriver::new(self.settings.clone());
-        for s in 0..4 {
+        for s in 0..self.player_count() {
             let config = config_for_seat(&self.cpu_configs, s);
             if self.seats[s].is_some() {
                 // 人間の座席にもシャドーCPUを常駐させ、切断時に即代打ちできるようにする
@@ -728,7 +732,7 @@ impl Room {
                 connected: seat.tx.is_some(),
             },
             None => {
-                if self.game_started() {
+                if self.game_started() && s < self.player_count() {
                     // 対局開始時の割り当てと同じ規則で強さ・性格を求める
                     let config = config_for_seat(&self.cpu_configs, s);
                     SeatInfo::Cpu {
@@ -763,6 +767,7 @@ impl Room {
             seats: seats_info.clone(),
             host_seat: HOST_SEAT,
             your_seat: seat,
+            three_player: self.settings.rules.three_player,
         };
         self.send_to_seat(seat, msg);
     }

--- a/crates/mahjong-net-server/tests/integration.rs
+++ b/crates/mahjong-net-server/tests/integration.rs
@@ -150,10 +150,36 @@ impl TestClient {
 
     /// ルームを作成し、ルームコードを返す
     async fn create_room(&mut self) -> String {
-        self.send(&ClientMessage::CreateRoom { round_count: 1 })
-            .await;
+        self.send(&ClientMessage::CreateRoom {
+            round_count: 1,
+            three_player: false,
+            nuki_dora: true,
+        })
+        .await;
         match self.recv().await {
             ServerMessage::RoomState { code, .. } => code,
+            other => panic!("RoomStateでないメッセージ: {other:?}"),
+        }
+    }
+
+    /// 三麻ルームを作成し、ルームコードを返す
+    async fn create_sanma_room(&mut self) -> String {
+        self.send(&ClientMessage::CreateRoom {
+            round_count: 1,
+            three_player: true,
+            nuki_dora: true,
+        })
+        .await;
+        match self.recv().await {
+            ServerMessage::RoomState {
+                code, three_player, ..
+            } => {
+                assert!(
+                    three_player,
+                    "三麻ルームの RoomState に three_player が立っていない"
+                );
+                code
+            }
             other => panic!("RoomStateでないメッセージ: {other:?}"),
         }
     }
@@ -449,6 +475,91 @@ async fn test_room_full() {
         .send(&ClientMessage::JoinRoom { code: code.clone() })
         .await;
     assert_eq!(fifth.recv_error().await, ErrorCode::RoomFull);
+}
+
+/// 三麻ルームは3人で満席になる（4人目は RoomFull）
+#[tokio::test]
+async fn test_sanma_room_full_at_three() {
+    let addr = start_server(fast_config()).await;
+
+    let mut host = TestClient::connect(addr).await;
+    host.hello("ホスト").await;
+    let code = host.create_sanma_room().await;
+
+    let mut guests = Vec::new();
+    for i in 0..2 {
+        let mut guest = TestClient::connect(addr).await;
+        guest.hello(&format!("ゲスト{i}")).await;
+        guest
+            .send(&ClientMessage::JoinRoom { code: code.clone() })
+            .await;
+        match guest.recv().await {
+            ServerMessage::RoomState { your_seat, .. } => assert_eq!(your_seat, i + 1),
+            other => panic!("RoomStateでないメッセージ: {other:?}"),
+        }
+        guests.push(guest);
+    }
+
+    // 4人目はシート3が使用不可のため満席エラーになる
+    let mut fourth = TestClient::connect(addr).await;
+    fourth.hello("4人目").await;
+    fourth
+        .send(&ClientMessage::JoinRoom { code: code.clone() })
+        .await;
+    assert_eq!(fourth.recv_error().await, ErrorCode::RoomFull);
+}
+
+/// 三麻ルームで 2人の人間 + CPU1人が東風戦（東1〜3局）を打ち切れることを確認する
+#[tokio::test]
+async fn test_sanma_full_game_with_two_humans() {
+    tokio::time::timeout(Duration::from_secs(120), async {
+        let addr = start_server(fast_config()).await;
+
+        let mut host = TestClient::connect(addr).await;
+        host.hello("ホスト").await;
+        let code = host.create_sanma_room().await;
+
+        let mut guest = TestClient::connect(addr).await;
+        guest.hello("ゲスト").await;
+        guest
+            .send(&ClientMessage::JoinRoom { code: code.clone() })
+            .await;
+        match guest.recv().await {
+            ServerMessage::RoomState { your_seat, .. } => assert_eq!(your_seat, 1),
+            other => panic!("RoomStateでないメッセージ: {other:?}"),
+        }
+        // ホスト側の更新 RoomState を読み捨てる
+        match host.recv().await {
+            ServerMessage::RoomState { .. } => {}
+            other => panic!("RoomStateでないメッセージ: {other:?}"),
+        }
+
+        host.send(&ClientMessage::StartGame { cpu_configs: None })
+            .await;
+
+        let (host_scores, guest_scores) = tokio::join!(
+            host.play_until_game_over(true),
+            guest.play_until_game_over(true),
+        );
+
+        // 両者が同じ最終得点を観測している
+        assert_eq!(host_scores, guest_scores);
+        // ダミー席（シート3）の点数は常に0
+        assert_eq!(host_scores[3], 0, "三麻でシート3に点数が入っている");
+        // 総和は 35000×3 以下で、差は供託（1000点）単位
+        let sum: i32 = host_scores.iter().sum();
+        assert!(
+            sum <= 35000 * 3,
+            "総和が初期点数を超えている: {host_scores:?}"
+        );
+        assert_eq!(
+            (35000 * 3 - sum) % 1000,
+            0,
+            "総和の差が供託単位でない: {host_scores:?}"
+        );
+    })
+    .await
+    .expect("テスト全体がタイムアウトした");
 }
 
 /// ホスト以外の StartGame は NotHost になる

--- a/crates/mahjong-server/src/protocol/net.rs
+++ b/crates/mahjong-server/src/protocol/net.rs
@@ -12,7 +12,8 @@ use crate::cpu::client::{CpuConfig, CpuLevel, CpuPersonality};
 ///
 /// 互換性のない変更を入れる際にインクリメントする。
 /// `Hello` で照合し、不一致なら `ErrorCode::VersionMismatch` で切断する。
-pub const PROTOCOL_VERSION: u32 = 2;
+/// v3: 三麻対応（CreateRoom の three_player/nuki_dora、RoomState の three_player）
+pub const PROTOCOL_VERSION: u32 = 3;
 
 /// CPUの強さ・性格の指定
 ///
@@ -40,6 +41,11 @@ impl CpuSpec {
     }
 }
 
+/// serde デフォルト用: true を返す
+fn default_true() -> bool {
+    true
+}
+
 /// クライアントからサーバへのメッセージ
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ClientMessage {
@@ -57,6 +63,12 @@ pub enum ClientMessage {
     CreateRoom {
         /// 東風戦(1)か東南戦(2)か
         round_count: u8,
+        /// 三麻（3人打ち）ルームか
+        #[serde(default)]
+        three_player: bool,
+        /// 北抜きドラありか（三麻のみ有効）
+        #[serde(default = "default_true")]
+        nuki_dora: bool,
     },
 
     /// ルームコードを指定して参加する
@@ -97,12 +109,15 @@ pub enum ServerMessage {
     RoomState {
         /// ルームコード
         code: String,
-        /// 各座席の状態（座席インデックス順）
+        /// 各座席の状態（座席インデックス順。三麻ではシート3は常に空席）
         seats: [SeatInfo; 4],
         /// ホストの座席インデックス
         host_seat: usize,
         /// 受信者自身の座席インデックス
         your_seat: usize,
+        /// 三麻（3人打ち）ルームか
+        #[serde(default)]
+        three_player: bool,
     },
 
     /// ゲーム内イベント
@@ -242,7 +257,16 @@ mod tests {
                 session_token: None,
                 display_name: String::new(),
             },
-            ClientMessage::CreateRoom { round_count: 2 },
+            ClientMessage::CreateRoom {
+                round_count: 2,
+                three_player: false,
+                nuki_dora: true,
+            },
+            ClientMessage::CreateRoom {
+                round_count: 1,
+                three_player: true,
+                nuki_dora: false,
+            },
             ClientMessage::JoinRoom {
                 code: "ABC234".to_string(),
             },
@@ -307,6 +331,7 @@ mod tests {
                 ],
                 host_seat: 0,
                 your_seat: 1,
+                three_player: false,
             },
             ServerMessage::Event(ServerEvent::TileDrawn {
                 tile: Tile::new(Tile::P5),


### PR DESCRIPTION
## Summary

Phase 4 of 6 for three-player mahjong (#257), stacked on #260. Adds sanma rooms to the online multiplayer server.

- **Protocol v3**: `CreateRoom` carries serde-defaulted `three_player` / `nuki_dora`; `RoomState` carries `three_player` so clients know the mode in the lobby, before `GameStarted`
- **connection.rs**: sanma rooms are created from `GameSettings::sanma_default()` (35000 points) with the requested round count and nuki-dora setting
- **room.rs**: joins fill seats `0..player_count` only (a sanma room is `RoomFull` at 3 humans); `StartGame` assigns CPUs / shadow CPUs to 3 seats; `seats_info` reports seat 3 as `Empty` in sanma. The `[CpuConfig; 3]` shape is kept (3rd entry unused in sanma) to avoid protocol churn
- **Client adapter** (compile-level; creation UI lands in Phase 6): `LobbyIntent::Create` / `RoomView` / `create_room()` carry the flags; the lobby seat list hides seat 3 in sanma rooms

## Test plan

- [x] New integration tests: `test_sanma_room_full_at_three` (4th join rejected with RoomFull) and `test_sanma_full_game_with_two_humans` (2 humans + 1 CPU play a sanma East game to GameOver; both observe identical final scores, seat 3 stays 0, sum conserved modulo riichi deposits against 35000×3)
- [x] Protocol roundtrip tests updated for both CreateRoom shapes and RoomState
- [x] `cargo build && cargo test` — full workspace green (19 integration tests)
- [x] `cargo fmt` / `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)