### PR TITLE
Rename kita to pei for the North extraction terminology (#257)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Implementation for Japanese Riichi Mahjong in Rust.
   - Disconnected players are taken over by the CPU and can rejoin to resync.
 - Three-player mahjong (sanma) is supported, both locally and online.
   - Characters 2–8 are removed (108 tiles, red fives 5p/5s only), chii is not available, and tsumo wins use tsumo-loss payments (per-person amounts are unchanged; the missing player's share is simply not received).
-  - Kita (extracting a North tile as a bonus dora with a replacement draw) is supported and can be toggled per game; the manzu dora chain wraps 1m ↔ 9m.
+  - Pei (extracting a North tile as a bonus dora with a replacement draw) is supported and can be toggled per game; the manzu dora chain wraps 1m ↔ 9m.
   - Games start with 35,000 points; an East-only game is East 1–3.
 - Vercel deployment using the included scripts is supported (static web client).
 

--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -261,9 +261,9 @@ pub struct GameState {
     /// 北抜きドラが有効か（三麻のみ true になり得る）
     pub nuki_dora: bool,
     /// 各プレイヤーの北抜き枚数（風のインデックス順: 東=0, 南=1, 西=2）
-    pub kita_counts: [u8; 4],
+    pub pei_counts: [u8; 4],
     /// 北抜き可能か（自分の手番で手牌・ツモ牌に北がある場合）
-    pub can_kita: bool,
+    pub can_pei: bool,
     /// 表示言語
     pub lang: Lang,
 }
@@ -499,8 +499,8 @@ impl GameState {
             my_seat: 0,
             player_count: 4,
             nuki_dora: false,
-            kita_counts: [0; 4],
-            can_kita: false,
+            pei_counts: [0; 4],
+            can_pei: false,
             // 保存された表示言語を読み込む（未保存なら日本語）。
             // 「もう一度」などで new() が再生成されても選択を保つ。
             lang: crate::persistence::load_lang().unwrap_or(Lang::Ja),
@@ -554,8 +554,8 @@ impl GameState {
             } => {
                 self.player_count = if three_player { 3 } else { 4 };
                 self.nuki_dora = nuki_dora;
-                self.kita_counts = [0; 4];
-                self.can_kita = false;
+                self.pei_counts = [0; 4];
+                self.can_pei = false;
                 self.seat_wind = Some(seat_wind);
                 self.hand = hand;
                 self.hand.sort();
@@ -615,7 +615,7 @@ impl GameState {
                 self.available_calls.clear();
                 self.call_target_tile = None;
                 self.refresh_self_kan_options();
-                self.refresh_can_kita();
+                self.refresh_can_pei();
                 // ツモ後は喰い替え制限が解除される
                 self.forbidden_discards.clear();
                 self.selected_forbidden_swap = false;
@@ -673,7 +673,7 @@ impl GameState {
                     self.selected_drawn = false;
                     self.clear_riichi_selection();
                     self.self_kan_options.clear();
-                    self.can_kita = false;
+                    self.can_pei = false;
                     // 打牌が完了したので喰い替え制限を解除する
                     self.forbidden_discards.clear();
                     self.selected_forbidden_swap = false;
@@ -860,11 +860,8 @@ impl GameState {
                 self.dora_indicators = dora_indicators;
             }
 
-            ServerEvent::KitaDeclared {
-                player,
-                kita_counts,
-            } => {
-                self.kita_counts = kita_counts;
+            ServerEvent::PeiDeclared { player, pei_counts } => {
+                self.pei_counts = pei_counts;
                 // 他家の北抜きは手牌が1枚減って見える（補充ツモで戻る）
                 let relative_idx = self.relative_player_index(player);
                 if relative_idx > 0 {
@@ -1301,16 +1298,16 @@ impl GameState {
     /// 北抜き可能かを更新する（三麻+北抜きあり時のみ）
     ///
     /// リーチ中はツモった牌が北の場合のみ可能。
-    fn refresh_can_kita(&mut self) {
-        self.can_kita = false;
+    fn refresh_can_pei(&mut self) {
+        self.can_pei = false;
         if !self.is_three_player() || !self.nuki_dora {
             return;
         }
         let drawn_is_north = self.drawn.is_some_and(|t| t.get() == Tile::Z4);
         if self.is_riichi {
-            self.can_kita = drawn_is_north;
+            self.can_pei = drawn_is_north;
         } else {
-            self.can_kita = drawn_is_north || self.hand.iter().any(|t| t.get() == Tile::Z4);
+            self.can_pei = drawn_is_north || self.hand.iter().any(|t| t.get() == Tile::Z4);
         }
     }
 
@@ -1681,7 +1678,7 @@ mod tests {
         assert_eq!(state.player_count, 3);
         assert!(state.is_three_player());
         assert!(state.nuki_dora);
-        assert_eq!(state.kita_counts, [0; 4]);
+        assert_eq!(state.pei_counts, [0; 4]);
     }
 
     #[test]
@@ -1703,24 +1700,24 @@ mod tests {
     }
 
     #[test]
-    fn test_sanma_kita_declared_updates_counts() {
+    fn test_sanma_pei_declared_updates_counts() {
         let mut state = GameState::new();
         state.handle_event(sanma_game_started(Wind::East));
         // 他家（南家）の手牌枚数を通常の13枚にしておく
         state.other_players[0].concealed_count = 13;
 
-        state.handle_event(ServerEvent::KitaDeclared {
+        state.handle_event(ServerEvent::PeiDeclared {
             player: Wind::South,
-            kita_counts: [0, 1, 0, 0],
+            pei_counts: [0, 1, 0, 0],
         });
 
-        assert_eq!(state.kita_counts, [0, 1, 0, 0]);
+        assert_eq!(state.pei_counts, [0, 1, 0, 0]);
         // 北を抜いた分、南家の伏せ牌は一時的に1枚減って見える
         assert_eq!(state.other_players[0].concealed_count, 12);
     }
 
     #[test]
-    fn test_sanma_can_kita_with_north_in_hand() {
+    fn test_sanma_can_pei_with_north_in_hand() {
         let mut state = GameState::new();
         state.handle_event(sanma_game_started(Wind::East));
         state.hand = vec![Tile::new(Tile::Z4)];
@@ -1732,7 +1729,7 @@ mod tests {
             can_riichi: false,
             is_furiten: false,
         });
-        assert!(state.can_kita, "手牌に北があるのに北抜き不可");
+        assert!(state.can_pei, "手牌に北があるのに北抜き不可");
 
         // リーチ中は手牌の北だけでは抜けない
         state.is_riichi = true;
@@ -1743,7 +1740,7 @@ mod tests {
             can_riichi: false,
             is_furiten: false,
         });
-        assert!(!state.can_kita, "リーチ中の手牌北で北抜き可になっている");
+        assert!(!state.can_pei, "リーチ中の手牌北で北抜き可になっている");
 
         // リーチ中でもツモった牌が北なら抜ける
         state.handle_event(ServerEvent::TileDrawn {
@@ -1753,7 +1750,7 @@ mod tests {
             can_riichi: false,
             is_furiten: false,
         });
-        assert!(state.can_kita, "リーチ中のツモ北で北抜き不可");
+        assert!(state.can_pei, "リーチ中のツモ北で北抜き不可");
     }
 
     #[test]

--- a/crates/mahjong-client/src/i18n/mod.rs
+++ b/crates/mahjong-client/src/i18n/mod.rs
@@ -337,7 +337,7 @@ pub enum Key {
     /// チー
     Chi,
     /// 北抜き（三麻の抜きドラ宣言ボタン）
-    Kita,
+    Pei,
     /// パス
     Pass,
     /// キャンセル
@@ -418,7 +418,7 @@ impl Key {
             },
             Key::NukiDoraToggle => match lang {
                 Lang::Ja => "北抜きドラ",
-                Lang::En => "Kita dora",
+                Lang::En => "Pei dora",
             },
             Key::CpuStrengthLabel => match lang {
                 Lang::Ja => "強さ",
@@ -534,9 +534,9 @@ impl Key {
                 // 用語集（docs/glossary.md）に合わせ "chii" を用いる
                 Lang::En => "Chii",
             },
-            Key::Kita => match lang {
+            Key::Pei => match lang {
                 Lang::Ja => "北抜き",
-                Lang::En => "Kita",
+                Lang::En => "Pei",
             },
             Key::Pass => match lang {
                 Lang::Ja => "パス",

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -694,11 +694,11 @@ fn draw_discards(state: &GameState, tile_textures: &TileTextures) {
         // 北抜き牌（三麻）: 捨て牌エリアの右横に小さく並べる
         if state.is_three_player() {
             let wind_idx = (my_wind_idx + rel) % state.player_count;
-            let kita = state.kita_counts[wind_idx] as usize;
+            let pei = state.pei_counts[wind_idx] as usize;
             let north = mahjong_core::tile::Tile::new(mahjong_core::tile::Tile::Z4);
             let kw = dtw * 0.75;
             let kh = dth * 0.75;
-            for k in 0..kita {
+            for k in 0..pei {
                 draw_tile_sprite(
                     tile_textures.for_tile(&north),
                     BOARD_CENTER_X + half_width + 10.0 + k as f32 * (kw * 0.6),

--- a/crates/mahjong-client/src/renderer/overlay.rs
+++ b/crates/mahjong-client/src/renderer/overlay.rs
@@ -286,7 +286,7 @@ pub(super) fn draw_action_buttons(
     }
 
     // 北抜きボタン（三麻+北抜きあり時のみ。暗カンボタンの並びに置く）
-    if state.can_kita {
+    if state.can_pei {
         let x = AGARI_BTN_X + state.self_kan_options.len() as f32 * (KAN_BTN_W + 10.0);
         theme::draw_gradient_button(
             x,
@@ -301,14 +301,14 @@ pub(super) fn draw_action_buttons(
         );
         theme::draw_text_centered(
             font,
-            tr.get(Key::Kita),
+            tr.get(Key::Pei),
             x + KAN_BTN_W / 2.0,
             KAN_BTN_Y + KAN_BTN_H / 2.0 + 6.0,
             SMALL_FONT,
             WHITE,
         );
         if clicked && result.is_none() && hit_rect(mx, my, x, KAN_BTN_Y, KAN_BTN_W, KAN_BTN_H) {
-            result = Some(OverlayClick::Action(ClientAction::Kita));
+            result = Some(OverlayClick::Action(ClientAction::Pei));
         }
     }
 

--- a/crates/mahjong-core/src/scoring/score.rs
+++ b/crates/mahjong-core/src/scoring/score.rs
@@ -118,7 +118,7 @@ pub enum DoraLabel {
     /// 裏ドラ
     UraDora,
     /// 北ドラ（三麻の北抜き。抜いた北風牌1枚につき1翻）
-    Kita,
+    PeiDora,
 }
 
 impl DoraLabel {
@@ -131,13 +131,13 @@ impl DoraLabel {
                 DoraLabel::Dora => "Dora",
                 DoraLabel::RedDora => "Red Five",
                 DoraLabel::UraDora => "Ura Dora",
-                DoraLabel::Kita => "Kita",
+                DoraLabel::PeiDora => "Pei Dora",
             },
             Lang::Ja => match self {
                 DoraLabel::Dora => "ドラ",
                 DoraLabel::RedDora => "赤ドラ",
                 DoraLabel::UraDora => "裏ドラ",
-                DoraLabel::Kita => "北ドラ",
+                DoraLabel::PeiDora => "北ドラ",
             },
         }
     }
@@ -643,7 +643,7 @@ mod tests {
         assert_eq!(DoraLabel::Dora.name(Lang::Ja), "ドラ");
         assert_eq!(DoraLabel::RedDora.name(Lang::Ja), "赤ドラ");
         assert_eq!(DoraLabel::UraDora.name(Lang::Ja), "裏ドラ");
-        assert_eq!(DoraLabel::Kita.name(Lang::Ja), "北ドラ");
+        assert_eq!(DoraLabel::PeiDora.name(Lang::Ja), "北ドラ");
     }
 
     /// ドラ種別名（英語）
@@ -652,6 +652,6 @@ mod tests {
         assert_eq!(DoraLabel::Dora.name(Lang::En), "Dora");
         assert_eq!(DoraLabel::RedDora.name(Lang::En), "Red Five");
         assert_eq!(DoraLabel::UraDora.name(Lang::En), "Ura Dora");
-        assert_eq!(DoraLabel::Kita.name(Lang::En), "Kita");
+        assert_eq!(DoraLabel::PeiDora.name(Lang::En), "Pei Dora");
     }
 }

--- a/crates/mahjong-server/src/cpu/client.rs
+++ b/crates/mahjong-server/src/cpu/client.rs
@@ -187,8 +187,8 @@ impl CpuClient {
         }
 
         // 北抜き検討（三麻+北抜きありのみ。リーチ中はツモった北のみ抜ける）
-        if let Some(kita_action) = self.consider_kita() {
-            return kita_action;
+        if let Some(pei_action) = self.consider_pei() {
+            return pei_action;
         }
 
         // リーチ中はツモ切りのみ
@@ -413,7 +413,7 @@ impl CpuClient {
     /// 手牌・ツモ牌に北風牌があればほぼ常に抜く（1枚=確定1翻+補充ツモ）。
     /// 例外: 国士無双を狙っている手（国士の向聴数が最良かつ3向聴以内）では北を残す。
     /// リーチ中はツモった北のみ抜ける。
-    fn consider_kita(&self) -> Option<ClientAction> {
+    fn consider_pei(&self) -> Option<ClientAction> {
         if !(self.state.three_player && self.state.nuki_dora) {
             return None;
         }
@@ -422,7 +422,7 @@ impl CpuClient {
 
         if self.state.is_riichi {
             // リーチ中: ツモった北のみ抜ける（can_tsumo は呼び出し元で判定済み）
-            return drawn_is_north.then_some(ClientAction::Kita);
+            return drawn_is_north.then_some(ClientAction::Pei);
         }
 
         let hand_has_north = self.state.my_hand.iter().any(|t| t.get() == Tile::Z4);
@@ -441,7 +441,7 @@ impl CpuClient {
             }
         }
 
-        Some(ClientAction::Kita)
+        Some(ClientAction::Pei)
     }
 
     /// 暗カンを検討する

--- a/crates/mahjong-server/src/cpu/client_tests.rs
+++ b/crates/mahjong-server/src/cpu/client_tests.rs
@@ -72,7 +72,7 @@ fn test_should_attack_counts_melds_when_tenpai() {
 // ===== 北抜き（#257 Phase 3） =====
 
 #[test]
-fn test_consider_kita_declares_with_north_in_hand() {
+fn test_consider_pei_declares_with_north_in_hand() {
     let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
     let mut client = CpuClient::new(config);
     client.state.three_player = true;
@@ -95,32 +95,32 @@ fn test_consider_kita_declares_with_north_in_hand() {
     ];
     client.state.my_drawn = Some(Tile::new(Tile::S7));
 
-    assert_eq!(client.consider_kita(), Some(ClientAction::Kita));
+    assert_eq!(client.consider_pei(), Some(ClientAction::Pei));
 }
 
 #[test]
-fn test_consider_kita_none_in_four_player() {
+fn test_consider_pei_none_in_four_player() {
     let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
     let mut client = CpuClient::new(config);
     client.state.three_player = false;
     client.state.my_hand = vec![Tile::new(Tile::Z4)];
 
-    assert_eq!(client.consider_kita(), None);
+    assert_eq!(client.consider_pei(), None);
 }
 
 #[test]
-fn test_consider_kita_none_when_nuki_dora_disabled() {
+fn test_consider_pei_none_when_nuki_dora_disabled() {
     let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
     let mut client = CpuClient::new(config);
     client.state.three_player = true;
     client.state.nuki_dora = false;
     client.state.my_hand = vec![Tile::new(Tile::Z4)];
 
-    assert_eq!(client.consider_kita(), None);
+    assert_eq!(client.consider_pei(), None);
 }
 
 #[test]
-fn test_consider_kita_keeps_north_for_kokushi() {
+fn test_consider_pei_keeps_north_for_kokushi() {
     let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
     let mut client = CpuClient::new(config);
     client.state.three_player = true;
@@ -142,11 +142,11 @@ fn test_consider_kita_keeps_north_for_kokushi() {
         Tile::new(Tile::Z7),
     ];
 
-    assert_eq!(client.consider_kita(), None);
+    assert_eq!(client.consider_pei(), None);
 }
 
 #[test]
-fn test_consider_kita_riichi_only_drawn_north() {
+fn test_consider_pei_riichi_only_drawn_north() {
     let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
     let mut client = CpuClient::new(config);
     client.state.three_player = true;
@@ -154,10 +154,10 @@ fn test_consider_kita_riichi_only_drawn_north() {
     client.state.is_riichi = true;
     client.state.my_hand = vec![Tile::new(Tile::Z4)]; // リーチ中の手牌は抜けない
 
-    assert_eq!(client.consider_kita(), None);
+    assert_eq!(client.consider_pei(), None);
 
     client.state.my_drawn = Some(Tile::new(Tile::Z4));
-    assert_eq!(client.consider_kita(), Some(ClientAction::Kita));
+    assert_eq!(client.consider_pei(), Some(ClientAction::Pei));
 }
 
 #[test]

--- a/crates/mahjong-server/src/cpu/state.rs
+++ b/crates/mahjong-server/src/cpu/state.rs
@@ -59,7 +59,7 @@ pub struct CpuGameState {
     /// 北抜きドラが有効か（三麻のみ true になり得る）
     pub nuki_dora: bool,
     /// 各プレイヤーの北抜き枚数（風のインデックス順: 東=0, 南=1, 西=2）
-    pub kita_counts: [u8; 4],
+    pub pei_counts: [u8; 4],
 
     // --- 鳴き関連 ---
     /// 現在利用可能な鳴きアクション
@@ -99,7 +99,7 @@ impl CpuGameState {
             riichi_sticks: 0,
             three_player: false,
             nuki_dora: false,
-            kita_counts: [0; 4],
+            pei_counts: [0; 4],
             pending_calls: Vec::new(),
             pending_call_tile: None,
             need_discard_after_call: false,
@@ -156,7 +156,7 @@ impl CpuGameState {
                 self.round_wind = *round_wind;
                 self.three_player = *three_player;
                 self.nuki_dora = *nuki_dora;
-                self.kita_counts = [0; 4];
+                self.pei_counts = [0; 4];
                 // 四麻: 136 - 14(王牌) - 13*4(配牌) = 70
                 // 三麻: 108 - 14(王牌) - 13*3(配牌) = 55
                 self.remaining_tiles = if *three_player { 55 } else { 70 };
@@ -301,11 +301,8 @@ impl CpuGameState {
                 self.dora_indicators = dora_indicators.clone();
             }
 
-            ServerEvent::KitaDeclared {
-                player,
-                kita_counts,
-            } => {
-                self.kita_counts = *kita_counts;
+            ServerEvent::PeiDeclared { player, pei_counts } => {
+                self.pei_counts = *pei_counts;
                 if *player == self.my_seat_wind {
                     // 自分の北抜き: 補充ツモ（TileDrawn）が来るまで打牌不要
                     // （直後の HandUpdated で打牌判断を始めないようにする）
@@ -444,8 +441,8 @@ impl CpuGameState {
         }
 
         // 北抜きで晒された北風牌（手牌にも河にも現れないため個別に加算）
-        let total_kita: u8 = self.kita_counts.iter().sum();
-        counts[Tile::Z4 as usize] = (counts[Tile::Z4 as usize] + total_kita).min(4);
+        let total_pei: u8 = self.pei_counts.iter().sum();
+        counts[Tile::Z4 as usize] = (counts[Tile::Z4 as usize] + total_pei).min(4);
 
         // 三麻ではゲームに存在しない萬子2〜8を「全て見えている」扱いにする。
         // これにより受け入れ枚数（4 - visible）や死に牌判定（visible >= 4）が

--- a/crates/mahjong-server/src/player.rs
+++ b/crates/mahjong-server/src/player.rs
@@ -37,7 +37,7 @@ pub struct Player {
     /// （チー・ポン直後にのみ設定され、打牌またはツモで解除される）
     forbidden_discards: Vec<TileType>,
     /// 北抜きで晒した北風牌（三麻の抜きドラ。1枚につき和了時+1翻）
-    pub kita_tiles: Vec<Tile>,
+    pub pei_tiles: Vec<Tile>,
 }
 
 /// 捨て牌1枚の情報
@@ -70,14 +70,14 @@ impl Player {
             is_riichi_furiten: false,
             is_temporary_furiten: false,
             forbidden_discards: Vec::new(),
-            kita_tiles: Vec::new(),
+            pei_tiles: Vec::new(),
         }
     }
 
     /// 北抜き可能かを返す（手牌またはツモ牌に北風牌があるか）
     ///
     /// リーチ後はツモった牌が北の場合のみ抜ける（手牌は固定のため）。
-    pub fn can_kita(&self) -> bool {
+    pub fn can_pei(&self) -> bool {
         if self.is_riichi {
             return self.hand.drawn().is_some_and(|t| t.get() == Tile::Z4);
         }
@@ -88,8 +88,8 @@ impl Player {
     /// 北抜きを実行する（北風牌1枚を手牌またはツモ牌から取り除いて晒す）
     ///
     /// 成功したら true。ツモ牌が北ならツモ牌を優先して抜く。
-    pub fn do_kita(&mut self) -> bool {
-        if !self.can_kita() {
+    pub fn do_pei(&mut self) -> bool {
+        if !self.can_pei() {
             return false;
         }
 
@@ -97,7 +97,7 @@ impl Player {
             // ツモ牌の北を抜く
             let tile = self.hand.drawn().unwrap();
             self.hand.set_drawn(None);
-            self.kita_tiles.push(tile);
+            self.pei_tiles.push(tile);
             return true;
         }
 
@@ -113,7 +113,7 @@ impl Player {
             tiles.sort();
         }
         self.hand.set_drawn(None);
-        self.kita_tiles.push(tile);
+        self.pei_tiles.push(tile);
         true
     }
 
@@ -1041,51 +1041,51 @@ mod tests {
     }
 
     #[test]
-    fn test_can_kita_and_do_kita_from_hand() {
+    fn test_can_pei_and_do_pei_from_hand() {
         let mut player = Player::new(Wind::East, make_test_tiles(), 35000);
         // make_test_tiles は 4z（北）を1枚含む
-        assert!(player.can_kita());
+        assert!(player.can_pei());
 
         player.draw(Tile::new(Tile::P1));
-        assert!(player.do_kita());
+        assert!(player.do_pei());
 
         // 北が手牌から抜かれ、ツモ牌が手牌に組み込まれる（13枚のまま）
-        assert_eq!(player.kita_tiles.len(), 1);
-        assert_eq!(player.kita_tiles[0].get(), Tile::Z4);
+        assert_eq!(player.pei_tiles.len(), 1);
+        assert_eq!(player.pei_tiles[0].get(), Tile::Z4);
         assert_eq!(player.hand.tiles().len(), 13);
         assert!(player.hand.drawn().is_none());
         assert!(!player.hand.tiles().iter().any(|t| t.get() == Tile::Z4));
     }
 
     #[test]
-    fn test_do_kita_prefers_drawn_north() {
+    fn test_do_pei_prefers_drawn_north() {
         let mut player = Player::new(Wind::East, make_test_tiles(), 35000);
         player.draw(Tile::new(Tile::Z4));
-        assert!(player.do_kita());
+        assert!(player.do_pei());
 
         // ツモった北を優先して抜くため、手牌の北は残る
-        assert_eq!(player.kita_tiles.len(), 1);
+        assert_eq!(player.pei_tiles.len(), 1);
         assert!(player.hand.tiles().iter().any(|t| t.get() == Tile::Z4));
         assert!(player.hand.drawn().is_none());
     }
 
     #[test]
-    fn test_can_kita_riichi_only_drawn_north() {
+    fn test_can_pei_riichi_only_drawn_north() {
         let mut player = Player::new(Wind::East, make_test_tiles(), 35000);
         player.is_riichi = true;
 
         // リーチ中は手牌の北だけでは抜けない
-        assert!(!player.can_kita());
+        assert!(!player.can_pei());
 
         // ツモった牌が北なら抜ける
         player.draw(Tile::new(Tile::Z4));
-        assert!(player.can_kita());
-        assert!(player.do_kita());
-        assert_eq!(player.kita_tiles.len(), 1);
+        assert!(player.can_pei());
+        assert!(player.do_pei());
+        assert_eq!(player.pei_tiles.len(), 1);
     }
 
     #[test]
-    fn test_can_kita_without_north() {
+    fn test_can_pei_without_north() {
         let tiles: Vec<Tile> = make_test_tiles()
             .into_iter()
             .map(|t| {
@@ -1097,8 +1097,8 @@ mod tests {
             })
             .collect();
         let mut player = Player::new(Wind::East, tiles, 35000);
-        assert!(!player.can_kita());
-        assert!(!player.do_kita());
+        assert!(!player.can_pei());
+        assert!(!player.do_pei());
     }
 
     #[test]

--- a/crates/mahjong-server/src/protocol/mod.rs
+++ b/crates/mahjong-server/src/protocol/mod.rs
@@ -54,7 +54,7 @@ pub struct PlayerHandInfo {
     pub melds: Vec<MeldTiles>,
     /// 北抜きで晒した北風牌（三麻のみ。四麻では常に空）
     #[serde(default)]
-    pub kita: Vec<Tile>,
+    pub pei: Vec<Tile>,
 }
 
 /// 副露の牌情報
@@ -181,11 +181,11 @@ pub enum ServerEvent {
     },
 
     /// 北抜き宣言（三麻の抜きドラ）
-    KitaDeclared {
+    PeiDeclared {
         /// 北抜きしたプレイヤーの風
         player: Wind,
         /// 各プレイヤーの北抜き枚数（風のインデックス順: 東=0, 南=1, 西=2）
-        kita_counts: [u8; 4],
+        pei_counts: [u8; 4],
     },
 
     /// 手牌更新（鳴き後やリーチ後に自分の手牌を同期する）
@@ -284,7 +284,7 @@ pub enum ClientAction {
     },
 
     /// 北抜きを宣言する（三麻の抜きドラ。手牌またはツモ牌の北を晒して補充ツモ）
-    Kita,
+    Pei,
 
     /// パス（鳴きやロンをしない）
     Pass,

--- a/crates/mahjong-server/src/round/mod.rs
+++ b/crates/mahjong-server/src/round/mod.rs
@@ -296,7 +296,7 @@ impl Round {
                     wind: p.seat_wind,
                     hand: p.hand.tiles().to_vec(),
                     melds,
-                    kita: p.kita_tiles.clone(),
+                    pei: p.pei_tiles.clone(),
                 }
             })
             .collect()
@@ -746,7 +746,7 @@ impl Round {
                 Some(winning_tile),
                 &dora_indicators,
                 &uradora_indicators,
-                &self.players[winner].kita_tiles,
+                &self.players[winner].pei_tiles,
                 self.settings.three_player,
             );
 
@@ -1170,7 +1170,7 @@ impl Round {
     /// - 補充は生牌山の末尾から行う（王牌は補充しない既存の簡略化に合わせる。
     ///   `remaining()`/海底の計算は自動で整合する）
     /// - 補充ツモでの和了は嶺上開花にならない
-    pub fn do_kita(&mut self) -> bool {
+    pub fn do_pei(&mut self) -> bool {
         if !(self.settings.three_player && self.settings.nuki_dora) {
             return false;
         }
@@ -1183,22 +1183,22 @@ impl Round {
         }
 
         let player_idx = self.current_player;
-        if !self.players[player_idx].do_kita() {
+        if !self.players[player_idx].do_pei() {
             return false;
         }
 
         // 全プレイヤーに北抜きを通知（各家の枚数は風のインデックス順）
         let declarer_wind = self.players[player_idx].seat_wind;
-        let mut kita_counts = [0u8; 4];
+        let mut pei_counts = [0u8; 4];
         for p in self.players.iter().take(self.player_count) {
-            kita_counts[p.seat_wind.to_index()] = p.kita_tiles.len() as u8;
+            pei_counts[p.seat_wind.to_index()] = p.pei_tiles.len() as u8;
         }
         for i in 0..self.player_count {
             self.events.push((
                 i,
-                ServerEvent::KitaDeclared {
+                ServerEvent::PeiDeclared {
                     player: declarer_wind,
-                    kita_counts,
+                    pei_counts,
                 },
             ));
         }
@@ -1217,7 +1217,7 @@ impl Round {
         };
         self.players[player_idx].draw(tile);
         self.last_draw_was_dead_wall = false;
-        self.push_draw_events(player_idx, tile, "kita_draw");
+        self.push_draw_events(player_idx, tile, "pei_draw");
         true
     }
 
@@ -1528,7 +1528,7 @@ impl Round {
             None,
             &dora_indicators,
             &uradora_indicators,
-            &self.players[winner].kita_tiles,
+            &self.players[winner].pei_tiles,
             self.settings.three_player,
         );
 

--- a/crates/mahjong-server/src/round/tests.rs
+++ b/crates/mahjong-server/src/round/tests.rs
@@ -1478,7 +1478,7 @@ fn test_sanma_pon_still_offered() {
 // ===== 北抜き（#257 Phase 3） =====
 
 /// 現在の手番プレイヤーに北を持たせて北抜きできる状態を作る
-fn setup_kita_round() -> Round {
+fn setup_pei_round() -> Round {
     let mut round = sanma_round(42, 0);
     round.drain_events();
     round.do_draw();
@@ -1489,14 +1489,14 @@ fn setup_kita_round() -> Round {
 }
 
 #[test]
-fn test_kita_basic_flow() {
-    let mut round = setup_kita_round();
+fn test_pei_basic_flow() {
+    let mut round = setup_pei_round();
     let remaining_before = round.wall.remaining();
 
-    assert!(round.do_kita());
+    assert!(round.do_pei());
 
     // 北が晒され、補充ツモで手牌13枚+ツモ牌1枚になる
-    assert_eq!(round.players[0].kita_tiles.len(), 1);
+    assert_eq!(round.players[0].pei_tiles.len(), 1);
     assert_eq!(round.players[0].hand.tiles().len(), 13);
     assert!(round.players[0].hand.drawn().is_some());
     // 補充で山が1枚減る
@@ -1505,21 +1505,17 @@ fn test_kita_basic_flow() {
     assert_eq!(round.current_player, 0);
     assert_eq!(round.phase, TurnPhase::WaitForDiscard);
 
-    // KitaDeclared が3人に配信され、枚数が正しい
+    // PeiDeclared が3人に配信され、枚数が正しい
     let events = round.drain_events();
-    let kita_events: Vec<_> = events
+    let pei_events: Vec<_> = events
         .iter()
-        .filter(|(_, e)| matches!(e, ServerEvent::KitaDeclared { .. }))
+        .filter(|(_, e)| matches!(e, ServerEvent::PeiDeclared { .. }))
         .collect();
-    assert_eq!(kita_events.len(), 3);
-    for (_, e) in &kita_events {
-        if let ServerEvent::KitaDeclared {
-            player,
-            kita_counts,
-        } = e
-        {
+    assert_eq!(pei_events.len(), 3);
+    for (_, e) in &pei_events {
+        if let ServerEvent::PeiDeclared { player, pei_counts } = e {
             assert_eq!(*player, Wind::East);
-            assert_eq!(*kita_counts, [1, 0, 0, 0]);
+            assert_eq!(*pei_counts, [1, 0, 0, 0]);
         }
     }
     // 補充ツモの TileDrawn が本人に届く
@@ -1531,7 +1527,7 @@ fn test_kita_basic_flow() {
 }
 
 #[test]
-fn test_kita_rejected_when_nuki_dora_disabled() {
+fn test_pei_rejected_when_nuki_dora_disabled() {
     let settings = Settings {
         three_player: true,
         nuki_dora: false,
@@ -1552,35 +1548,35 @@ fn test_kita_rejected_when_nuki_dora_disabled() {
     round.do_draw();
     round.players[0].hand = Hand::from("19m199p1199s1234z 5z");
 
-    assert!(!round.do_kita());
-    assert!(round.players[0].kita_tiles.is_empty());
+    assert!(!round.do_pei());
+    assert!(round.players[0].pei_tiles.is_empty());
 }
 
 #[test]
-fn test_kita_rejected_in_four_player_game() {
+fn test_pei_rejected_in_four_player_game() {
     let mut round =
         Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
     round.drain_events();
     round.do_draw();
     round.players[0].hand = Hand::from("19m199p1199s1234z 5z");
 
-    assert!(!round.do_kita());
+    assert!(!round.do_pei());
 }
 
 #[test]
-fn test_kita_rejected_when_wall_empty() {
-    let mut round = setup_kita_round();
+fn test_pei_rejected_when_wall_empty() {
+    let mut round = setup_pei_round();
     // 山を空にする
     while round.wall.draw().is_some() {}
 
-    assert!(!round.do_kita());
-    assert!(round.players[0].kita_tiles.is_empty());
+    assert!(!round.do_pei());
+    assert!(round.players[0].pei_tiles.is_empty());
 }
 
 #[test]
-fn test_kita_win_adds_kita_dora() {
-    let mut round = setup_kita_round();
-    assert!(round.do_kita());
+fn test_pei_win_adds_pei_dora() {
+    let mut round = setup_pei_round();
+    assert!(round.do_pei());
     round.drain_events();
 
     // 手牌をタンヤオのツモ和了形に差し替える（三麻に萬子2-8は無いため筒子・索子のみ）
@@ -1601,7 +1597,7 @@ fn test_kita_win_adds_kita_dora() {
     assert!(
         yaku_list.iter().any(|(item, han)| *item
             == mahjong_core::scoring::score::ScoreItem::Dora(
-                mahjong_core::scoring::score::DoraLabel::Kita
+                mahjong_core::scoring::score::DoraLabel::PeiDora
             )
             && *han == 1),
         "北ドラが加算されていない: {:?}",

--- a/crates/mahjong-server/src/scoring.rs
+++ b/crates/mahjong-server/src/scoring.rs
@@ -287,7 +287,7 @@ pub fn calculate_tsumo_score_deltas(
 /// * `extra_tile` - ロン和了の場合の和了牌（手牌に含まれていないため別途指定）
 /// * `dora_indicators` - ドラ表示牌
 /// * `uradora_indicators` - 裏ドラ表示牌（リーチ時のみ非空）
-/// * `kita_tiles` - 北抜きで晒した北風牌（三麻のみ。1枚につき+1翻、
+/// * `pei_tiles` - 北抜きで晒した北風牌（三麻のみ。1枚につき+1翻、
 ///   表示牌が北を指す場合は表示牌ドラとしても重複カウントされる）
 /// * `three_player` - 三麻かどうか（萬子のドラチェーンが 1m↔9m にラップする）
 pub fn add_dora_to_score(
@@ -296,7 +296,7 @@ pub fn add_dora_to_score(
     extra_tile: Option<Tile>,
     dora_indicators: &[Tile],
     uradora_indicators: &[Tile],
-    kita_tiles: &[Tile],
+    pei_tiles: &[Tile],
     three_player: bool,
 ) {
     // 役満の場合はドラを加算しない
@@ -315,7 +315,7 @@ pub fn add_dora_to_score(
     for open in hand.melds() {
         all_tiles.extend(open.expanded_tiles());
     }
-    all_tiles.extend_from_slice(kita_tiles);
+    all_tiles.extend_from_slice(pei_tiles);
 
     // ドラ表示牌からドラ牌を計算してカウント
     let mut dora_count: u32 = 0;
@@ -335,9 +335,9 @@ pub fn add_dora_to_score(
     let red_dora_count = all_tiles.iter().filter(|t| t.is_red_dora()).count() as u32;
 
     // 北ドラ（抜き北1枚につき1翻）をカウント
-    let kita_count = kita_tiles.len() as u32;
+    let pei_count = pei_tiles.len() as u32;
 
-    let extra_han = dora_count + uradora_count + red_dora_count + kita_count;
+    let extra_han = dora_count + uradora_count + red_dora_count + pei_count;
     if extra_han == 0 {
         return;
     }
@@ -371,10 +371,10 @@ pub fn add_dora_to_score(
             .yaku_list
             .push((ScoreItem::Dora(DoraLabel::UraDora), uradora_count));
     }
-    if kita_count > 0 {
+    if pei_count > 0 {
         score_result
             .yaku_list
-            .push((ScoreItem::Dora(DoraLabel::Kita), kita_count));
+            .push((ScoreItem::Dora(DoraLabel::PeiDora), pei_count));
     }
 }
 
@@ -557,7 +557,7 @@ mod tests {
     }
 
     #[test]
-    fn test_kita_dora_added_and_double_counted_with_north_indicator() {
+    fn test_pei_dora_added_and_double_counted_with_north_indicator() {
         let mut score = ScoreResult {
             han: 1,
             fu: 30,
@@ -590,7 +590,7 @@ mod tests {
 
         // 抜き北2枚。表示牌が西（3z）→ ドラは北（4z）のため、
         // 抜き北は北ドラ2翻+表示牌ドラ2翻の計4翻になる
-        let kita_tiles = vec![Tile::new(Tile::Z4), Tile::new(Tile::Z4)];
+        let pei_tiles = vec![Tile::new(Tile::Z4), Tile::new(Tile::Z4)];
         let dora_indicators = vec![Tile::new(Tile::Z3)];
         add_dora_to_score(
             &mut score,
@@ -598,14 +598,14 @@ mod tests {
             None,
             &dora_indicators,
             &[],
-            &kita_tiles,
+            &pei_tiles,
             true,
         );
 
         assert!(
             score
                 .yaku_list
-                .contains(&(ScoreItem::Dora(DoraLabel::Kita), 2)),
+                .contains(&(ScoreItem::Dora(DoraLabel::PeiDora), 2)),
             "北ドラ2翻が加算されていない: {:?}",
             score.yaku_list
         );

--- a/crates/mahjong-server/src/table.rs
+++ b/crates/mahjong-server/src/table.rs
@@ -213,11 +213,11 @@ impl Table {
             }
 
             // === 北抜きアクション（三麻のみ） ===
-            ClientAction::Kita => {
+            ClientAction::Pei => {
                 if round.current_player != player_idx {
                     return false;
                 }
-                round.do_kita()
+                round.do_pei()
             }
 
             // === 九種九牌アクション ===

--- a/docs/glossary.ja.md
+++ b/docs/glossary.ja.md
@@ -51,7 +51,7 @@
 | 裏ドラ | ura dora | ura dora | — | リーチ和了時のみ公開される裏のドラ。 |
 | 槓ドラ | kan dora | kan dora | — | カン成立時に追加で公開されるドラ表示牌。 |
 | 赤ドラ / 赤五 | aka dora / aka five | red five | `Tile::new_red`, `Tile::is_red_dora` | +1 翻の赤い `5`。 |
-| 抜きドラ / 北ドラ | nuki-dora / kita-dora | kita dora | `DoraLabel::Kita` | 三人麻雀で抜いた北風牌。1枚につき +1 翻。 |
+| 抜きドラ / 北ドラ | nuki-dora / pei-dora | pei dora | `DoraLabel::PeiDora` | 三人麻雀で抜いた北風牌。1枚につき +1 翻。読みは牌名の「ペー」（北）に従う。 |
 
 ---
 
@@ -132,7 +132,7 @@
 | 九種九牌 | kyūshu kyūhai | nine terminals abortive draw | `Settings::nine_terminals_draw` | オプション。 |
 | 三家和 | sanchahō | triple-ron abortive draw | `Settings::triple_ron_draw` | オプション。 |
 | 三人麻雀 / 三麻 | sanma | three-player mahjong | `Settings::three_player` | 萬子2〜8を除外した108枚・チーなし・ツモ損で3人で打つ。 |
-| 北抜き | kita-nuki | kita (North extraction) | `Settings::nuki_dora` | 三麻専用。北風牌を晒して抜きドラとし、牌山から1枚補充する。 |
+| 北抜き | pei-nuki | pei (North extraction) | `Settings::nuki_dora` | 三麻専用。北風牌を晒して抜きドラとし、牌山から1枚補充する。 |
 | ツモ損 | tsumo-zon | tsumo loss | — | 三麻のツモ支払い方式。1人あたりの支払額は四麻と同じで、いない北家の分は貰えない。 |
 
 ---

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -52,7 +52,7 @@ A Japanese-language edition of this document is maintained in parallel at
 | 裏ドラ | ura dora | ura dora | — | Hidden dora revealed only on a riichi win. |
 | 槓ドラ | kan dora | kan dora | — | Extra dora indicator revealed when a quad is made. |
 | 赤ドラ / 赤五 | aka dora / aka five | red five | `Tile::new_red`, `Tile::is_red_dora` | A red `5` worth +1 han. |
-| 抜きドラ / 北ドラ | nuki-dora / kita-dora | kita dora | `DoraLabel::Kita` | In three-player mahjong: each extracted North tile is worth +1 han. |
+| 抜きドラ / 北ドラ | nuki-dora / pei-dora | pei dora | `DoraLabel::PeiDora` | In three-player mahjong: each extracted North tile is worth +1 han. Reading follows the tile name *pei* (北). |
 
 ---
 
@@ -133,7 +133,7 @@ A Japanese-language edition of this document is maintained in parallel at
 | 九種九牌 | kyūshu kyūhai | nine terminals abortive draw | `Settings::nine_terminals_draw` | Optional rule. |
 | 三家和 | sanchahō | triple-ron abortive draw | `Settings::triple_ron_draw` | Optional rule. |
 | 三人麻雀 / 三麻 | sanma | three-player mahjong | `Settings::three_player` | Characters 2–8 removed (108 tiles); no chii; tsumo loss payments. |
-| 北抜き | kita-nuki | kita (North extraction) | `Settings::nuki_dora` | Three-player only: set aside a North tile as a kita dora and draw a replacement tile. |
+| 北抜き | pei-nuki | pei (North extraction) | `Settings::nuki_dora` | Three-player only: set aside a North tile as a pei dora and draw a replacement tile. |
 | ツモ損 | tsumo-zon | tsumo loss | — | Three-player tsumo payment style: per-person amounts are unchanged and the missing player's share is simply not received. |
 
 ---


### PR DESCRIPTION
## Summary

Follow-up to the sanma phases, targeting the integration branch so #264 picks it up.

The North wind tile is read **pei** (ペー) — the reading the glossary already uses for the tile itself (北 | pei | North) — and the sanma bonus is commonly called ペードラ, not きたドラ. This renames every "kita" reading to "pei" in the glossaries, English UI strings, and code identifiers. Kanji UI strings (北抜き, 北ドラ) are unchanged.

- `DoraLabel::Kita` → `DoraLabel::PeiDora` (En display "Pei Dora"; Ja 北ドラ unchanged)
- `ClientAction::Kita` → `ClientAction::Pei`, `ServerEvent::KitaDeclared` → `PeiDeclared`, `PlayerHandInfo.kita` → `pei` — safe to rename since protocol v3 has not shipped
- All `kita_*` identifiers, helpers (`do_kita` → `do_pei`, `can_kita` → `can_pei`, …), and test names renamed across server, CPU, and client
- i18n: English button/toggle labels "Kita" / "Kita dora" → "Pei" / "Pei dora"
- Glossaries: romaji `kita-dora` / `kita-nuki` → `pei-dora` / `pei-nuki`, English terms "kita dora" → "pei dora"; README wording updated

## Test plan

- [x] Pure rename — no behavior change; `cargo build && cargo test` green (768 tests)
- [x] `cargo fmt` / `cargo clippy` clean
- [x] `rg -i kita` finds no remaining occurrences outside the generated JS bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)