### PR TITLE
Show player names instead of seat winds on the win result screen

### DIFF
--- a/crates/mahjong-client/src/game/events.rs
+++ b/crates/mahjong-client/src/game/events.rs
@@ -404,26 +404,15 @@ impl GameState {
 
                 let lang = self.lang;
                 let tr = Translator::new(lang);
-                let winner_is_me = self.relative_player_index(winner) == 0;
-                let winner_name = if winner_is_me {
-                    Key::You.text(lang).to_string()
-                } else {
-                    self.wind_to_name(winner)
-                };
-                let loser_name = loser.map(|l| {
-                    if self.relative_player_index(l) == 0 {
-                        Key::You.text(lang).to_string()
-                    } else {
-                        self.wind_to_name(l)
-                    }
-                });
+                let winner_name = self.player_display_name(winner);
+                let loser_name = loser.map(|l| self.player_display_name(l));
                 let win_type = if loser.is_some() {
                     tr.get(Key::Ron)
                 } else {
                     tr.get(Key::Tsumo)
                 };
                 let loser_text = if let Some(l) = loser {
-                    tr.dealt_in_by(&self.wind_to_name(l))
+                    tr.dealt_in_by(&self.player_display_name(l))
                 } else {
                     String::new()
                 };

--- a/crates/mahjong-client/src/game/labels.rs
+++ b/crates/mahjong-client/src/game/labels.rs
@@ -57,6 +57,21 @@ impl PlayerLabel {
             }
         }
     }
+
+    /// 得点チップや和了結果などで使う短い表示名（例:「CPU2」）。
+    pub fn short_name(&self, rel: usize, lang: Lang) -> String {
+        match self {
+            PlayerLabel::Me => Key::You.text(lang).to_string(),
+            PlayerLabel::Human(name) => {
+                let mut s: String = name.chars().take(5).collect();
+                if name.chars().count() > 5 {
+                    s.push('…');
+                }
+                s
+            }
+            PlayerLabel::Cpu { .. } => format!("CPU{}", rel),
+        }
+    }
 }
 
 /// CPU の表示名（例: 日「CPU1（普通・バランス）」/ 英「CPU1 (Normal, Balanced)」）。

--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -413,4 +413,11 @@ impl GameState {
             Lang::En => wind.name(Lang::En).to_string(),
         }
     }
+
+    /// 和了結果などに使うプレイヤー名（例:「CPU2」）。席名ではなくプレイヤー名を表示する。
+    fn player_display_name(&self, wind: Wind) -> String {
+        let rel = self.relative_player_index(wind);
+        let seat = (self.my_seat + rel) % self.player_count;
+        self.player_labels[seat].short_name(rel, self.lang)
+    }
 }

--- a/crates/mahjong-client/src/renderer/board.rs
+++ b/crates/mahjong-client/src/renderer/board.rs
@@ -217,18 +217,7 @@ pub(super) fn short_player_name(
     rel: usize,
     lang: Lang,
 ) -> String {
-    use crate::game::PlayerLabel;
-    match label {
-        PlayerLabel::Me => Key::You.text(lang).to_string(),
-        PlayerLabel::Human(name) => {
-            let mut s: String = name.chars().take(5).collect();
-            if name.chars().count() > 5 {
-                s.push('…');
-            }
-            s
-        }
-        PlayerLabel::Cpu { .. } => format!("CPU{}", rel),
-    }
+    label.short_name(rel, lang)
 }
 
 /// 桁区切り付きの得点表記。


### PR DESCRIPTION
## Summary
- Show the player's display name (e.g. "CPU2") instead of the seat wind (e.g. "南家") on the win result screen for both Ron and Tsumo, in both CPU and online matches.
- Reuses the same short-name logic already used for the score chips (`PlayerLabel::short_name`), instead of the seat-wind-based `wind_to_name`.

Closes #280

## Test plan
- [x] `cargo build`
- [x] `cargo clippy` (no warnings)
- [x] `cargo fmt --check`
- [x] `cargo test` (415 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)