### PR TITLE
Route cross-machine room joins via fly-replay (#235)

### DIFF
--- a/crates/mahjong-net-server/Cargo.toml
+++ b/crates/mahjong-net-server/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 
 [dependencies]
 mahjong-server = { path = "../mahjong-server" }
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "net"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "net", "io-util"] }
 axum = { version = "0.8", features = ["ws"] }
 futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }

--- a/crates/mahjong-net-server/src/connection.rs
+++ b/crates/mahjong-net-server/src/connection.rs
@@ -8,10 +8,10 @@ use std::collections::VecDeque;
 use std::net::{IpAddr, SocketAddr};
 use std::time::{Duration, Instant};
 
-use axum::extract::State;
 use axum::extract::connect_info::ConnectInfo;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
-use axum::http::{HeaderMap, StatusCode, header};
+use axum::extract::{Query, State};
+use axum::http::{HeaderMap, HeaderName, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
@@ -49,11 +49,27 @@ fn generate_token() -> String {
     format!("{:032x}", rand::rng().random::<u128>())
 }
 
+/// 転送済みリクエストに Fly Proxy が付けるヘッダ（再転送のループ防止に使う）
+const FLY_REPLAY_SRC: HeaderName = HeaderName::from_static("fly-replay-src");
+
+/// `/ws` のクエリパラメータ
+///
+/// `room` は参加・再接続したいルームのコード。複数マシン構成で、
+/// WebSocket アップグレード前にルームの所在（どのマシンか）を判断する
+/// ために使う。入室処理自体は従来どおりアップグレード後の
+/// `JoinRoom` メッセージで行うため、このパラメータは省略可能
+/// （省略時はルーム作成またはこのマシンのルームへの参加として扱う）。
+#[derive(serde::Deserialize)]
+pub struct WsQuery {
+    room: Option<String>,
+}
+
 /// `/ws` ハンドラ
 pub async fn ws_handler(
     ws: WebSocketUpgrade,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
+    Query(query): Query<WsQuery>,
     headers: HeaderMap,
 ) -> Response {
     // Origin 制限（ALLOWED_ORIGIN 設定時のみ）
@@ -63,11 +79,53 @@ pub async fn ws_handler(
         return StatusCode::FORBIDDEN.into_response();
     }
 
+    // 指定されたルームを他マシンが所持していれば、そのマシンへ転送させる
+    if let Some(code) = query.room.as_deref()
+        && let Some(replay) = maybe_replay(&state, code, &headers).await
+    {
+        return replay;
+    }
+
     // フレーム/メッセージサイズを制限して巨大ペイロードを防ぐ
     let ws = ws
         .max_message_size(MAX_MESSAGE_SIZE)
         .max_frame_size(MAX_MESSAGE_SIZE);
     ws.on_upgrade(move |socket| handle_socket(socket, addr.ip(), state))
+}
+
+/// ルームコードの所在を確認し、他マシンが所持していれば fly-replay 応答を返す
+///
+/// None を返した場合は通常どおりアップグレードする（ローカルに存在する、
+/// ルームが見つからない、または転送済みリクエスト）。見つからない場合に
+/// エラーにしないのは、所在確認と入室の間にルームが閉じられるレースが
+/// ありうるため。エラー通知は従来どおり `JoinRoom` の応答で行う。
+async fn maybe_replay(state: &AppState, code: &str, headers: &HeaderMap) -> Option<Response> {
+    let code = crate::lobby::normalize_code(code);
+    // 形式が不正なコードで無駄なピア照会をしない（このパスは認証も
+    // レート制限も通らないため、照会コストを抑える）
+    if !crate::lobby::is_valid_code(&code) {
+        return None;
+    }
+    if state.lobby.get(&code).is_some() {
+        return None;
+    }
+    // 転送されてきたリクエストは再転送しない（マシン間のループ防止）。
+    // 転送直後にルームが閉じた場合は通常の RoomNotFound フローに任せる
+    if headers.contains_key(FLY_REPLAY_SRC) {
+        return None;
+    }
+    let machine_id = state.peers.find_room(&code).await?;
+    tracing::info!(code, machine_id, "replaying connection to room owner");
+    Some(
+        (
+            StatusCode::NO_CONTENT,
+            [(
+                HeaderName::from_static("fly-replay"),
+                format!("instance={machine_id}"),
+            )],
+        )
+            .into_response(),
+    )
 }
 
 /// 接続元 Origin が許可されるか判定する
@@ -216,7 +274,11 @@ impl Connection {
                     // ルール設定はホストの指定を丸ごと採用する。
                     // 持ち点はサーバが決める（四麻25000点・三麻35000点）。
                     let settings = GameSettings::with_rules(length, rules);
-                    let (_code, room_tx) = self.state.lobby.create_room(settings);
+                    let (_code, room_tx) = self
+                        .state
+                        .lobby
+                        .create_room(settings, &self.state.peers)
+                        .await;
                     Some(room_tx)
                 }
                 ClientMessage::JoinRoom { code } => {

--- a/crates/mahjong-net-server/src/lib.rs
+++ b/crates/mahjong-net-server/src/lib.rs
@@ -8,16 +8,26 @@
 //! - [`lobby`] — ルームコードとルームアクターのレジストリ
 //! - [`room`] — ルームアクター（1ルーム = 1 tokio タスク）
 //! - [`connection`] — WebSocket 接続のハンドシェイクとメッセージ中継
+//! - [`peers`] — 複数マシン構成でのピア発見・ルーム所在の照会
+//!
+//! ルームは生成されたマシンのメモリ上にのみ存在する。複数マシン構成では
+//! `/ws?room=CODE` のコードを持たないマシンに接続が着地したとき、
+//! [`peers`] で所持マシンを特定し `fly-replay` ヘッダで転送させる。
 
 pub mod connection;
 pub mod lobby;
+pub mod peers;
 pub mod ratelimit;
 pub mod room;
 
 use axum::Router;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 
 use lobby::Lobby;
+use peers::Peers;
 use ratelimit::RateLimiter;
 use room::RoomConfig;
 
@@ -30,24 +40,59 @@ pub struct AppState {
     pub rate_limiter: RateLimiter,
     /// 接続を許可する Origin（None なら全許可）
     pub allowed_origin: Option<String>,
+    /// ピア（他マシン）の発見・照会
+    pub peers: Peers,
 }
 
-/// ルーターを構築する
+/// 環境変数から共有状態を構築する
 ///
-/// `/ws` が WebSocket エンドポイント、`/healthz` がヘルスチェック。
-/// `ALLOWED_ORIGIN` 環境変数が設定されていれば、その Origin からの
+/// `ALLOWED_ORIGIN` が設定されていれば、その Origin からの
 /// WebSocket 接続のみを許可する（未設定なら全許可）。
-pub fn app(config: RoomConfig) -> Router {
+/// ピア構成は [`Peers::from_env`] を参照。
+pub fn build_state(config: RoomConfig) -> AppState {
     let allowed_origin = std::env::var("ALLOWED_ORIGIN")
         .ok()
         .filter(|s| !s.is_empty());
-    let state = AppState {
+    AppState {
         lobby: Lobby::new(config),
         rate_limiter: RateLimiter::new(),
         allowed_origin,
-    };
+        peers: Peers::from_env(),
+    }
+}
+
+/// 公開ルーターを構築する
+///
+/// `/ws` が WebSocket エンドポイント、`/healthz` がヘルスチェック。
+pub fn app_with_state(state: AppState) -> Router {
     Router::new()
         .route("/healthz", get(|| async { "ok" }))
         .route("/ws", get(connection::ws_handler))
         .with_state(state)
+}
+
+/// 環境変数から状態を構築して公開ルーターを作る
+pub fn app(config: RoomConfig) -> Router {
+    app_with_state(build_state(config))
+}
+
+/// 内部（マシン間照会）API のルーター
+///
+/// `GET /internal/rooms/{code}` — ルームを所持していれば 200 と自マシン ID を返す。
+/// プライベートネットワーク専用のリスナーにのみ bind し、公開してはならない
+/// （Fly Proxy は全パスを internal_port へ転送するため、公開ルーターに
+/// 内部ルートを生やすと外部から到達できてしまう）。
+pub fn internal_app(state: AppState) -> Router {
+    Router::new()
+        .route("/internal/rooms/{code}", get(internal_room_lookup))
+        .with_state(state)
+}
+
+/// ルーム所在の照会に応答する
+async fn internal_room_lookup(Path(code): Path<String>, State(state): State<AppState>) -> Response {
+    // マシン ID が無いと fly-replay の宛先にできないため、所持していても 404
+    match (state.peers.machine_id(), state.lobby.get(&code)) {
+        (Some(id), Some(_)) => (StatusCode::OK, id.to_string()).into_response(),
+        _ => StatusCode::NOT_FOUND.into_response(),
+    }
 }

--- a/crates/mahjong-net-server/src/lobby.rs
+++ b/crates/mahjong-net-server/src/lobby.rs
@@ -10,6 +10,7 @@ use mahjong_server::table::GameSettings;
 use rand::RngExt;
 use tokio::sync::mpsc;
 
+use crate::peers::Peers;
 use crate::room::{RoomConfig, RoomMsg, run_room};
 
 /// ルームコードの文字種（紛らわしい 0/O/1/I を除いた32文字）
@@ -24,6 +25,16 @@ fn generate_code() -> String {
     (0..CODE_LEN)
         .map(|_| CODE_ALPHABET[rng.random_range(0..CODE_ALPHABET.len())] as char)
         .collect()
+}
+
+/// ルームコードを正規化する（前後の空白を除き大文字にする）
+pub fn normalize_code(code: &str) -> String {
+    code.trim().to_ascii_uppercase()
+}
+
+/// 正規化済みのルームコードとして正しい形式か判定する
+pub fn is_valid_code(code: &str) -> bool {
+    code.len() == CODE_LEN && code.bytes().all(|b| CODE_ALPHABET.contains(&b))
 }
 
 /// ロビー: ルームコード → ルームアクターのレジストリ
@@ -45,20 +56,36 @@ impl Lobby {
     /// ルームを作成し、アクタータスクを起動する
     ///
     /// 生成したルームコードと、ルームへの送信チャネルを返す。
-    pub fn create_room(&self, settings: GameSettings) -> (String, mpsc::Sender<RoomMsg>) {
+    /// コードはローカルのレジストリに加えて、ピア（他マシン）のルームとも
+    /// 衝突しないことを確認して確定する（衝突すると参加者が誤ったルームへ
+    /// 転送されうるため）。
+    pub async fn create_room(
+        &self,
+        settings: GameSettings,
+        peers: &Peers,
+    ) -> (String, mpsc::Sender<RoomMsg>) {
         let (tx, rx) = mpsc::channel(64);
 
-        let code = {
+        let code = loop {
+            // ローカルで未使用の候補を選び、ピアにも照会する
+            let candidate = peers
+                .pick_unused_code(|| {
+                    let rooms = self.rooms.lock().unwrap();
+                    loop {
+                        let candidate = generate_code();
+                        if !rooms.contains_key(&candidate) {
+                            break candidate;
+                        }
+                    }
+                })
+                .await;
+            // ピア照会（await）中にローカルで同じコードが使われた可能性が
+            // あるため、挿入と同じロック内で再確認する
             let mut rooms = self.rooms.lock().unwrap();
-            // 衝突したら引き直す
-            let code = loop {
-                let candidate = generate_code();
-                if !rooms.contains_key(&candidate) {
-                    break candidate;
-                }
-            };
-            rooms.insert(code.clone(), tx.clone());
-            code
+            if !rooms.contains_key(&candidate) {
+                rooms.insert(candidate.clone(), tx.clone());
+                break candidate;
+            }
         };
 
         tracing::info!(code, "room created");
@@ -75,7 +102,7 @@ impl Lobby {
 
     /// ルームコードからルームを引く（大文字小文字は区別しない）
     pub fn get(&self, code: &str) -> Option<mpsc::Sender<RoomMsg>> {
-        let normalized = code.trim().to_ascii_uppercase();
+        let normalized = normalize_code(code);
         self.rooms.lock().unwrap().get(&normalized).cloned()
     }
 
@@ -109,10 +136,23 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_normalize_and_validate_code() {
+        assert_eq!(normalize_code(" abc234 "), "ABC234");
+        assert!(is_valid_code("ABC234"));
+        // 長さ違い・不正文字（0/O/1/I や小文字）は拒否
+        assert!(!is_valid_code("ABC23"));
+        assert!(!is_valid_code("ABC2345"));
+        assert!(!is_valid_code("ABC0O1"));
+        assert!(!is_valid_code("abc234"));
+    }
+
     #[tokio::test]
     async fn test_create_and_lookup_room() {
         let lobby = Lobby::new(RoomConfig::default());
-        let (code, _tx) = lobby.create_room(GameSettings::default());
+        let (code, _tx) = lobby
+            .create_room(GameSettings::default(), &Peers::none())
+            .await;
 
         assert_eq!(lobby.room_count(), 1);
         assert!(lobby.get(&code).is_some());

--- a/crates/mahjong-net-server/src/main.rs
+++ b/crates/mahjong-net-server/src/main.rs
@@ -2,11 +2,15 @@
 //!
 //! `PORT` 環境変数でリッスンポートを指定する（デフォルト 8080）。
 //! ログは `RUST_LOG` で制御する（例: `RUST_LOG=mahjong_net_server=debug`）。
+//!
+//! 複数マシン構成ではマシン間のルーム所在照会のため、公開リスナーとは別に
+//! 内部リスナー（デフォルト 8081、`INTERNAL_PORT` で変更可）を起動する。
+//! Fly.io 上ではプライベートネットワーク（6PN）のアドレスにのみ bind する。
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use mahjong_net_server::app;
 use mahjong_net_server::room::RoomConfig;
+use mahjong_net_server::{app_with_state, build_state, internal_app, peers};
 
 #[tokio::main]
 async fn main() {
@@ -28,10 +32,34 @@ async fn main() {
         .unwrap_or_else(|e| panic!("failed to bind {addr}: {e}"));
     tracing::info!("listening on {addr}");
 
+    let state = build_state(RoomConfig::default());
+
+    // 内部（マシン間照会）リスナー。公開サービスには含めない。
+    // Fly 上では 6PN アドレス（FLY_PRIVATE_IP）にのみ bind し、
+    // ローカル開発ではループバックに bind する。
+    let internal_host: IpAddr = std::env::var("FLY_PRIVATE_IP")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST));
+    let internal_addr = SocketAddr::from((internal_host, peers::internal_port_from_env()));
+    match tokio::net::TcpListener::bind(internal_addr).await {
+        Ok(internal_listener) => {
+            tracing::info!("internal listener on {internal_addr}");
+            let internal_state = state.clone();
+            tokio::spawn(async move {
+                if let Err(e) = axum::serve(internal_listener, internal_app(internal_state)).await {
+                    tracing::error!("internal listener error: {e}");
+                }
+            });
+        }
+        // 内部リスナーが無くても単一マシンとしては動けるため、起動は続ける
+        Err(e) => tracing::warn!("failed to bind internal listener {internal_addr}: {e}"),
+    }
+
     // ConnectInfo<SocketAddr> を有効にして接続元IPを取得できるようにする
     axum::serve(
         listener,
-        app(RoomConfig::default()).into_make_service_with_connect_info::<SocketAddr>(),
+        app_with_state(state).into_make_service_with_connect_info::<SocketAddr>(),
     )
     .await
     .expect("server error");

--- a/crates/mahjong-net-server/src/peers.rs
+++ b/crates/mahjong-net-server/src/peers.rs
@@ -1,0 +1,244 @@
+//! ピア（同一アプリの他マシン）の発見と照会
+//!
+//! 複数マシン構成では、ルームは生成されたマシンのメモリ上にのみ存在する。
+//! 他マシンが持つルームコードで接続要求を受けたときは、各ピアの内部リスナー
+//! （`GET /internal/rooms/{code}`）へ照会して所持マシンの ID を特定し、
+//! `fly-replay` ヘッダで Fly Proxy にそのマシンへ転送させる。
+//!
+//! ピアの発見方法は環境変数で決まる:
+//! - `MAHJONG_PEERS` — カンマ区切りの `host:port` 固定リスト（ローカル・テスト用）
+//! - `FLY_APP_NAME` — Fly.io 内部 DNS（`<app>.internal` の AAAA レコード）
+//! - どちらも無ければピアなし（単一マシン運用）
+
+use std::net::IpAddr;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// 内部リスナーのデフォルトポート
+pub const DEFAULT_INTERNAL_PORT: u16 = 8081;
+
+/// ピア照会のタイムアウト（接続 + 応答の合計）
+const QUERY_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// ルーム作成時にピア衝突で引き直す最大回数
+///
+/// ピアが誤って常に「所持している」と答え続けても、ルーム作成が
+/// 無限ループしないための上限。上限に達したらローカルの一意性のみで確定する。
+const CREATE_COLLISION_RETRIES: usize = 4;
+
+/// ピアの発見方法
+#[derive(Clone)]
+enum PeerSource {
+    /// ピアなし（単一マシン・ローカル開発）
+    None,
+    /// 固定リスト（`MAHJONG_PEERS`）
+    Static(Vec<String>),
+    /// Fly.io 内部 DNS（`<app>.internal` の AAAA レコード）
+    FlyDns { app_name: String, port: u16 },
+}
+
+/// ピア一覧と自マシンの識別情報
+#[derive(Clone)]
+pub struct Peers {
+    /// 自マシンの ID（`FLY_MACHINE_ID`）。`fly-replay: instance=` に使う
+    machine_id: Option<String>,
+    /// 自マシンの 6PN アドレス（DNS 結果から自分を除外するのに使う）
+    private_ip: Option<IpAddr>,
+    source: PeerSource,
+}
+
+impl Peers {
+    /// ピアなしの構成（単一マシン運用・既存テスト用）
+    pub fn none() -> Self {
+        Peers {
+            machine_id: None,
+            private_ip: None,
+            source: PeerSource::None,
+        }
+    }
+
+    /// 環境変数から構成を読み取る
+    pub fn from_env() -> Self {
+        let machine_id = std::env::var("FLY_MACHINE_ID")
+            .ok()
+            .filter(|s| !s.is_empty());
+        let private_ip = std::env::var("FLY_PRIVATE_IP")
+            .ok()
+            .and_then(|s| s.parse().ok());
+        let source = if let Ok(peers) = std::env::var("MAHJONG_PEERS") {
+            PeerSource::Static(
+                peers
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(String::from)
+                    .collect(),
+            )
+        } else if let Ok(app_name) = std::env::var("FLY_APP_NAME") {
+            PeerSource::FlyDns {
+                app_name,
+                port: internal_port_from_env(),
+            }
+        } else {
+            PeerSource::None
+        };
+        Peers {
+            machine_id,
+            private_ip,
+            source,
+        }
+    }
+
+    /// 固定ピアリストで構成する（テスト用）
+    pub fn with_static(machine_id: Option<&str>, peers: Vec<String>) -> Self {
+        Peers {
+            machine_id: machine_id.map(String::from),
+            private_ip: None,
+            source: PeerSource::Static(peers),
+        }
+    }
+
+    /// 自マシンの ID
+    pub fn machine_id(&self) -> Option<&str> {
+        self.machine_id.as_deref()
+    }
+
+    /// ルームコードを所持しているピアを探し、そのマシン ID を返す
+    ///
+    /// 全ピアへ同時に照会し、最初に見つかったものを返す。
+    /// 照会失敗（接続不可・タイムアウト）は「所持していない」として扱う。
+    pub async fn find_room(&self, code: &str) -> Option<String> {
+        let addrs = self.peer_addrs().await;
+        if addrs.is_empty() {
+            return None;
+        }
+        let queries = addrs.iter().map(|addr| query_peer(addr, code));
+        futures_util::future::join_all(queries)
+            .await
+            .into_iter()
+            .flatten()
+            .next()
+    }
+
+    /// ルーム作成の候補コードが他マシンと衝突しないか確認しつつ生成する
+    ///
+    /// `generate` が返す候補（ローカルでは未使用のもの）をピアに照会し、
+    /// 衝突しないコードを返す。照会の上限回数を超えたら最後の候補で確定する。
+    pub async fn pick_unused_code(&self, mut generate: impl FnMut() -> String) -> String {
+        for _ in 0..CREATE_COLLISION_RETRIES {
+            let candidate = generate();
+            if self.find_room(&candidate).await.is_none() {
+                return candidate;
+            }
+            tracing::warn!(code = candidate, "room code collides with a peer; retrying");
+        }
+        // ピアの応答が信用できない場合でもルーム作成は継続する
+        tracing::warn!("giving up peer collision check; using locally unique code");
+        generate()
+    }
+
+    /// ピア一覧（`host:port`）を得る
+    async fn peer_addrs(&self) -> Vec<String> {
+        match &self.source {
+            PeerSource::None => Vec::new(),
+            PeerSource::Static(list) => list.clone(),
+            PeerSource::FlyDns { app_name, port } => {
+                let host = format!("{app_name}.internal:{port}");
+                match tokio::net::lookup_host(&host).await {
+                    Ok(addrs) => addrs
+                        .filter(|addr| Some(addr.ip()) != self.private_ip)
+                        .map(|addr| addr.to_string())
+                        .collect(),
+                    Err(e) => {
+                        tracing::warn!("failed to resolve {host}: {e}");
+                        Vec::new()
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// 内部リスナーのポートを環境変数 `INTERNAL_PORT` から読む
+pub fn internal_port_from_env() -> u16 {
+    std::env::var("INTERNAL_PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(DEFAULT_INTERNAL_PORT)
+}
+
+/// 1つのピアへルーム所持を照会する
+///
+/// 応答が単純（Content-Length 付き・非チャンク）になるよう HTTP/1.0 で
+/// リクエストし、200 ならボディ（所持マシンの ID）を返す。
+async fn query_peer(addr: &str, code: &str) -> Option<String> {
+    let result = tokio::time::timeout(QUERY_TIMEOUT, async {
+        let mut stream = TcpStream::connect(addr).await.ok()?;
+        let request = format!("GET /internal/rooms/{code} HTTP/1.0\r\nHost: {addr}\r\n\r\n");
+        stream.write_all(request.as_bytes()).await.ok()?;
+        let mut raw = Vec::new();
+        stream.read_to_end(&mut raw).await.ok()?;
+        parse_response(&raw)
+    })
+    .await;
+    result.ok().flatten()
+}
+
+/// HTTP 応答からマシン ID を取り出す（200 以外・不正な形式は None）
+fn parse_response(raw: &[u8]) -> Option<String> {
+    let text = std::str::from_utf8(raw).ok()?;
+    let (head, body) = text.split_once("\r\n\r\n")?;
+    let status_line = head.lines().next()?;
+    if !status_line.starts_with("HTTP/1.") || status_line.split_whitespace().nth(1)? != "200" {
+        return None;
+    }
+    let id = body.trim();
+    // fly-replay ヘッダにそのまま埋め込むため、マシン ID の形式を検証する
+    (!id.is_empty() && id.bytes().all(|b| b.is_ascii_alphanumeric())).then(|| id.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_response_ok() {
+        let raw = b"HTTP/1.0 200 OK\r\ncontent-length: 14\r\n\r\ne784079b449483";
+        assert_eq!(parse_response(raw), Some("e784079b449483".to_string()));
+    }
+
+    #[test]
+    fn test_parse_response_not_found() {
+        let raw = b"HTTP/1.0 404 Not Found\r\ncontent-length: 0\r\n\r\n";
+        assert_eq!(parse_response(raw), None);
+    }
+
+    #[test]
+    fn test_parse_response_rejects_invalid_machine_id() {
+        // ヘッダインジェクションになりうる文字は拒否する
+        let raw = b"HTTP/1.0 200 OK\r\n\r\nbad;id=x";
+        assert_eq!(parse_response(raw), None);
+        let empty = b"HTTP/1.0 200 OK\r\n\r\n";
+        assert_eq!(parse_response(empty), None);
+    }
+
+    #[test]
+    fn test_parse_response_rejects_garbage() {
+        assert_eq!(parse_response(b"not http"), None);
+        assert_eq!(parse_response(&[0xff, 0xfe]), None);
+    }
+
+    #[tokio::test]
+    async fn test_find_room_without_peers() {
+        assert_eq!(Peers::none().find_room("ABCDEF").await, None);
+    }
+
+    #[tokio::test]
+    async fn test_find_room_unreachable_peer_is_ignored() {
+        // 接続できないピアは「所持していない」として扱う
+        let peers = Peers::with_static(Some("self1"), vec!["127.0.0.1:1".to_string()]);
+        assert_eq!(peers.find_room("ABCDEF").await, None);
+    }
+}

--- a/crates/mahjong-net-server/tests/multi_machine.rs
+++ b/crates/mahjong-net-server/tests/multi_machine.rs
@@ -1,0 +1,302 @@
+//! 複数マシン構成の統合テスト
+//!
+//! 2台の「マシン」（プロセス内サーバ）を相互にピア登録して起動し、
+//! ルーム所在の照会と fly-replay 転送の判断を検証する。
+//! 実際の転送は Fly Proxy が行うため、ここでは「正しい fly-replay
+//! ヘッダを返すこと」と「転送後のリクエストが正常に処理されること」を
+//! それぞれ確認する。
+
+use std::net::SocketAddr;
+
+use futures_util::{SinkExt, StreamExt};
+use mahjong_core::settings::Settings;
+use mahjong_net_server::lobby::Lobby;
+use mahjong_net_server::peers::Peers;
+use mahjong_net_server::ratelimit::RateLimiter;
+use mahjong_net_server::room::RoomConfig;
+use mahjong_net_server::{AppState, app_with_state, internal_app};
+use mahjong_server::protocol::net::{ClientMessage, ErrorCode, PROTOCOL_VERSION, ServerMessage};
+use mahjong_server::table::GameLength;
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async, tungstenite};
+
+/// テスト用マシン（プロセス内サーバ）
+struct Machine {
+    /// 公開リスナー（/ws）のアドレス
+    public: SocketAddr,
+    /// 内部リスナー（/internal/rooms/{code}）のアドレス
+    internal: SocketAddr,
+}
+
+/// 状態からマシンを起動する（内部リスナーは bind 済みのものを使う）
+async fn serve_machine(state: AppState, internal: tokio::net::TcpListener) -> Machine {
+    let internal_addr = internal.local_addr().unwrap();
+    let internal_state = state.clone();
+    tokio::spawn(async move {
+        axum::serve(internal, internal_app(internal_state))
+            .await
+            .unwrap();
+    });
+
+    let public = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let public_addr = public.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(
+            public,
+            app_with_state(state).into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
+
+    Machine {
+        public: public_addr,
+        internal: internal_addr,
+    }
+}
+
+/// 2台のマシンを相互にピア登録して起動する
+async fn start_two_machines() -> (Machine, Machine) {
+    // 先に内部リスナーを bind してアドレスを確定させ、相互参照させる
+    let internal_a = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let internal_b = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr_a = internal_a.local_addr().unwrap().to_string();
+    let addr_b = internal_b.local_addr().unwrap().to_string();
+
+    let state = |machine_id: &str, peer: String| AppState {
+        lobby: Lobby::new(RoomConfig::default()),
+        rate_limiter: RateLimiter::new(),
+        allowed_origin: None,
+        peers: Peers::with_static(Some(machine_id), vec![peer]),
+    };
+
+    let machine_a = serve_machine(state("machinea", addr_b), internal_a).await;
+    let machine_b = serve_machine(state("machineb", addr_a), internal_b).await;
+    (machine_a, machine_b)
+}
+
+/// テスト用 WebSocket クライアント（ロビー操作のみ）
+struct TestClient {
+    ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
+}
+
+impl TestClient {
+    async fn connect(url: &str) -> Self {
+        Self::connect_with(url.into_client_request().unwrap()).await
+    }
+
+    async fn connect_with(request: tungstenite::handshake::client::Request) -> Self {
+        let (ws, _) = connect_async(request).await.expect("接続に失敗した");
+        TestClient { ws }
+    }
+
+    async fn send(&mut self, msg: &ClientMessage) {
+        let json = msg.to_json().unwrap();
+        self.ws.send(Message::text(json)).await.unwrap();
+    }
+
+    async fn recv(&mut self) -> ServerMessage {
+        loop {
+            let frame = tokio::time::timeout(std::time::Duration::from_secs(30), self.ws.next())
+                .await
+                .expect("受信がタイムアウトした")
+                .expect("接続が閉じられた")
+                .expect("WebSocketエラー");
+            match frame {
+                Message::Text(text) => {
+                    return ServerMessage::from_json(text.as_str()).expect("不正なJSON");
+                }
+                Message::Ping(_) | Message::Pong(_) => continue,
+                other => panic!("予期しないフレーム: {other:?}"),
+            }
+        }
+    }
+
+    async fn hello(&mut self, name: &str) {
+        self.send(&ClientMessage::Hello {
+            protocol_version: PROTOCOL_VERSION,
+            session_token: None,
+            display_name: name.to_string(),
+        })
+        .await;
+        match self.recv().await {
+            ServerMessage::Welcome { .. } => {}
+            other => panic!("Welcomeでないメッセージ: {other:?}"),
+        }
+    }
+
+    async fn create_room(&mut self) -> String {
+        self.send(&ClientMessage::CreateRoom {
+            length: GameLength::EastOnly,
+            rules: Settings::new(),
+        })
+        .await;
+        match self.recv().await {
+            ServerMessage::RoomState { code, .. } => code,
+            other => panic!("RoomStateでないメッセージ: {other:?}"),
+        }
+    }
+
+    async fn join_room(&mut self, code: &str) -> ServerMessage {
+        self.send(&ClientMessage::JoinRoom {
+            code: code.to_string(),
+        })
+        .await;
+        self.recv().await
+    }
+}
+
+/// 他マシンのルームコード付きで接続すると fly-replay 応答が返る
+#[tokio::test]
+async fn test_join_foreign_room_returns_fly_replay() {
+    let (machine_a, machine_b) = start_two_machines().await;
+
+    let mut host = TestClient::connect(&format!("ws://{}/ws", machine_a.public)).await;
+    host.hello("ホスト").await;
+    let code = host.create_room().await;
+
+    // マシンBへ ?room=CODE 付きで接続すると、アップグレードせずに
+    // マシンAへの fly-replay 応答が返る
+    let request = format!("ws://{}/ws?room={}", machine_b.public, code)
+        .into_client_request()
+        .unwrap();
+    match connect_async(request).await {
+        Err(tungstenite::Error::Http(response)) => {
+            let replay = response
+                .headers()
+                .get("fly-replay")
+                .expect("fly-replay ヘッダが無い")
+                .to_str()
+                .unwrap();
+            assert_eq!(replay, "instance=machinea");
+        }
+        Ok(_) => panic!("アップグレードされてしまった（fly-replay が返るべき）"),
+        Err(other) => panic!("予期しないエラー: {other:?}"),
+    }
+}
+
+/// 自マシンのルームコード付きの接続は通常どおりアップグレードして入室できる
+#[tokio::test]
+async fn test_join_local_room_with_query_param() {
+    let (machine_a, _machine_b) = start_two_machines().await;
+
+    let mut host = TestClient::connect(&format!("ws://{}/ws", machine_a.public)).await;
+    host.hello("ホスト").await;
+    let code = host.create_room().await;
+
+    let mut guest =
+        TestClient::connect(&format!("ws://{}/ws?room={}", machine_a.public, code)).await;
+    guest.hello("ゲスト").await;
+    match guest.join_room(&code).await {
+        ServerMessage::RoomState { your_seat, .. } => assert_eq!(your_seat, 1),
+        other => panic!("RoomStateでないメッセージ: {other:?}"),
+    }
+}
+
+/// 転送されてきたリクエスト（fly-replay-src 付き）は再転送されない
+///
+/// Fly Proxy による転送後の受信側の挙動を、ヘッダを付けた直接接続で模擬する。
+/// ルームを所持するマシンでは入室でき、所持しないマシンでは（転送し直さず）
+/// RoomNotFound になることを確認する。
+#[tokio::test]
+async fn test_replayed_request_is_not_replayed_again() {
+    let (machine_a, machine_b) = start_two_machines().await;
+
+    let mut host = TestClient::connect(&format!("ws://{}/ws", machine_a.public)).await;
+    host.hello("ホスト").await;
+    let code = host.create_room().await;
+
+    let with_replay_src = |addr: SocketAddr| {
+        let mut request = format!("ws://{addr}/ws?room={code}")
+            .into_client_request()
+            .unwrap();
+        request.headers_mut().insert(
+            "fly-replay-src",
+            "instance=machineb;t=1751772000000000".parse().unwrap(),
+        );
+        request
+    };
+
+    // 所持マシンA: 転送後のリクエストとして正常に入室できる
+    let mut guest = TestClient::connect_with(with_replay_src(machine_a.public)).await;
+    guest.hello("ゲスト").await;
+    match guest.join_room(&code).await {
+        ServerMessage::RoomState { your_seat, .. } => assert_eq!(your_seat, 1),
+        other => panic!("RoomStateでないメッセージ: {other:?}"),
+    }
+
+    // 非所持マシンB: 再転送せずアップグレードし、JoinRoom は RoomNotFound
+    let mut lost = TestClient::connect_with(with_replay_src(machine_b.public)).await;
+    lost.hello("迷子").await;
+    match lost.join_room(&code).await {
+        ServerMessage::Error { code, .. } => assert_eq!(code, ErrorCode::RoomNotFound),
+        other => panic!("Errorでないメッセージ: {other:?}"),
+    }
+}
+
+/// 存在しないコードや不正な形式のコードでは転送されず通常どおり接続できる
+#[tokio::test]
+async fn test_unknown_or_invalid_code_upgrades_normally() {
+    let (machine_a, _machine_b) = start_two_machines().await;
+
+    for room in ["ZZZZZZ", "abc", "%2F%2F", ""] {
+        let mut client =
+            TestClient::connect(&format!("ws://{}/ws?room={}", machine_a.public, room)).await;
+        client.hello("探検者").await;
+    }
+}
+
+/// ピア照会（find_room）がルームの所在を正しく返す
+#[tokio::test]
+async fn test_peer_lookup_finds_room_owner() {
+    let (machine_a, _machine_b) = start_two_machines().await;
+
+    let mut host = TestClient::connect(&format!("ws://{}/ws", machine_a.public)).await;
+    host.hello("ホスト").await;
+    let code = host.create_room().await;
+
+    // 第三者視点のピア構成からマシンAの内部リスナーへ照会する
+    let observer = Peers::with_static(Some("observer1"), vec![machine_a.internal.to_string()]);
+    assert_eq!(
+        observer.find_room(&code).await,
+        Some("machinea".to_string())
+    );
+    assert_eq!(observer.find_room("ZZZZZZ").await, None);
+    // 小文字でも正規化されて見つかる（Lobby::get が正規化する）
+    assert_eq!(
+        observer.find_room(&code.to_ascii_lowercase()).await,
+        Some("machinea".to_string())
+    );
+}
+
+/// ピアが常に「所持している」と答えてもルーム作成が完了する（無限ループしない）
+#[tokio::test]
+async fn test_create_room_completes_with_lying_peer() {
+    // どのコードにも 200 を返す偽ピア
+    let liar = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let liar_addr = liar.local_addr().unwrap().to_string();
+    tokio::spawn(async move {
+        let router = axum::Router::new().route(
+            "/internal/rooms/{code}",
+            axum::routing::get(|| async { "machinex" }),
+        );
+        axum::serve(liar, router).await.unwrap();
+    });
+
+    let state = AppState {
+        lobby: Lobby::new(RoomConfig::default()),
+        rate_limiter: RateLimiter::new(),
+        allowed_origin: None,
+        peers: Peers::with_static(Some("machinea"), vec![liar_addr]),
+    };
+    let internal = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let machine = serve_machine(state, internal).await;
+
+    let mut host = TestClient::connect(&format!("ws://{}/ws", machine.public)).await;
+    host.hello("ホスト").await;
+    // 衝突チェックの上限に達した後、ローカルの一意性のみで確定して完了する
+    let code = host.create_room().await;
+    assert_eq!(code.len(), 6);
+}


### PR DESCRIPTION
## Summary

Part 1/3 of #235 (multi-machine backend scaling). Rooms stay pinned to the machine that created them; this PR adds the routing so a join or reconnect that lands on the wrong machine gets forwarded to the owner by Fly Proxy.

- `/ws` accepts an optional `?room=CODE` query parameter. If the room is not hosted locally, the server queries its peers and answers with a `fly-replay: instance=<machine id>` header (before the WebSocket upgrade) so Fly Proxy replays the request on the owning machine. Requests already carrying `fly-replay-src` are never replayed again (loop prevention).
- New `peers` module: peer discovery via `<app>.internal` DNS (or a static `MAHJONG_PEERS` list for local testing) and room lookups against a private internal listener (`GET /internal/rooms/{code}`, default port 8081).
- The internal listener binds only to the 6PN private address (`FLY_PRIVATE_IP`), so it is unreachable through the public proxy.
- Room creation checks peers for code collisions, with a bounded retry so a misbehaving peer cannot stall creation.

Protocol messages are unchanged (no version bump); the query parameter is additive and older clients keep working on a single machine.

## Test plan

- `cargo test -p mahjong-net-server` — all existing tests plus new unit tests and `tests/multi_machine.rs` (two in-process servers peered via static lists: fly-replay header, local-room upgrade, loop prevention, invalid codes, peer lookup, lying-peer creation).
- Manual smoke test with two real server processes (`FLY_MACHINE_ID`/`MAHJONG_PEERS`/`INTERNAL_PORT`): verified 204 + `fly-replay: instance=machine1` from the non-owning machine, 101 upgrade on the owner, 200/404 from the internal API, and no re-replay with `fly-replay-src` set.
- Real Fly Proxy replay behavior still needs a staging check after deploy (see part 3/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)