### PR TITLE
Restructure menu screens with top menu, mode select, and CPU setup (#245)

### DIFF
--- a/crates/mahjong-client/src/adapter/remote.rs
+++ b/crates/mahjong-client/src/adapter/remote.rs
@@ -46,6 +46,8 @@ pub struct RoomView {
     pub rules: Settings,
     /// 対局の長さ（東風戦か半荘戦か）
     pub length: GameLength,
+    /// 空席を埋めるCPUの強さ・性格（旧サーバでは None）
+    pub cpu_configs: Option<[CpuSpec; 3]>,
 }
 
 impl RoomView {
@@ -196,6 +198,13 @@ impl RemoteAdapter {
     /// `cpu_configs` でCPUの強さ・性格を指定する（`None` ならサーバ既定）。
     pub fn start_game(&mut self, cpu_configs: Option<[CpuSpec; 3]>) {
         self.send(&ClientMessage::StartGame { cpu_configs });
+    }
+
+    /// 空席を埋めるCPUの強さ・性格を設定する（ホストのみ有効）
+    ///
+    /// サーバが保持して RoomState で全員のロビー表示へ共有する。
+    pub fn set_cpu_configs(&mut self, cpu_configs: [CpuSpec; 3]) {
+        self.send(&ClientMessage::SetCpuConfigs { cpu_configs });
     }
 
     /// ルームから退出する
@@ -351,6 +360,7 @@ impl RemoteAdapter {
                 your_seat,
                 rules,
                 length,
+                cpu_configs,
             } => {
                 self.room_code = Some(code.clone());
                 // 座席情報から人間プレイヤーの接続状態を取り込む
@@ -367,6 +377,7 @@ impl RemoteAdapter {
                     your_seat,
                     rules,
                     length,
+                    cpu_configs,
                 });
             }
             ServerMessage::Event(event) => {
@@ -641,6 +652,7 @@ mod tests {
             your_seat,
             rules: Settings::new(),
             length: GameLength::EastOnly,
+            cpu_configs: None,
         }
     }
 
@@ -736,6 +748,7 @@ mod tests {
             your_seat: 0,
             rules: Settings::new(),
             length: GameLength::Hanchan,
+            cpu_configs: None,
         };
         handle.push_msg(&msg);
         adapter.tick();
@@ -778,6 +791,60 @@ mod tests {
         assert_eq!(room.code, "ABC234");
         assert_eq!(room.your_seat, 0);
         assert!(room.is_host());
+    }
+
+    /// set_cpu_configs が SetCpuConfigs を送り、RoomState のCPU設定が
+    /// RoomView に反映されること（#245）
+    #[test]
+    fn test_set_cpu_configs_roundtrip() {
+        use mahjong_server::cpu::client::{CpuLevel, CpuPersonality};
+
+        let (mut adapter, handle) = create_adapter();
+        let specs = [
+            CpuSpec {
+                level: CpuLevel::Strong,
+                personality: CpuPersonality::Defensive,
+            },
+            CpuSpec {
+                level: CpuLevel::Weak,
+                personality: CpuPersonality::Speedy,
+            },
+            CpuSpec {
+                level: CpuLevel::Normal,
+                personality: CpuPersonality::HighValue,
+            },
+        ];
+        adapter.set_cpu_configs(specs);
+
+        let sent = handle.sent();
+        assert!(matches!(
+            sent[0],
+            ClientMessage::SetCpuConfigs { cpu_configs } if cpu_configs == specs
+        ));
+
+        // サーバがCPU設定入りの RoomState を返すと RoomView に反映される
+        let msg = ServerMessage::RoomState {
+            code: "ABC234".to_string(),
+            seats: [
+                SeatInfo::Human {
+                    name: "ホスト".to_string(),
+                    connected: true,
+                },
+                SeatInfo::Empty,
+                SeatInfo::Empty,
+                SeatInfo::Empty,
+            ],
+            host_seat: 0,
+            your_seat: 0,
+            rules: Settings::new(),
+            length: GameLength::EastOnly,
+            cpu_configs: Some(specs),
+        };
+        handle.push_msg(&msg);
+        adapter.tick();
+
+        let room = adapter.room().expect("入室しているはず");
+        assert_eq!(room.cpu_configs, Some(specs));
     }
 
     #[test]

--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -210,11 +210,24 @@ pub struct GameState {
     pub lang: Lang,
 }
 
+/// モード選択・CPU設定画面の遷移元（戻り先と確定時の動作を決める）
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MenuOrigin {
+    /// CPU対戦（トップ画面 → モード選択 → CPU設定 → 対局開始）
+    Local,
+    /// オンライン対戦（ルーム作成前のモード選択／ロビーからのCPU設定）
+    Online,
+}
+
 /// ゲームフェーズ
 #[derive(Debug, Clone, PartialEq)]
 pub enum GamePhase {
-    /// 対局開始前の設定画面
-    Setup,
+    /// トップ画面（CPU対戦・オンライン対戦・設定・言語設定）
+    TopMenu,
+    /// 対局モード選択（四人東風〜三人半荘・北抜きドラ）
+    ModeSelect(MenuOrigin),
+    /// CPU設定画面（強さ・性格。ローカルは対局開始、オンラインは決定）
+    CpuSetup(MenuOrigin),
     /// オンライン対戦メニュー（名前・ルームコード入力）
     OnlineMenu,
     /// オンラインロビー（メンバー待ち）
@@ -260,7 +273,7 @@ impl GameState {
             win_results: Vec::new(),
             win_result_index: 0,
             is_my_turn: false,
-            phase: GamePhase::Setup,
+            phase: GamePhase::TopMenu,
             available_calls: Vec::new(),
             call_target_tile: None,
             call_discarder: None,

--- a/crates/mahjong-client/src/i18n/mod.rs
+++ b/crates/mahjong-client/src/i18n/mod.rs
@@ -161,6 +161,18 @@ impl Translator {
         }
     }
 
+    /// ロビーの空席行（空席をどのCPUが埋めるかを添える）。
+    ///
+    /// 例: 日「空席（CPU: 普通・バランス）」/ 英「Empty (CPU: Normal, Balanced)」。
+    pub fn empty_seat_cpu_label(&self, level: CpuLevel, personality: CpuPersonality) -> String {
+        let lv = self.cpu_level_name(level);
+        let ps = self.cpu_personality_name(personality);
+        match self.lang {
+            Lang::Ja => format!("空席（CPU: {lv}・{ps}）"),
+            Lang::En => format!("Empty (CPU: {lv}, {ps})"),
+        }
+    }
+
     /// ロビーの参加者行（例: 日「1: {who}{marks}」/ 英「1: {who}{marks}」）。
     ///
     /// 席順（風）は対局開始時にランダムで決まるため、風ではなく
@@ -273,8 +285,24 @@ impl Translator {
 /// `Lang` に追加し、各 `match` 腕へ訳を足す（コンパイル時に網羅性が保証される）。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Key {
-    /// 対局設定画面のタイトル
-    SetupTitle,
+    /// トップ画面のタイトル
+    AppTitle,
+    /// トップ画面: CPU対戦ボタン
+    CpuBattle,
+    /// トップ画面: 設定ボタン（ルール設定。未実装）
+    SettingsMenu,
+    /// 未実装機能の注記
+    ComingSoon,
+    /// トップ画面: 言語設定の見出し
+    LanguageLabel,
+    /// モード選択画面のタイトル
+    ModeSelectTitle,
+    /// 北抜きドラが三麻のみ有効である旨の注記
+    SanmaOnlyNote,
+    /// CPU設定画面のタイトル・ロビーのCPU設定ボタン
+    CpuSetupTitle,
+    /// 決定ボタン（オンラインのCPU設定確定）
+    Confirm,
     /// 対局モード: 四人東風
     ModeFourEast,
     /// 対局モード: 四人半荘
@@ -409,9 +437,41 @@ impl Key {
     /// 指定言語での文言を返す。
     pub fn text(self, lang: Lang) -> &'static str {
         match self {
-            Key::SetupTitle => match lang {
-                Lang::Ja => "対局設定",
-                Lang::En => "Game Setup",
+            Key::AppTitle => match lang {
+                Lang::Ja => "麻雀",
+                Lang::En => "Riichi Mahjong",
+            },
+            Key::CpuBattle => match lang {
+                Lang::Ja => "CPU対戦",
+                Lang::En => "VS CPU",
+            },
+            Key::SettingsMenu => match lang {
+                Lang::Ja => "設定",
+                Lang::En => "Settings",
+            },
+            Key::ComingSoon => match lang {
+                Lang::Ja => "（準備中）",
+                Lang::En => " (coming soon)",
+            },
+            Key::LanguageLabel => match lang {
+                Lang::Ja => "言語設定",
+                Lang::En => "Language",
+            },
+            Key::ModeSelectTitle => match lang {
+                Lang::Ja => "モード選択",
+                Lang::En => "Select Mode",
+            },
+            Key::SanmaOnlyNote => match lang {
+                Lang::Ja => "（三麻のみ）",
+                Lang::En => " (3-player only)",
+            },
+            Key::CpuSetupTitle => match lang {
+                Lang::Ja => "CPU設定",
+                Lang::En => "CPU Settings",
+            },
+            Key::Confirm => match lang {
+                Lang::Ja => "決定",
+                Lang::En => "Confirm",
             },
             Key::ModeFourEast => match lang {
                 Lang::Ja => "四人東風",
@@ -695,6 +755,21 @@ mod tests {
         assert_eq!(en.personality_label(0), "Balanced");
         assert_eq!(ja.cpu_slot(1), "CPU 2");
         assert_eq!(en.cpu_slot(2), "CPU 3");
+    }
+
+    /// 空席行にCPU設定が言語に応じて添えられること（#245）
+    #[test]
+    fn empty_seat_cpu_label_localizes() {
+        let ja = Translator::new(Lang::Ja);
+        let en = Translator::new(Lang::En);
+        assert_eq!(
+            ja.empty_seat_cpu_label(CpuLevel::Normal, CpuPersonality::Balanced),
+            "空席（CPU: 普通・バランス）"
+        );
+        assert_eq!(
+            en.empty_seat_cpu_label(CpuLevel::Strong, CpuPersonality::Defensive),
+            "Empty (CPU: Strong, Defensive)"
+        );
     }
 
     #[test]

--- a/crates/mahjong-client/src/main.rs
+++ b/crates/mahjong-client/src/main.rs
@@ -18,10 +18,12 @@ mod transport;
 mod wasm_rng;
 
 use adapter::{ConnStatus, GameAdapter, LocalAdapter, RemoteAdapter, RoomView, error_code_message};
-use game::{GameMode, GamePhase, GameState, PlayerLabel, RoomViewUi};
+use game::{GameMode, GamePhase, GameState, MenuOrigin, PlayerLabel, RoomViewUi};
 use mahjong_core::settings::Lang;
 use mahjong_server::protocol::net::SeatInfo;
-use renderer::{OnlineLobbyAction, OnlineMenuAction, SetupAction, TileTextures};
+use renderer::{
+    ModeSelectAction, OnlineLobbyAction, OnlineMenuAction, SetupAction, TileTextures, TopMenuAction,
+};
 
 fn window_conf() -> Conf {
     Conf {
@@ -57,7 +59,15 @@ fn build_seat_labels(room: &RoomView, lang: Lang) -> [String; 4] {
             return String::new();
         }
         let who = match &room.seats[i] {
-            SeatInfo::Empty => tr.get(i18n::Key::EmptySeat).to_string(),
+            SeatInfo::Empty => match room.cpu_configs {
+                // 空席を埋めるCPUの設定を添える（サーバの config_for_seat と
+                // 同じ規則: 座席1〜3 → configs[0..3]）
+                Some(configs) => {
+                    let spec = configs[i.saturating_sub(1).min(2)];
+                    tr.empty_seat_cpu_label(spec.level, spec.personality)
+                }
+                None => tr.get(i18n::Key::EmptySeat).to_string(),
+            },
             SeatInfo::Cpu { level, personality } => tr.cpu_seat_label(*level, *personality),
             SeatInfo::Human { name, connected } => {
                 if *connected {
@@ -213,9 +223,55 @@ async fn main() {
         }
 
         match game_state.phase {
-            GamePhase::Setup => {
-                // 設定画面の入力処理
-                if let Some(action) = renderer::handle_setup_input(&mut game_state, font.as_ref()) {
+            GamePhase::TopMenu => {
+                if let Some(action) = renderer::handle_top_menu_input(&mut game_state) {
+                    match action {
+                        TopMenuAction::CpuBattle => {
+                            game_state.phase = GamePhase::ModeSelect(MenuOrigin::Local);
+                        }
+                        TopMenuAction::Online => {
+                            game_state.online_state.status_line = None;
+                            game_state.online_state.status_is_error = false;
+                            game_state.online_state.room = None;
+                            game_state.phase = GamePhase::OnlineMenu;
+                        }
+                    }
+                }
+            }
+
+            GamePhase::ModeSelect(origin) => {
+                if let Some(action) = renderer::handle_mode_select_input(&mut game_state, origin) {
+                    match (action, origin) {
+                        (ModeSelectAction::ModeChosen(_), MenuOrigin::Local) => {
+                            // 選んだモードでCPU設定へ（モードは setup_state に反映済み）
+                            game_state.phase = GamePhase::CpuSetup(MenuOrigin::Local);
+                        }
+                        (ModeSelectAction::ModeChosen(_), MenuOrigin::Online) => {
+                            // 選んだモードでルームを作成する（online_state に反映済み）
+                            let url = transport::default_server_url();
+                            let name = display_name(&game_state);
+                            let rules = game_state.online_state.build_rules();
+                            let length = game_state.online_state.length();
+                            online = Some(RemoteAdapter::create_room(&url, &name, length, rules));
+                            let msg = i18n::Key::Connecting.text(game_state.lang);
+                            set_status(&mut game_state, msg, false);
+                            // 接続状況の表示と入室待ちはオンラインメニューが担う
+                            game_state.phase = GamePhase::OnlineMenu;
+                        }
+                        (ModeSelectAction::Back, MenuOrigin::Local) => {
+                            game_state.phase = GamePhase::TopMenu;
+                        }
+                        (ModeSelectAction::Back, MenuOrigin::Online) => {
+                            game_state.phase = GamePhase::OnlineMenu;
+                        }
+                    }
+                }
+            }
+
+            GamePhase::CpuSetup(origin) => {
+                if let Some(action) =
+                    renderer::handle_setup_input(&mut game_state, font.as_ref(), origin)
+                {
                     match action {
                         SetupAction::StartLocal(mut configs) => {
                             // ローカル対局開始（三麻設定は setup_state から反映される）
@@ -236,11 +292,19 @@ async fn main() {
                             }
                             adapter = Some(Box::new(new_adapter));
                         }
-                        SetupAction::GoOnline => {
-                            game_state.online_state.status_line = None;
-                            game_state.online_state.status_is_error = false;
-                            game_state.online_state.room = None;
-                            game_state.phase = GamePhase::OnlineMenu;
+                        SetupAction::ApplyOnline => {
+                            // CPU設定をサーバへ送って全員のロビー表示に反映する
+                            if let Some(remote) = &mut online {
+                                let specs = game_state.setup_state.build_cpu_specs();
+                                remote.set_cpu_configs(specs);
+                            }
+                            game_state.phase = GamePhase::OnlineLobby;
+                        }
+                        SetupAction::Back => {
+                            game_state.phase = match origin {
+                                MenuOrigin::Local => GamePhase::ModeSelect(MenuOrigin::Local),
+                                MenuOrigin::Online => GamePhase::OnlineLobby,
+                            };
                         }
                     }
                 }
@@ -250,13 +314,8 @@ async fn main() {
                 if let Some(action) = renderer::handle_online_menu_input(&mut game_state) {
                     match action {
                         OnlineMenuAction::CreateRoom => {
-                            let url = transport::default_server_url();
-                            let name = display_name(&game_state);
-                            let rules = game_state.online_state.build_rules();
-                            let length = game_state.online_state.length();
-                            online = Some(RemoteAdapter::create_room(&url, &name, length, rules));
-                            let msg = i18n::Key::Connecting.text(game_state.lang);
-                            set_status(&mut game_state, msg, false);
+                            // ルーム作成の前に対局モードを選ぶ
+                            game_state.phase = GamePhase::ModeSelect(MenuOrigin::Online);
                         }
                         OnlineMenuAction::JoinRoom => {
                             let code = game_state.online_state.code_input.clone();
@@ -275,7 +334,7 @@ async fn main() {
                             online = None;
                             game_state.online_state.status_line = None;
                             game_state.online_state.status_is_error = false;
-                            game_state.phase = GamePhase::Setup;
+                            game_state.phase = GamePhase::TopMenu;
                         }
                     }
                 }
@@ -291,6 +350,13 @@ async fn main() {
             GamePhase::OnlineLobby => {
                 if let Some(action) = renderer::handle_online_lobby_input(&game_state) {
                     match action {
+                        OnlineLobbyAction::OpenCpuSettings => {
+                            // ルームのモードに合わせてCPU人数を揃えてから開く
+                            if let Some(room) = &game_state.online_state.room {
+                                game_state.setup_state.mode = room.mode;
+                            }
+                            game_state.phase = GamePhase::CpuSetup(MenuOrigin::Online);
+                        }
                         OnlineLobbyAction::StartGame => {
                             if let Some(remote) = &mut online {
                                 // ホストが設定画面で選んだCPUの強さ・性格を送る
@@ -338,7 +404,7 @@ async fn main() {
 
             GamePhase::GameOver => {
                 if is_mouse_button_pressed(MouseButton::Left) {
-                    // 設定画面に戻る
+                    // トップ画面に戻る
                     game_state = GameState::new();
                     adapter = None;
                     online = None;

--- a/crates/mahjong-client/src/renderer/menu.rs
+++ b/crates/mahjong-client/src/renderer/menu.rs
@@ -1,0 +1,381 @@
+//! トップ画面・モード選択画面
+//!
+//! トップ画面はアプリ起動直後の入口で、CPU対戦・オンライン対戦・
+//! 設定（未実装）・言語設定を選ぶ。モード選択画面は対局モード
+//! （四人東風〜三人半荘）と北抜きドラを選び、CPU対戦とオンラインの
+//! ルーム作成で共有する。
+
+use macroquad::prelude::*;
+
+use super::{DESIGN_W, draw_jp_text, mouse_position_design, theme};
+use crate::game::{GameMode, GameState, MenuOrigin};
+use crate::i18n::Key;
+use mahjong_core::settings::Lang;
+
+/// ボタンの矩形
+struct Rect2 {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+}
+
+impl Rect2 {
+    fn contains(&self, mx: f32, my: f32) -> bool {
+        mx >= self.x && mx < self.x + self.w && my >= self.y && my < self.y + self.h
+    }
+
+    fn center_x(&self) -> f32 {
+        self.x + self.w / 2.0
+    }
+
+    fn center_y(&self) -> f32 {
+        self.y + self.h / 2.0
+    }
+}
+
+// 共通パネル（トップ画面・モード選択画面で同じ枠を使う）
+const PANEL_W: f32 = 560.0;
+const PANEL_Y: f32 = 110.0;
+const PANEL_H: f32 = 580.0;
+
+fn panel_x() -> f32 {
+    (DESIGN_W - PANEL_W) / 2.0
+}
+
+/// メニューの縦積みボタン（幅・Xは共通、Yだけ変える）
+fn menu_button(y: f32, h: f32) -> Rect2 {
+    Rect2 {
+        x: DESIGN_W / 2.0 - 180.0,
+        y,
+        w: 360.0,
+        h,
+    }
+}
+
+// ========== トップ画面 ==========
+
+fn top_cpu_rect() -> Rect2 {
+    menu_button(300.0, 56.0)
+}
+
+fn top_online_rect() -> Rect2 {
+    menu_button(376.0, 56.0)
+}
+
+fn top_settings_rect() -> Rect2 {
+    menu_button(452.0, 56.0)
+}
+
+/// 言語トグルのボタン矩形。idx 0=日本語, 1=English。
+fn top_lang_rect(idx: usize) -> Rect2 {
+    const W: f32 = 140.0;
+    const H: f32 = 40.0;
+    const GAP: f32 = 12.0;
+    let left = DESIGN_W / 2.0 - W - GAP / 2.0;
+    Rect2 {
+        x: left + idx as f32 * (W + GAP),
+        y: 588.0,
+        w: W,
+        h: H,
+    }
+}
+
+/// 言語トグルに表示する固有名（言語非依存の自称表記）。
+const LANG_LABELS: [&str; 2] = ["日本語", "English"];
+
+/// トップ画面での操作
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TopMenuAction {
+    /// CPU対戦（モード選択へ）
+    CpuBattle,
+    /// オンライン対戦（オンライン対戦設定へ）
+    Online,
+}
+
+/// メニュー画面共通のパネルとタイトルを描画する
+fn draw_menu_panel(font: Option<&Font>, title: &str, title_size: u16) {
+    super::draw_setup_background();
+    theme::draw_panel(
+        panel_x(),
+        PANEL_Y,
+        PANEL_W,
+        PANEL_H,
+        12.0,
+        theme::PANEL_BG,
+        theme::PANEL_BORDER,
+    );
+    theme::draw_text_centered(
+        font,
+        title,
+        DESIGN_W / 2.0,
+        PANEL_Y + 80.0,
+        title_size,
+        theme::TEXT_BR,
+    );
+}
+
+/// 大きなメニューボタンを描画する
+fn draw_menu_button(font: Option<&Font>, rect: &Rect2, label: &str, accent: bool) {
+    if accent {
+        theme::draw_gradient_button(
+            rect.x,
+            rect.y,
+            rect.w,
+            rect.h,
+            8.0,
+            theme::rgb_pub(0x9a7a1a),
+            theme::rgb_pub(0x6a5210),
+            theme::GOLD,
+            2.0,
+        );
+        theme::draw_text_centered(
+            font,
+            label,
+            rect.center_x(),
+            rect.center_y() + 7.0,
+            18,
+            theme::GOLD_LT,
+        );
+    } else {
+        theme::draw_rounded_rect(
+            rect.x,
+            rect.y,
+            rect.w,
+            rect.h,
+            6.0,
+            theme::rgba(0xffffff, 0.05),
+        );
+        theme::draw_rounded_rect_lines(
+            rect.x,
+            rect.y,
+            rect.w,
+            rect.h,
+            6.0,
+            1.0,
+            theme::rgba(0xc8a227, 0.3),
+        );
+        theme::draw_text_centered(
+            font,
+            label,
+            rect.center_x(),
+            rect.center_y() + 6.0,
+            15,
+            theme::TEXT,
+        );
+    }
+}
+
+/// 押せないメニューボタン（未実装機能）を描画する
+fn draw_disabled_button(font: Option<&Font>, rect: &Rect2, label: &str) {
+    theme::draw_rounded_rect(
+        rect.x,
+        rect.y,
+        rect.w,
+        rect.h,
+        6.0,
+        theme::rgba(0xffffff, 0.02),
+    );
+    theme::draw_rounded_rect_lines(
+        rect.x,
+        rect.y,
+        rect.w,
+        rect.h,
+        6.0,
+        1.0,
+        theme::rgba(0xffffff, 0.06),
+    );
+    theme::draw_text_centered(
+        font,
+        label,
+        rect.center_x(),
+        rect.center_y() + 6.0,
+        15,
+        theme::rgba(0xffffff, 0.25),
+    );
+}
+
+/// 小さなトグルボタン（選択状態を金色で示す）を描画する
+fn draw_toggle(font: Option<&Font>, rect: &Rect2, label: &str, selected: bool, size: u16) {
+    let (fill, border, text_color) = if selected {
+        (
+            theme::rgba(0xc8a227, 0.13),
+            theme::rgba(0xc8a227, 0.45),
+            theme::GOLD_LT,
+        )
+    } else {
+        (
+            Color::new(1.0, 1.0, 1.0, 0.04),
+            Color::new(1.0, 1.0, 1.0, 0.07),
+            theme::TEXT_DIM,
+        )
+    };
+    theme::draw_rounded_rect(rect.x, rect.y, rect.w, rect.h, 4.0, fill);
+    theme::draw_rounded_rect_lines(rect.x, rect.y, rect.w, rect.h, 4.0, 1.0, border);
+    theme::draw_text_centered(
+        font,
+        label,
+        rect.center_x(),
+        rect.center_y() + 5.0,
+        size,
+        text_color,
+    );
+}
+
+/// トップ画面を描画する
+pub fn draw_top_menu(state: &GameState, font: Option<&Font>) {
+    let tr = state.tr();
+    draw_menu_panel(font, tr.get(Key::AppTitle), 32);
+
+    draw_menu_button(font, &top_cpu_rect(), tr.get(Key::CpuBattle), true);
+    draw_menu_button(font, &top_online_rect(), tr.get(Key::OnlinePlay), true);
+
+    // 設定（ルール設定の変更）は未実装のため押せない
+    let settings_label = format!("{}{}", tr.get(Key::SettingsMenu), tr.get(Key::ComingSoon));
+    draw_disabled_button(font, &top_settings_rect(), &settings_label);
+
+    // 言語設定（日本語 / English）
+    let lang_rect = top_lang_rect(0);
+    draw_jp_text(
+        font,
+        tr.get(Key::LanguageLabel),
+        lang_rect.x,
+        lang_rect.y - 12.0,
+        12,
+        theme::TEXT_DIM,
+    );
+    let active_lang = match state.lang {
+        Lang::Ja => 0,
+        Lang::En => 1,
+    };
+    for (idx, &label) in LANG_LABELS.iter().enumerate() {
+        draw_toggle(font, &top_lang_rect(idx), label, idx == active_lang, 14);
+    }
+}
+
+/// トップ画面の入力を処理する。ボタンが押された場合 Some(action) を返す。
+pub fn handle_top_menu_input(state: &mut GameState) -> Option<TopMenuAction> {
+    if !is_mouse_button_pressed(MouseButton::Left) {
+        return None;
+    }
+    let (mx, my) = mouse_position_design();
+
+    // 言語切替トグル（日本語 / English）
+    for (idx, lang) in [Lang::Ja, Lang::En].into_iter().enumerate() {
+        if top_lang_rect(idx).contains(mx, my) {
+            state.lang = lang;
+            crate::persistence::save_lang(lang);
+            return None;
+        }
+    }
+
+    if top_cpu_rect().contains(mx, my) {
+        return Some(TopMenuAction::CpuBattle);
+    }
+    if top_online_rect().contains(mx, my) {
+        return Some(TopMenuAction::Online);
+    }
+
+    None
+}
+
+// ========== モード選択画面 ==========
+
+/// 対局モードボタンの矩形。idx はモードトグルの表示順（GameMode::ALL）。
+fn mode_rect(idx: usize) -> Rect2 {
+    menu_button(220.0 + idx as f32 * 66.0, 52.0)
+}
+
+/// 北抜きドラトグルの矩形（モードボタンの下）
+fn nuki_rect() -> Rect2 {
+    menu_button(504.0, 40.0)
+}
+
+/// 戻るボタンの矩形
+fn mode_back_rect() -> Rect2 {
+    menu_button(596.0, 40.0)
+}
+
+/// モード選択画面での操作
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModeSelectAction {
+    /// モードを選んで次へ進む（ローカルはCPU設定へ、オンラインはルーム作成）
+    ModeChosen(GameMode),
+    /// 前の画面へ戻る
+    Back,
+}
+
+/// 遷移元に応じたモード・北抜きドラの現在値を返す
+fn mode_and_nuki(state: &GameState, origin: MenuOrigin) -> (GameMode, bool) {
+    match origin {
+        MenuOrigin::Local => (state.setup_state.mode, state.setup_state.nuki_dora),
+        MenuOrigin::Online => (state.online_state.mode, state.online_state.nuki_dora),
+    }
+}
+
+/// モード選択画面を描画する
+pub fn draw_mode_select(state: &GameState, font: Option<&Font>, origin: MenuOrigin) {
+    let tr = state.tr();
+    draw_menu_panel(font, tr.get(Key::ModeSelectTitle), 26);
+
+    let (current_mode, nuki_dora) = mode_and_nuki(state, origin);
+
+    for (idx, mode) in GameMode::ALL.into_iter().enumerate() {
+        draw_toggle(
+            font,
+            &mode_rect(idx),
+            tr.get(mode.label_key()),
+            mode == current_mode,
+            16,
+        );
+    }
+
+    // 北抜きドラトグル（三麻を選んで進む場合のみ効く）
+    let nuki_label = format!(
+        "{}{}",
+        tr.get(Key::NukiDoraToggle),
+        tr.get(Key::SanmaOnlyNote)
+    );
+    draw_toggle(font, &nuki_rect(), &nuki_label, nuki_dora, 13);
+
+    draw_menu_button(font, &mode_back_rect(), tr.get(Key::Back), false);
+}
+
+/// モード選択画面の入力を処理する。ボタンが押された場合 Some(action) を返す。
+pub fn handle_mode_select_input(
+    state: &mut GameState,
+    origin: MenuOrigin,
+) -> Option<ModeSelectAction> {
+    if !is_mouse_button_pressed(MouseButton::Left) {
+        return None;
+    }
+    let (mx, my) = mouse_position_design();
+
+    for (idx, mode) in GameMode::ALL.into_iter().enumerate() {
+        if mode_rect(idx).contains(mx, my) {
+            match origin {
+                MenuOrigin::Local => state.setup_state.mode = mode,
+                MenuOrigin::Online => state.online_state.mode = mode,
+            }
+            return Some(ModeSelectAction::ModeChosen(mode));
+        }
+    }
+
+    if nuki_rect().contains(mx, my) {
+        match origin {
+            MenuOrigin::Local => {
+                state.setup_state.nuki_dora = !state.setup_state.nuki_dora;
+            }
+            MenuOrigin::Online => {
+                state.online_state.nuki_dora = !state.online_state.nuki_dora;
+            }
+        }
+        return None;
+    }
+
+    if mode_back_rect().contains(mx, my) {
+        return Some(ModeSelectAction::Back);
+    }
+
+    None
+}

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -3,6 +3,7 @@
 //! 埋め込みPNGを使って麻雀牌を描画する。
 
 mod board;
+mod menu;
 mod online;
 mod overlay;
 mod result;
@@ -12,6 +13,7 @@ mod tests;
 mod theme;
 mod tiles;
 
+pub use menu::{ModeSelectAction, TopMenuAction, handle_mode_select_input, handle_top_menu_input};
 pub use setup::{SetupAction, handle_setup_input};
 
 use board::*;
@@ -31,7 +33,7 @@ use mahjong_server::cpu::client::CpuConfig;
 
 use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
 
-use crate::game::{GameMode, GamePhase, GameState, SetupState};
+use crate::game::{GamePhase, GameState, SetupState};
 use crate::i18n::Key;
 
 const RIICHI_DISABLED_TINT: Color = Color::new(0.45, 0.45, 0.42, 1.0);
@@ -334,8 +336,16 @@ pub fn draw_game(
     tile_textures: &TileTextures,
 ) -> Option<OverlayClick> {
     match state.phase {
-        GamePhase::Setup => {
-            draw_setup(state, font);
+        GamePhase::TopMenu => {
+            menu::draw_top_menu(state, font);
+            None
+        }
+        GamePhase::ModeSelect(origin) => {
+            menu::draw_mode_select(state, font, origin);
+            None
+        }
+        GamePhase::CpuSetup(origin) => {
+            draw_setup(state, font, origin);
             None
         }
         GamePhase::OnlineMenu => {

--- a/crates/mahjong-client/src/renderer/online.rs
+++ b/crates/mahjong-client/src/renderer/online.rs
@@ -6,7 +6,7 @@
 use macroquad::prelude::*;
 
 use super::{DESIGN_W, draw_jp_text, theme};
-use crate::game::{GameMode, GameState};
+use crate::game::GameState;
 use crate::i18n::Key;
 
 /// パネルのレイアウト（設定画面と揃える）
@@ -51,33 +51,6 @@ const CODE_BOX: Rect2 = Rect2 {
     w: 400.0,
     h: 44.0,
 };
-/// 対局モードトグル（四人東風/四人半荘/三人東風/三人半荘）と北抜きトグルの行
-const MODE_BTN_W: f32 = 100.0;
-const MODE_BTN_H: f32 = 32.0;
-const MODE_BTN_GAP: f32 = 8.0;
-const MODE_Y: f32 = 408.0;
-
-/// 対局モードトグルのボタン矩形。
-/// idx 0=四人東風, 1=四人半荘, 2=三人東風, 3=三人半荘。
-fn mode_btn_rect(idx: usize) -> Rect2 {
-    Rect2 {
-        x: NAME_BOX.x + idx as f32 * (MODE_BTN_W + MODE_BTN_GAP),
-        y: MODE_Y,
-        w: MODE_BTN_W,
-        h: MODE_BTN_H,
-    }
-}
-
-/// 北抜きドラトグルのボタン矩形（三麻選択時のみ表示）。
-fn nuki_btn_rect() -> Rect2 {
-    Rect2 {
-        x: NAME_BOX.x + GameMode::ALL.len() as f32 * (MODE_BTN_W + MODE_BTN_GAP) + 10.0,
-        y: MODE_Y,
-        w: 130.0,
-        h: MODE_BTN_H,
-    }
-}
-
 const CREATE_BTN: Rect2 = Rect2 {
     x: 440.0,
     y: 450.0,
@@ -95,6 +68,13 @@ const BACK_BTN: Rect2 = Rect2 {
     y: 610.0,
     w: 400.0,
     h: 40.0,
+};
+/// ロビーのCPU設定ボタン（ホストのみ表示）
+const CPU_SETUP_BTN: Rect2 = Rect2 {
+    x: 440.0,
+    y: 500.0,
+    w: 400.0,
+    h: 44.0,
 };
 const START_BTN: Rect2 = Rect2 {
     x: 440.0,
@@ -123,6 +103,8 @@ pub enum OnlineMenuAction {
 /// ロビーでの操作
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OnlineLobbyAction {
+    /// CPU設定画面を開く（ホストのみ）
+    OpenCpuSettings,
     /// 対局を開始する（ホストのみ）
     StartGame,
     /// 退出する
@@ -226,33 +208,6 @@ fn draw_input_box(font: Option<&Font>, rect: &Rect2, text: &str, focused: bool) 
     );
 }
 
-/// 小さなトグルボタン（設定画面のオプションボタンと同じ見た目）を描画する。
-fn draw_toggle(font: Option<&Font>, rect: &Rect2, label: &str, selected: bool) {
-    let (fill, border, text_color) = if selected {
-        (
-            theme::rgba(0xc8a227, 0.13),
-            theme::rgba(0xc8a227, 0.45),
-            theme::GOLD_LT,
-        )
-    } else {
-        (
-            Color::new(1.0, 1.0, 1.0, 0.04),
-            Color::new(1.0, 1.0, 1.0, 0.07),
-            theme::TEXT_DIM,
-        )
-    };
-    theme::draw_rounded_rect(rect.x, rect.y, rect.w, rect.h, 4.0, fill);
-    theme::draw_rounded_rect_lines(rect.x, rect.y, rect.w, rect.h, 4.0, 1.0, border);
-    theme::draw_text_centered(
-        font,
-        label,
-        rect.center_x(),
-        rect.y + rect.h / 2.0 + 5.0,
-        13,
-        text_color,
-    );
-}
-
 fn draw_status_line(state: &GameState, font: Option<&Font>, y: f32) {
     if let Some(line) = &state.online_state.status_line {
         let color = if state.online_state.status_is_error {
@@ -290,25 +245,6 @@ pub fn draw_online_menu(state: &GameState, font: Option<&Font>) {
         theme::TEXT_DIM,
     );
     draw_input_box(font, &CODE_BOX, &online.code_input, online.code_focused);
-
-    // 対局モードトグル（ルーム作成時に適用される）
-    for (idx, mode) in GameMode::ALL.into_iter().enumerate() {
-        let selected = mode == online.mode;
-        draw_toggle(
-            font,
-            &mode_btn_rect(idx),
-            tr.get(mode.label_key()),
-            selected,
-        );
-    }
-    if online.mode.three_player() {
-        draw_toggle(
-            font,
-            &nuki_btn_rect(),
-            tr.get(Key::NukiDoraToggle),
-            online.nuki_dora,
-        );
-    }
 
     draw_button(font, &CREATE_BTN, tr.get(Key::CreateRoom), true);
     draw_button(font, &JOIN_BTN, tr.get(Key::JoinRoom), true);
@@ -361,17 +297,6 @@ pub fn handle_online_menu_input(state: &mut GameState) -> Option<OnlineMenuActio
     }
     if CODE_BOX.contains(mx, my) {
         online.code_focused = true;
-        return None;
-    }
-    // 対局モードトグル
-    for (idx, mode) in GameMode::ALL.into_iter().enumerate() {
-        if mode_btn_rect(idx).contains(mx, my) {
-            online.mode = mode;
-            return None;
-        }
-    }
-    if online.mode.three_player() && nuki_btn_rect().contains(mx, my) {
-        online.nuki_dora = !online.nuki_dora;
         return None;
     }
 
@@ -451,15 +376,16 @@ pub fn draw_online_lobby(state: &GameState, font: Option<&Font>) {
     }
 
     if room.is_host {
-        draw_button(font, &START_BTN, tr.get(Key::StartGame), true);
         theme::draw_text_centered(
             font,
             tr.get(Key::EmptySeatsCpu),
             cx,
-            START_BTN.y - 8.0,
+            CPU_SETUP_BTN.y - 10.0,
             12,
             theme::TEXT_DIM,
         );
+        draw_button(font, &CPU_SETUP_BTN, tr.get(Key::CpuSetupTitle), false);
+        draw_button(font, &START_BTN, tr.get(Key::StartGame), true);
     } else {
         theme::draw_text_centered(
             font,
@@ -487,6 +413,9 @@ pub fn handle_online_lobby_input(state: &GameState) -> Option<OnlineLobbyAction>
         .room
         .as_ref()
         .is_some_and(|room| room.is_host);
+    if is_host && CPU_SETUP_BTN.contains(mx, my) {
+        return Some(OnlineLobbyAction::OpenCpuSettings);
+    }
     if is_host && START_BTN.contains(mx, my) {
         return Some(OnlineLobbyAction::StartGame);
     }

--- a/crates/mahjong-client/src/renderer/setup.rs
+++ b/crates/mahjong-client/src/renderer/setup.rs
@@ -1,8 +1,12 @@
-//! 設定画面の描画と入力処理
+//! CPU設定画面の描画と入力処理
+//!
+//! CPU対戦では「対局開始」、オンライン対戦（ホストがロビーから開く）では
+//! 「決定」で確定する。対局モードはモード選択画面（menu.rs）で選ぶ。
 
 use super::*;
+use crate::game::MenuOrigin;
 
-// ========== 設定画面 ==========
+// ========== CPU設定画面 ==========
 
 /// 設定画面のボタン領域
 pub(super) struct SetupButton {
@@ -28,48 +32,6 @@ pub(super) const SETUP_CARD_Y: f32 = 142.0;
 pub(super) const SETUP_CARD_H: f32 = 348.0;
 pub(super) const SETUP_OPT_H: f32 = 28.0;
 pub(super) const SETUP_OPT_STEP: f32 = 32.0;
-
-/// 言語切替トグルのボタン矩形（パネル右上）。idx 0=日本語, 1=English。
-pub(super) fn setup_lang_button_rect(idx: usize) -> SetupButton {
-    const W: f32 = 84.0;
-    const H: f32 = 28.0;
-    const GAP: f32 = 6.0;
-    let right = setup_panel_x() + SETUP_PANEL_W - SETUP_CARD_PAD;
-    let y = SETUP_PANEL_Y + 24.0;
-    // 右詰めで [日本語][English] を並べる
-    let x = right - (2.0 - idx as f32) * W - (1.0 - idx as f32) * GAP;
-    SetupButton { x, y, w: W, h: H }
-}
-
-/// 言語切替トグルに表示する固有名（言語非依存の自称表記）。
-pub(super) const SETUP_LANG_LABELS: [&str; 2] = ["日本語", "English"];
-
-/// 対局モードトグルのボタン矩形（パネル左上）。
-/// idx 0=四人東風, 1=四人半荘, 2=三人東風, 3=三人半荘。
-pub(super) fn setup_mode_button_rect(idx: usize) -> SetupButton {
-    const W: f32 = 96.0;
-    const H: f32 = 28.0;
-    const GAP: f32 = 6.0;
-    let left = setup_panel_x() + SETUP_CARD_PAD;
-    let y = SETUP_PANEL_Y + 24.0;
-    SetupButton {
-        x: left + idx as f32 * (W + GAP),
-        y,
-        w: W,
-        h: H,
-    }
-}
-
-/// 北抜きドラトグルのボタン矩形（三麻選択時のみ表示）。
-pub(super) fn setup_nuki_button_rect() -> SetupButton {
-    let m = setup_mode_button_rect(GameMode::ALL.len() - 1);
-    SetupButton {
-        x: m.x + m.w + 18.0,
-        y: m.y,
-        w: 110.0,
-        h: m.h,
-    }
-}
 
 pub(super) fn setup_panel_x() -> f32 {
     (DESIGN_W - SETUP_PANEL_W) / 2.0
@@ -106,7 +68,7 @@ pub(super) fn setup_start_rect() -> SetupButton {
     }
 }
 
-pub(super) fn setup_online_rect() -> SetupButton {
+pub(super) fn setup_back_rect() -> SetupButton {
     let s = setup_start_rect();
     SetupButton {
         x: DESIGN_W / 2.0 - 110.0,
@@ -137,8 +99,11 @@ pub(super) fn draw_setup_option(
     draw_jp_text(font, label, btn.x + 12.0, btn.y + 18.0, 13, text_color);
 }
 
-/// 設定画面を描画する
-pub(super) fn draw_setup(state: &GameState, font: Option<&Font>) {
+/// CPU設定画面を描画する
+///
+/// `origin` により確定ボタンの文言が変わる
+/// （ローカル=対局開始、オンライン=決定）。
+pub(super) fn draw_setup(state: &GameState, font: Option<&Font>, origin: MenuOrigin) {
     draw_setup_background();
     let setup = &state.setup_state;
     let tr = state.tr();
@@ -155,37 +120,24 @@ pub(super) fn draw_setup(state: &GameState, font: Option<&Font>) {
         theme::PANEL_BORDER,
     );
 
-    // タイトル
+    // タイトル（選択中の対局モードを添える）
     let cx = DESIGN_W / 2.0;
     theme::draw_text_centered(
         font,
-        tr.get(Key::SetupTitle),
+        tr.get(Key::CpuSetupTitle),
         cx,
         SETUP_PANEL_Y + 52.0,
         26,
         theme::TEXT_BR,
     );
-
-    // 言語切替トグル（日本語 / English）
-    let active_lang = match state.lang {
-        Lang::Ja => 0,
-        Lang::En => 1,
-    };
-    for (idx, &label) in SETUP_LANG_LABELS.iter().enumerate() {
-        let btn = setup_lang_button_rect(idx);
-        draw_setup_option(font, &btn, label, idx == active_lang);
-    }
-
-    // 対局モードトグル（四人東風 / 四人半荘 / 三人東風 / 三人半荘）
-    for (idx, mode) in GameMode::ALL.into_iter().enumerate() {
-        let btn = setup_mode_button_rect(idx);
-        draw_setup_option(font, &btn, tr.get(mode.label_key()), mode == setup.mode);
-    }
-    // 北抜きドラトグル（三麻のみ）
-    if setup.mode.three_player() {
-        let btn = setup_nuki_button_rect();
-        draw_setup_option(font, &btn, tr.get(Key::NukiDoraToggle), setup.nuki_dora);
-    }
+    theme::draw_text_centered(
+        font,
+        tr.get(setup.mode.label_key()),
+        cx,
+        SETUP_PANEL_Y + 78.0,
+        13,
+        theme::GOLD_LT,
+    );
 
     // CPU カード（三麻はCPU2人）
     let card_w = setup_card_w();
@@ -271,7 +223,11 @@ pub(super) fn draw_setup(state: &GameState, font: Option<&Font>) {
         }
     }
 
-    // 対局開始ボタン（ゴールド）
+    // 確定ボタン（ゴールド。ローカル=対局開始、オンライン=決定）
+    let confirm_key = match origin {
+        MenuOrigin::Local => Key::StartGame,
+        MenuOrigin::Online => Key::Confirm,
+    };
     let s = setup_start_rect();
     theme::draw_gradient_button(
         s.x,
@@ -286,66 +242,42 @@ pub(super) fn draw_setup(state: &GameState, font: Option<&Font>) {
     );
     theme::draw_text_centered(
         font,
-        tr.get(Key::StartGame),
+        tr.get(confirm_key),
         cx,
         s.y + 34.0,
         20,
         theme::GOLD_LT,
     );
 
-    // オンライン対戦ボタン
-    let o = setup_online_rect();
-    theme::draw_rounded_rect(o.x, o.y, o.w, o.h, 6.0, theme::rgba(0xffffff, 0.05));
-    theme::draw_rounded_rect_lines(o.x, o.y, o.w, o.h, 6.0, 1.0, theme::rgba(0xc8a227, 0.3));
-    theme::draw_text_centered(
-        font,
-        tr.get(Key::OnlinePlay),
-        cx,
-        o.y + 24.0,
-        14,
-        theme::TEXT,
-    );
+    // 戻るボタン
+    let b = setup_back_rect();
+    theme::draw_rounded_rect(b.x, b.y, b.w, b.h, 6.0, theme::rgba(0xffffff, 0.05));
+    theme::draw_rounded_rect_lines(b.x, b.y, b.w, b.h, 6.0, 1.0, theme::rgba(0xc8a227, 0.3));
+    theme::draw_text_centered(font, tr.get(Key::Back), cx, b.y + 24.0, 14, theme::TEXT);
 }
 
-/// 設定画面での操作
+/// CPU設定画面での操作
 pub enum SetupAction {
     /// ローカル対局を開始する
     StartLocal([CpuConfig; 3]),
-    /// オンライン対戦メニューへ
-    GoOnline,
+    /// CPU設定を確定してロビーへ戻る（オンラインのホストのみ）
+    ApplyOnline,
+    /// 前の画面へ戻る（ローカル=モード選択、オンライン=ロビー）
+    Back,
 }
 
-/// 設定画面の入力を処理する。ボタンが押された場合 Some(action) を返す。
-pub fn handle_setup_input(state: &mut GameState, _font: Option<&Font>) -> Option<SetupAction> {
+/// CPU設定画面の入力を処理する。ボタンが押された場合 Some(action) を返す。
+pub fn handle_setup_input(
+    state: &mut GameState,
+    _font: Option<&Font>,
+    origin: MenuOrigin,
+) -> Option<SetupAction> {
     if !is_mouse_button_pressed(MouseButton::Left) {
         return None;
     }
 
     let (mx, my) = mouse_position_design();
-
-    // 言語切替トグル（日本語 / English）
-    for (idx, lang) in [Lang::Ja, Lang::En].into_iter().enumerate() {
-        if setup_lang_button_rect(idx).contains(mx, my) {
-            state.lang = lang;
-            crate::persistence::save_lang(lang);
-            return None;
-        }
-    }
-
     let setup = &mut state.setup_state;
-
-    // 対局モードトグル（四人東風 / 四人半荘 / 三人東風 / 三人半荘）
-    for (idx, mode) in GameMode::ALL.into_iter().enumerate() {
-        if setup_mode_button_rect(idx).contains(mx, my) {
-            setup.mode = mode;
-            return None;
-        }
-    }
-    // 北抜きドラトグル（三麻のみ）
-    if setup.mode.three_player() && setup_nuki_button_rect().contains(mx, my) {
-        setup.nuki_dora = !setup.nuki_dora;
-        return None;
-    }
 
     for cpu_idx in 0..setup.cpu_count() {
         // 強さボタン
@@ -364,16 +296,21 @@ pub fn handle_setup_input(state: &mut GameState, _font: Option<&Font>) -> Option
         }
     }
 
-    // 対局開始ボタン
+    // 確定ボタン（ローカル=対局開始、オンライン=決定）
     if setup_start_rect().contains(mx, my) {
-        let configs = setup.build_configs();
-        state.phase = GamePhase::WaitingForStart;
-        return Some(SetupAction::StartLocal(configs));
+        return match origin {
+            MenuOrigin::Local => {
+                let configs = setup.build_configs();
+                state.phase = GamePhase::WaitingForStart;
+                Some(SetupAction::StartLocal(configs))
+            }
+            MenuOrigin::Online => Some(SetupAction::ApplyOnline),
+        };
     }
 
-    // オンライン対戦ボタン
-    if setup_online_rect().contains(mx, my) {
-        return Some(SetupAction::GoOnline);
+    // 戻るボタン
+    if setup_back_rect().contains(mx, my) {
+        return Some(SetupAction::Back);
     }
 
     None

--- a/crates/mahjong-net-server/src/room.rs
+++ b/crates/mahjong-net-server/src/room.rs
@@ -361,6 +361,9 @@ impl Room {
 
     fn handle_client_message(&mut self, seat: usize, msg: ClientMessage) {
         match msg {
+            ClientMessage::SetCpuConfigs { cpu_configs } => {
+                self.handle_set_cpu_configs(seat, cpu_configs)
+            }
             ClientMessage::StartGame { cpu_configs } => self.handle_start_game(seat, cpu_configs),
             ClientMessage::Action(action) => {
                 if !self.game_started() || self.awaiting_ready {
@@ -399,6 +402,20 @@ impl Room {
                 self.send_error(seat, ErrorCode::BadMessage, "unexpected message");
             }
         }
+    }
+
+    /// ホストが選んだCPUの強さ・性格を保持し、全員のロビー表示へ共有する
+    fn handle_set_cpu_configs(&mut self, seat: usize, cpu_configs: [CpuSpec; 3]) {
+        if seat != HOST_SEAT {
+            self.send_error(seat, ErrorCode::NotHost, "only the host can configure CPUs");
+            return;
+        }
+        if self.game_started() {
+            self.send_error(seat, ErrorCode::GameInProgress, "game already started");
+            return;
+        }
+        self.cpu_configs = cpu_configs.map(|spec| spec.to_config());
+        self.broadcast_room_state();
     }
 
     fn handle_start_game(&mut self, seat: usize, cpu_configs: Option<[CpuSpec; 3]>) {
@@ -780,6 +797,9 @@ impl Room {
             your_seat: seat,
             rules: self.settings.rules.clone(),
             length: self.settings.length,
+            cpu_configs: Some(std::array::from_fn(|i| {
+                CpuSpec::from_config(&self.cpu_configs[i])
+            })),
         };
         self.send_to_seat(seat, msg);
     }

--- a/crates/mahjong-net-server/tests/integration.rs
+++ b/crates/mahjong-net-server/tests/integration.rs
@@ -400,6 +400,76 @@ async fn test_host_chosen_cpu_configs_apply() {
     .expect("テスト全体がタイムアウトした");
 }
 
+/// ホストの SetCpuConfigs が全参加者の RoomState に共有される（#245）
+#[tokio::test]
+async fn test_set_cpu_configs_shared_in_lobby() {
+    use mahjong_server::cpu::client::{CpuLevel, CpuPersonality};
+    use mahjong_server::protocol::net::{CpuSpec, SeatInfo};
+
+    tokio::time::timeout(Duration::from_secs(30), async {
+        let addr = start_server(fast_config()).await;
+        let mut host = TestClient::connect(addr).await;
+        host.hello("ホスト").await;
+        let code = host.create_room().await;
+
+        let mut guest = TestClient::connect(addr).await;
+        guest.hello("ゲスト").await;
+        guest
+            .send(&ClientMessage::JoinRoom { code: code.clone() })
+            .await;
+        // 入室による RoomState を読み飛ばす（既定のCPU設定が入っている）
+        match guest.recv().await {
+            ServerMessage::RoomState { cpu_configs, .. } => {
+                assert!(
+                    cpu_configs.is_some(),
+                    "ロビーの RoomState はCPU設定を含むべき"
+                );
+            }
+            other => panic!("RoomStateでないメッセージ: {other:?}"),
+        }
+        host.recv().await;
+
+        let specs = [
+            CpuSpec {
+                level: CpuLevel::Strong,
+                personality: CpuPersonality::Defensive,
+            },
+            CpuSpec {
+                level: CpuLevel::Weak,
+                personality: CpuPersonality::Speedy,
+            },
+            CpuSpec {
+                level: CpuLevel::Normal,
+                personality: CpuPersonality::HighValue,
+            },
+        ];
+
+        // ホスト以外は変更できない
+        guest
+            .send(&ClientMessage::SetCpuConfigs { cpu_configs: specs })
+            .await;
+        assert_eq!(guest.recv_error().await, ErrorCode::NotHost);
+
+        // ホストの変更は全員へ新しい RoomState として届く
+        host.send(&ClientMessage::SetCpuConfigs { cpu_configs: specs })
+            .await;
+        for client in [&mut host, &mut guest] {
+            match client.recv().await {
+                ServerMessage::RoomState {
+                    cpu_configs, seats, ..
+                } => {
+                    assert_eq!(cpu_configs, Some(specs));
+                    // 対局開始前なので空席は Empty のまま（表示側で補う）
+                    assert!(matches!(seats[2], SeatInfo::Empty));
+                }
+                other => panic!("RoomStateでないメッセージ: {other:?}"),
+            }
+        }
+    })
+    .await
+    .expect("テスト全体がタイムアウトした");
+}
+
 /// プロトコルバージョン不一致は VersionMismatch エラーになる
 #[tokio::test]
 async fn test_version_mismatch() {

--- a/crates/mahjong-server/src/protocol/net.rs
+++ b/crates/mahjong-server/src/protocol/net.rs
@@ -79,6 +79,15 @@ pub enum ClientMessage {
     /// ルームから退出する
     LeaveRoom,
 
+    /// 空席を埋めるCPUの強さ・性格を設定する（ホストのみ。開始前のみ）
+    ///
+    /// サーバは設定を保持して `RoomState` で全員へ共有する。
+    /// 対局開始時の割り当ては `StartGame` 時の設定が優先される。
+    SetCpuConfigs {
+        /// 各CPUの強さ・性格（下家・対面・上家の順）
+        cpu_configs: [CpuSpec; 3],
+    },
+
     /// 対局を開始する（ホストのみ。空席はCPUで埋める）
     StartGame {
         /// ホストが選んだ各CPUの強さ・性格（下家・対面・上家の順）。
@@ -120,6 +129,12 @@ pub enum ServerMessage {
         /// 対局の長さ（東風戦か半荘戦か。東風/半荘の表示に使う）
         #[serde(default)]
         length: GameLength,
+        /// 空席を埋めるCPUの強さ・性格（下家・対面・上家の順）
+        ///
+        /// ホストが `SetCpuConfigs` で変更でき、ロビーの空席表示に使う。
+        /// 旧サーバのメッセージには無いため `None` に補完される。
+        #[serde(default)]
+        cpu_configs: Option<[CpuSpec; 3]>,
     },
 
     /// ゲーム内イベント
@@ -276,6 +291,22 @@ mod tests {
                 code: "ABC234".to_string(),
             },
             ClientMessage::LeaveRoom,
+            ClientMessage::SetCpuConfigs {
+                cpu_configs: [
+                    CpuSpec {
+                        level: CpuLevel::Weak,
+                        personality: CpuPersonality::Defensive,
+                    },
+                    CpuSpec {
+                        level: CpuLevel::Normal,
+                        personality: CpuPersonality::Balanced,
+                    },
+                    CpuSpec {
+                        level: CpuLevel::Strong,
+                        personality: CpuPersonality::Speedy,
+                    },
+                ],
+            },
             ClientMessage::StartGame { cpu_configs: None },
             ClientMessage::StartGame {
                 cpu_configs: Some([
@@ -338,6 +369,20 @@ mod tests {
                 your_seat: 1,
                 rules: Settings::new(),
                 length: GameLength::Hanchan,
+                cpu_configs: Some([
+                    CpuSpec {
+                        level: CpuLevel::Normal,
+                        personality: CpuPersonality::Balanced,
+                    },
+                    CpuSpec {
+                        level: CpuLevel::Normal,
+                        personality: CpuPersonality::Speedy,
+                    },
+                    CpuSpec {
+                        level: CpuLevel::Normal,
+                        personality: CpuPersonality::HighValue,
+                    },
+                ]),
             },
             ServerMessage::Event(ServerEvent::TileDrawn {
                 tile: Tile::new(Tile::P5),
@@ -416,6 +461,17 @@ mod tests {
         let decoded = ServerMessage::from_json(json).expect("decode");
         match decoded {
             ServerMessage::RoomState { length, .. } => assert_eq!(length, GameLength::EastOnly),
+            _ => panic!("variant changed"),
+        }
+    }
+
+    /// cpu_configs を送らない旧サーバの RoomState が None に補完されること（#245）
+    #[test]
+    fn test_room_state_without_cpu_configs_defaults_to_none() {
+        let json = r#"{"RoomState":{"code":"ABC234","seats":["Empty","Empty","Empty","Empty"],"host_seat":0,"your_seat":1}}"#;
+        let decoded = ServerMessage::from_json(json).expect("decode");
+        match decoded {
+            ServerMessage::RoomState { cpu_configs, .. } => assert_eq!(cpu_configs, None),
             _ => panic!("variant changed"),
         }
     }


### PR DESCRIPTION
## Summary

Implements the menu restructuring proposed in #245. The client previously booted straight into the CPU setup screen; it now starts on a top menu with a hierarchical flow:

```
Top menu ─ VS CPU ────────→ Mode select ──→ CPU setup ──(Start Game)──→ game
         ├ Online Play ───→ Online menu ─(Create Room)→ Mode select ──→ lobby
         │                                (Join Room)─────────────────→ lobby
         ├ Settings (placeholder, disabled)
         └ Language (日本語 / English)
```

### Client

- **Top menu** (new `renderer/menu.rs`): VS CPU / Online Play / disabled Settings placeholder / language toggle (moved from the old setup screen)
- **Mode select** (new, shared): 4P/3P × East/Hanchan buttons plus the pei-dora toggle (annotated as 3-player only). Used by both the local flow and online room creation; `GamePhase::ModeSelect(MenuOrigin)` tracks where to return
- **CPU setup**: `renderer/setup.rs` trimmed down to CPU strength/personality cards. The confirm button reads "Start Game" locally and "Confirm" when opened from the online lobby; a Back button was added
- **Online menu**: mode/pei-dora toggles removed; "Create Room" now routes through the shared mode select screen before connecting
- **Online lobby**: host-only "CPU Settings" button opens the CPU setup screen

### Server / protocol

- New `ClientMessage::SetCpuConfigs` (host only, before game start): the host's confirmed CPU settings are stored in the room and broadcast immediately
- `RoomState` gains `cpu_configs` (`#[serde(default)]`, so messages from older servers still decode): every participant's lobby now shows which CPU will fill each empty seat, e.g. 「空席（CPU: 普通・バランス）」
- `StartGame` still sends the specs as before, so game-start behavior is unchanged even if `SetCpuConfigs` was never sent

## Testing

- `cargo build && cargo test` — all crates pass
- `cargo fmt` / `cargo clippy --all-targets` — no warnings
- WASM release build (`wasm32-unknown-unknown`) compiles
- New tests: server integration test for `SetCpuConfigs` broadcast + NotHost rejection, client adapter round-trip test, i18n label test, protocol serde-default regression test
- Manually verified on the native client: top menu → mode select → CPU setup (2 CPU cards in 3-player mode), online menu → Create Room → mode select routing, Back navigation, and the English language toggle

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)