### PR TITLE
Pass the full rule settings struct when creating rooms (#257)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,6 +594,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "futures-util",
+ "mahjong-core",
  "mahjong-server",
  "rand 0.10.1",
  "serde",

--- a/crates/mahjong-client/src/adapter/remote.rs
+++ b/crates/mahjong-client/src/adapter/remote.rs
@@ -10,7 +10,7 @@
 //! 4. `RoomState` で入室完了（`room()` が Some になる）
 //! 5. ホストが `start_game` → `Event(GameStarted)` で対局開始
 
-use mahjong_core::settings::Lang;
+use mahjong_core::settings::{Lang, Settings};
 use mahjong_server::protocol::net::{
     ClientMessage, CpuSpec, ErrorCode, PROTOCOL_VERSION, SeatInfo, ServerMessage,
 };
@@ -41,8 +41,8 @@ pub struct RoomView {
     pub host_seat: usize,
     /// 自分の座席
     pub your_seat: usize,
-    /// 三麻（3人打ち）ルームか
-    pub three_player: bool,
+    /// このルームのルール設定
+    pub rules: Settings,
 }
 
 impl RoomView {
@@ -51,9 +51,14 @@ impl RoomView {
         self.your_seat == self.host_seat
     }
 
+    /// 三麻（3人打ち）ルームか
+    pub fn three_player(&self) -> bool {
+        self.rules.three_player
+    }
+
     /// プレイヤー人数を返す（四麻=4、三麻=3）
     pub fn player_count(&self) -> usize {
-        if self.three_player { 3 } else { 4 }
+        self.rules.player_count()
     }
 }
 
@@ -70,14 +75,8 @@ pub struct RemoteError {
 
 /// Welcome 受信後に送るロビー操作
 enum LobbyIntent {
-    Create {
-        round_count: u8,
-        three_player: bool,
-        nuki_dora: bool,
-    },
-    Join {
-        code: String,
-    },
+    Create { round_count: u8, rules: Settings },
+    Join { code: String },
 }
 
 /// 自動再接続のバックオフ間隔（秒）。試行回数で頭打ちにする。
@@ -153,24 +152,17 @@ impl RemoteAdapter {
     }
 
     /// サーバに接続してルームを作成する
-    pub fn create_room(
-        url: &str,
-        display_name: &str,
-        round_count: u8,
-        three_player: bool,
-        nuki_dora: bool,
-    ) -> Self {
+    ///
+    /// `rules` にはルームのルール設定を丸ごと渡す（三麻・北抜きに限らず、
+    /// 将来ルール選択UIが増えてもこのシグネチャのまま拡張できる）。
+    pub fn create_room(url: &str, display_name: &str, round_count: u8, rules: Settings) -> Self {
         let (transport, connector) = Self::connector_for(url);
         Self::build(
             transport,
             connector,
             default_clock(),
             display_name,
-            LobbyIntent::Create {
-                round_count,
-                three_player,
-                nuki_dora,
-            },
+            LobbyIntent::Create { round_count, rules },
         )
     }
 
@@ -341,15 +333,9 @@ impl RemoteAdapter {
                 self.status = ConnStatus::Connected;
                 if let Some(intent) = self.pending_intent.take() {
                     let msg = match intent {
-                        LobbyIntent::Create {
-                            round_count,
-                            three_player,
-                            nuki_dora,
-                        } => ClientMessage::CreateRoom {
-                            round_count,
-                            three_player,
-                            nuki_dora,
-                        },
+                        LobbyIntent::Create { round_count, rules } => {
+                            ClientMessage::CreateRoom { round_count, rules }
+                        }
                         LobbyIntent::Join { code } => ClientMessage::JoinRoom { code },
                     };
                     self.send(&msg);
@@ -360,7 +346,7 @@ impl RemoteAdapter {
                 seats,
                 host_seat,
                 your_seat,
-                three_player,
+                rules,
             } => {
                 self.room_code = Some(code.clone());
                 // 座席情報から人間プレイヤーの接続状態を取り込む
@@ -375,7 +361,7 @@ impl RemoteAdapter {
                     seats,
                     host_seat,
                     your_seat,
-                    three_player,
+                    rules,
                 });
             }
             ServerMessage::Event(event) => {
@@ -621,8 +607,7 @@ mod tests {
             transport,
             LobbyIntent::Create {
                 round_count: 1,
-                three_player: false,
-                nuki_dora: true,
+                rules: Settings::new(),
             },
         );
         (adapter, handle)
@@ -649,7 +634,7 @@ mod tests {
             ],
             host_seat: 0,
             your_seat,
-            three_player: false,
+            rules: Settings::new(),
         }
     }
 
@@ -697,14 +682,13 @@ mod tests {
         assert_eq!(adapter.status(), ConnStatus::Connected);
         let sent = handle.sent();
         assert_eq!(sent.len(), 2);
-        assert!(matches!(
-            sent[1],
-            ClientMessage::CreateRoom {
-                round_count: 1,
-                three_player: false,
-                nuki_dora: true,
+        match &sent[1] {
+            ClientMessage::CreateRoom { round_count, rules } => {
+                assert_eq!(*round_count, 1);
+                assert_eq!(*rules, Settings::new());
             }
-        ));
+            other => panic!("CreateRoomでないメッセージ: {other:?}"),
+        }
     }
 
     #[test]
@@ -850,8 +834,7 @@ mod tests {
             "E2Eテスト",
             LobbyIntent::Create {
                 round_count: 1,
-                three_player: false,
-                nuki_dora: true,
+                rules: Settings::new(),
             },
         );
 
@@ -1146,8 +1129,7 @@ mod tests {
             "テスト",
             LobbyIntent::Create {
                 round_count: 1,
-                three_player: false,
-                nuki_dora: true,
+                rules: Settings::new(),
             },
         );
 
@@ -1177,8 +1159,7 @@ mod tests {
             "テスト",
             LobbyIntent::Create {
                 round_count: 1,
-                three_player: false,
-                nuki_dora: true,
+                rules: Settings::new(),
             },
         );
         handle.push_msg(&ServerMessage::TurnTimer { seconds: 5 });

--- a/crates/mahjong-client/src/game.rs
+++ b/crates/mahjong-client/src/game.rs
@@ -306,6 +306,18 @@ impl OnlineUiState {
             nuki_dora: true,
         }
     }
+
+    /// ルーム作成時に送るルール設定を組み立てる
+    ///
+    /// UIで選択できないルールは既定値のまま。ルール選択UIを増やす場合は
+    /// ここに反映すればサーバへそのまま伝わる。
+    pub fn build_rules(&self) -> mahjong_core::settings::Settings {
+        mahjong_core::settings::Settings {
+            three_player: self.three_player,
+            nuki_dora: self.nuki_dora,
+            ..mahjong_core::settings::Settings::new()
+        }
+    }
 }
 
 /// ロビー画面に表示するルーム情報
@@ -349,15 +361,21 @@ impl SetupState {
         if self.three_player { 2 } else { 3 }
     }
 
-    /// ゲーム設定を組み立てる
-    pub fn build_game_settings(&self) -> mahjong_server::table::GameSettings {
-        if self.three_player {
-            let mut settings = mahjong_server::table::GameSettings::sanma_default();
-            settings.rules.nuki_dora = self.nuki_dora;
-            settings
-        } else {
-            mahjong_server::table::GameSettings::default()
+    /// 選択中のルール設定を組み立てる
+    ///
+    /// UIで選択できないルールは既定値のまま。ルール選択UIを増やす場合は
+    /// ここに反映すれば、ローカル・オンラインの両方に伝わる。
+    pub fn build_rules(&self) -> mahjong_core::settings::Settings {
+        mahjong_core::settings::Settings {
+            three_player: self.three_player,
+            nuki_dora: self.nuki_dora,
+            ..mahjong_core::settings::Settings::new()
         }
+    }
+
+    /// ゲーム設定を組み立てる（持ち点はルールから決まる）
+    pub fn build_game_settings(&self) -> mahjong_server::table::GameSettings {
+        mahjong_server::table::GameSettings::with_rules(1, self.build_rules())
     }
 
     pub fn level_count() -> usize {

--- a/crates/mahjong-client/src/main.rs
+++ b/crates/mahjong-client/src/main.rs
@@ -103,7 +103,7 @@ fn sync_online_ui(remote: &mut RemoteAdapter, state: &mut GameState) {
         code: room.code.clone(),
         seat_labels: build_seat_labels(room, lang),
         is_host: room.is_host(),
-        three_player: room.three_player,
+        three_player: room.three_player(),
     });
 
     if let Some(err) = remote.take_error() {
@@ -235,15 +235,8 @@ async fn main() {
                         OnlineMenuAction::CreateRoom => {
                             let url = transport::default_server_url();
                             let name = display_name(&game_state);
-                            let three_player = game_state.online_state.three_player;
-                            let nuki_dora = game_state.online_state.nuki_dora;
-                            online = Some(RemoteAdapter::create_room(
-                                &url,
-                                &name,
-                                1,
-                                three_player,
-                                nuki_dora,
-                            ));
+                            let rules = game_state.online_state.build_rules();
+                            online = Some(RemoteAdapter::create_room(&url, &name, 1, rules));
                             let msg = i18n::Key::Connecting.text(game_state.lang);
                             set_status(&mut game_state, msg, false);
                         }

--- a/crates/mahjong-core/src/settings.rs
+++ b/crates/mahjong-core/src/settings.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// 表示をどの言語にするかの列挙型
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Lang {
     /// 英語
     En,
@@ -10,7 +10,12 @@ pub enum Lang {
 }
 
 /// 設定
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// ネットワーク越しに送受信されるため（`CreateRoom` / `RoomState`）、
+/// 構造体レベルの `#[serde(default)]` で欠けたフィールドを既定値に補完する。
+/// これにより将来ルールフラグを追加しても旧クライアントの JSON を解釈できる。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct Settings {
     /// 表示言語（デフォルトは日本語）
     pub display_lang: Lang,
@@ -44,17 +49,10 @@ pub struct Settings {
     /// 三人麻雀（サンマ）かどうか（デフォルトは false = 四人麻雀）
     /// ありの場合: 萬子2〜8を除外した108枚で3人で打つ。チーは提供されない。
     /// ツモはツモ損（1人あたりの支払額は四麻と同じで、いない北家分は貰えない）。
-    #[serde(default)]
     pub three_player: bool,
     /// 北抜きドラありかなしか（三人麻雀のみ有効。デフォルトはあり）
     /// ありの場合: 手番中に北風牌を晒して1枚につきドラ1として扱い、牌山から補充する。
-    #[serde(default = "default_true")]
     pub nuki_dora: bool,
-}
-
-/// serde デフォルト用: true を返す
-fn default_true() -> bool {
-    true
 }
 
 impl Default for Settings {
@@ -120,5 +118,13 @@ mod tests {
         let settings: Settings = serde_json::from_value(value).unwrap();
         assert!(!settings.three_player);
         assert!(settings.nuki_dora);
+    }
+
+    /// 構造体レベルの serde デフォルトにより、空の JSON からでも既定値で復元できる
+    /// （将来ルールフラグを追加しても旧クライアントのメッセージを解釈できる）
+    #[test]
+    fn deserialize_from_empty_object_uses_defaults() {
+        let settings: Settings = serde_json::from_str("{}").unwrap();
+        assert_eq!(settings, Settings::new());
     }
 }

--- a/crates/mahjong-net-server/Cargo.toml
+++ b/crates/mahjong-net-server/Cargo.toml
@@ -16,4 +16,5 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
+mahjong-core = { path = "../mahjong-core" }
 tokio-tungstenite = "0.27"

--- a/crates/mahjong-net-server/src/connection.rs
+++ b/crates/mahjong-net-server/src/connection.rs
@@ -207,11 +207,7 @@ impl Connection {
             };
 
             let room_tx = match msg {
-                ClientMessage::CreateRoom {
-                    round_count,
-                    three_player,
-                    nuki_dora,
-                } => {
+                ClientMessage::CreateRoom { round_count, rules } => {
                     if !self.allow_room_entry() {
                         self.send_error(ErrorCode::RateLimited, "too many room attempts")
                             .await;
@@ -222,17 +218,9 @@ impl Connection {
                             .await;
                         continue;
                     }
-                    let settings = if three_player {
-                        let mut settings = GameSettings::sanma_default();
-                        settings.round_count = round_count;
-                        settings.rules.nuki_dora = nuki_dora;
-                        settings
-                    } else {
-                        GameSettings {
-                            round_count,
-                            ..GameSettings::default()
-                        }
-                    };
+                    // ルール設定はホストの指定を丸ごと採用する。
+                    // 持ち点はサーバが決める（四麻25000点・三麻35000点）。
+                    let settings = GameSettings::with_rules(round_count, rules);
                     let (_code, room_tx) = self.state.lobby.create_room(settings);
                     Some(room_tx)
                 }

--- a/crates/mahjong-net-server/src/room.rs
+++ b/crates/mahjong-net-server/src/room.rs
@@ -767,7 +767,7 @@ impl Room {
             seats: seats_info.clone(),
             host_seat: HOST_SEAT,
             your_seat: seat,
-            three_player: self.settings.rules.three_player,
+            rules: self.settings.rules.clone(),
         };
         self.send_to_seat(seat, msg);
     }

--- a/crates/mahjong-net-server/tests/integration.rs
+++ b/crates/mahjong-net-server/tests/integration.rs
@@ -7,6 +7,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
+use mahjong_core::settings::Settings;
 use mahjong_net_server::app;
 use mahjong_net_server::room::RoomConfig;
 use mahjong_server::protocol::net::{ClientMessage, ErrorCode, PROTOCOL_VERSION, ServerMessage};
@@ -152,8 +153,7 @@ impl TestClient {
     async fn create_room(&mut self) -> String {
         self.send(&ClientMessage::CreateRoom {
             round_count: 1,
-            three_player: false,
-            nuki_dora: true,
+            rules: Settings::new(),
         })
         .await;
         match self.recv().await {
@@ -166,16 +166,16 @@ impl TestClient {
     async fn create_sanma_room(&mut self) -> String {
         self.send(&ClientMessage::CreateRoom {
             round_count: 1,
-            three_player: true,
-            nuki_dora: true,
+            rules: Settings {
+                three_player: true,
+                ..Settings::new()
+            },
         })
         .await;
         match self.recv().await {
-            ServerMessage::RoomState {
-                code, three_player, ..
-            } => {
+            ServerMessage::RoomState { code, rules, .. } => {
                 assert!(
-                    three_player,
+                    rules.three_player,
                     "三麻ルームの RoomState に three_player が立っていない"
                 );
                 code

--- a/crates/mahjong-server/src/protocol/net.rs
+++ b/crates/mahjong-server/src/protocol/net.rs
@@ -3,6 +3,7 @@
 //! WebSocket のテキストフレームで JSON としてやり取りするエンベロープ型。
 //! ゲーム内のやり取りは既存の `ClientAction` / `ServerEvent` をそのまま包む。
 
+use mahjong_core::settings::Settings;
 use serde::{Deserialize, Serialize};
 
 use super::{ClientAction, ServerEvent};
@@ -12,7 +13,7 @@ use crate::cpu::client::{CpuConfig, CpuLevel, CpuPersonality};
 ///
 /// 互換性のない変更を入れる際にインクリメントする。
 /// `Hello` で照合し、不一致なら `ErrorCode::VersionMismatch` で切断する。
-/// v3: 三麻対応（CreateRoom の three_player/nuki_dora、RoomState の three_player）
+/// v3: 三麻対応（CreateRoom / RoomState がルール設定 `Settings` を丸ごと運ぶ）
 pub const PROTOCOL_VERSION: u32 = 3;
 
 /// CPUの強さ・性格の指定
@@ -41,11 +42,6 @@ impl CpuSpec {
     }
 }
 
-/// serde デフォルト用: true を返す
-fn default_true() -> bool {
-    true
-}
-
 /// クライアントからサーバへのメッセージ
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ClientMessage {
@@ -63,12 +59,13 @@ pub enum ClientMessage {
     CreateRoom {
         /// 東風戦(1)か東南戦(2)か
         round_count: u8,
-        /// 三麻（3人打ち）ルームか
+        /// ルール設定（三麻・北抜き・喰いタン・三家和などの全フラグ）
+        ///
+        /// 持ち点はサーバがルールから決める（四麻25000点・三麻35000点）。
+        /// 欠けたフィールドは既定値に補完されるため、ルールフラグを
+        /// 追加しても旧クライアントのメッセージを解釈できる。
         #[serde(default)]
-        three_player: bool,
-        /// 北抜きドラありか（三麻のみ有効）
-        #[serde(default = "default_true")]
-        nuki_dora: bool,
+        rules: Settings,
     },
 
     /// ルームコードを指定して参加する
@@ -115,9 +112,9 @@ pub enum ServerMessage {
         host_seat: usize,
         /// 受信者自身の座席インデックス
         your_seat: usize,
-        /// 三麻（3人打ち）ルームか
+        /// このルームのルール設定（三麻か否かの表示などに使う）
         #[serde(default)]
-        three_player: bool,
+        rules: Settings,
     },
 
     /// ゲーム内イベント
@@ -259,13 +256,16 @@ mod tests {
             },
             ClientMessage::CreateRoom {
                 round_count: 2,
-                three_player: false,
-                nuki_dora: true,
+                rules: Settings::new(),
             },
             ClientMessage::CreateRoom {
                 round_count: 1,
-                three_player: true,
-                nuki_dora: false,
+                rules: Settings {
+                    three_player: true,
+                    nuki_dora: false,
+                    triple_ron_draw: true,
+                    ..Settings::new()
+                },
             },
             ClientMessage::JoinRoom {
                 code: "ABC234".to_string(),
@@ -331,7 +331,7 @@ mod tests {
                 ],
                 host_seat: 0,
                 your_seat: 1,
-                three_player: false,
+                rules: Settings::new(),
             },
             ServerMessage::Event(ServerEvent::TileDrawn {
                 tile: Tile::new(Tile::P5),

--- a/crates/mahjong-server/src/table.rs
+++ b/crates/mahjong-server/src/table.rs
@@ -31,16 +31,28 @@ impl Default for GameSettings {
 }
 
 impl GameSettings {
+    /// ルール設定から標準の持ち点でゲーム設定を作る
+    ///
+    /// 持ち点はルールから決まる（四麻25000点・三麻35000点）。
+    /// ルーム作成（`CreateRoom`）やローカル対局設定からの変換に使う。
+    pub fn with_rules(round_count: u8, rules: Settings) -> Self {
+        let initial_score = if rules.three_player { 35000 } else { 25000 };
+        GameSettings {
+            initial_score,
+            round_count,
+            rules,
+        }
+    }
+
     /// 三麻の標準設定を返す（35000点持ち・東風戦）
     pub fn sanma_default() -> Self {
-        GameSettings {
-            initial_score: 35000,
-            round_count: 1, // 東風戦（東1〜3局）
-            rules: Settings {
+        Self::with_rules(
+            1, // 東風戦（東1〜3局）
+            Settings {
                 three_player: true,
                 ..Settings::new()
             },
-        }
+        )
     }
 }
 
@@ -442,6 +454,24 @@ mod tests {
         }
 
         assert!(table.is_game_over);
+    }
+
+    #[test]
+    fn test_game_settings_with_rules() {
+        // ルール構造体を丸ごと引き継ぎ、持ち点はルールから決まる
+        let rules = Settings {
+            three_player: true,
+            nuki_dora: false,
+            triple_ron_draw: true,
+            ..Settings::new()
+        };
+        let settings = GameSettings::with_rules(2, rules.clone());
+        assert_eq!(settings.initial_score, 35000);
+        assert_eq!(settings.round_count, 2);
+        assert_eq!(settings.rules, rules);
+
+        let four_player = GameSettings::with_rules(1, Settings::new());
+        assert_eq!(four_player.initial_score, 25000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up refactor on the integration branch (picked up by #264). Room creation and the adapters passed only `three_player` / `nuki_dora` as individual flags, so every future host-selectable rule (`triple_ron_draw`, `multiple_ron`, `forbid_swap_calling`, …) would have required touching the protocol, both adapters, and the server. They now carry the whole `mahjong_core::settings::Settings` struct.

- **`Settings`**: container-level `#[serde(default)]` — fields missing from a payload fall back to defaults, so adding rule flags later stays wire-compatible in both directions; `PartialEq`/`Eq` derives for tests
- **Protocol v3** (still unreleased, so reshaping is safe): `CreateRoom { round_count, rules: Settings }`; `RoomState` carries `rules` instead of a lone `three_player` bool
- **`GameSettings::with_rules(round_count, rules)`**: single place that derives the starting score from the rules (25000 / 35000) — the server keeps score authority (clients cannot pick arbitrary scores) and `sanma_default()` now delegates to it
- **connection.rs** adopts the host's rules wholesale instead of rebuilding them from flags
- **Client**: `LobbyIntent` / `RemoteAdapter::create_room` / `RoomView` carry `Settings`; `SetupState::build_rules()` and `OnlineUiState::build_rules()` are the single points to extend when a new rule toggle is added to the UI — it then propagates to local and online play automatically

## Test plan

- [x] New tests: `Settings` deserializes from `{}` to full defaults (forward-compat guarantee), `GameSettings::with_rules` score derivation and rule passthrough (incl. `triple_ron_draw`), CreateRoom roundtrip with a non-default rule set
- [x] `cargo build && cargo test` — 770 tests green (sanma integration tests unchanged)
- [x] `cargo fmt` / `cargo clippy` clean
- [x] WASM build verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)