### PR TITLE
Show call and riichi declarations as speech-bubble banners

### DIFF
--- a/crates/mahjong-client/src/game/events.rs
+++ b/crates/mahjong-client/src/game/events.rs
@@ -67,6 +67,7 @@ impl GameState {
                     OtherPlayerHand::new(),
                 ];
                 self.last_discarder = None;
+                self.call_banners = [None; 4];
             }
 
             ServerEvent::TileDrawn {

--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! サーバから受信したイベントに基づいてクライアント側の状態を管理する。
 
+use std::collections::VecDeque;
+
 use macroquad::prelude::*;
 use mahjong_core::hand::Hand;
 use mahjong_core::hand_info::hand_analyzer::HandAnalyzer;
@@ -27,6 +29,32 @@ pub use labels::PlayerLabel;
 pub use setup::{GameMode, OnlineUiState, RoomViewUi, SetupState};
 
 use labels::*;
+
+/// 鳴き・リーチ宣言バナー表示後、後続イベントの適用を保留する時間（秒）
+pub const CALL_HOLD_SECS: f64 = 0.9;
+/// ロン・ツモ・九種九牌の宣言バナー表示から結果画面表示までの保留時間（秒）
+pub const WIN_HOLD_SECS: f64 = 1.2;
+/// 宣言バナーの表示時間（秒）
+pub const CALL_BANNER_SECS: f64 = 1.5;
+
+/// 鳴き・リーチなどの宣言バナー（発声の代わりに画面へ表示する吹き出し）
+#[derive(Debug, Clone, Copy)]
+pub struct CallBanner {
+    /// 表示する文言（ポン・チー・カン・リーチ・ロン・ツモなど）
+    pub label: Key,
+    /// 表示開始時刻（[`GameState::process_events`] に渡された now と同じ時計）
+    pub shown_at: f64,
+}
+
+/// 宣言イベントの表示内容（`declaration_for` が返す）
+struct Declaration {
+    /// バナーを出すプレイヤーと文言（ダブロン時は複数）
+    banners: Vec<(Wind, Key)>,
+    /// 後続イベントの適用を保留する時間（秒）
+    hold_secs: f64,
+    /// true ならイベント自体の適用も保留する（ロン・ツモ・九種九牌）
+    before_apply: bool,
+}
 
 /// 1人分の和了結果（結果画面の1ページ分）
 #[derive(Debug, Clone)]
@@ -206,6 +234,14 @@ pub struct GameState {
     pub pei_counts: [u8; 4],
     /// 北抜き可能か（自分の手番で手牌・ツモ牌に北がある場合）
     pub can_pei: bool,
+    /// 各プレイヤーの宣言バナー（相対位置順: 自分=0, 下家=1, 対面=2, 上家=3）
+    pub call_banners: [Option<CallBanner>; 4],
+    /// 未適用のサーバイベント（宣言演出中は適用を保留する）
+    pending_events: VecDeque<ServerEvent>,
+    /// この時刻まで後続イベントの適用を保留する
+    event_hold_until: f64,
+    /// キュー先頭イベントの宣言バナーを表示済みか（適用前保留の管理用）
+    head_announced: bool,
     /// 表示言語
     pub lang: Lang,
 }
@@ -318,6 +354,10 @@ impl GameState {
             nuki_dora: false,
             pei_counts: [0; 4],
             can_pei: false,
+            call_banners: [None; 4],
+            pending_events: VecDeque::new(),
+            event_hold_until: 0.0,
+            head_announced: false,
             // 保存された表示言語を読み込む（未保存なら日本語）。
             // 「もう一度」などで new() が再生成されても選択を保つ。
             lang: crate::persistence::load_lang().unwrap_or(Lang::Ja),
@@ -403,6 +443,127 @@ impl GameState {
             2 => MeldFrom::Opposite,  // 対面
             1 => MeldFrom::Following, // 下家
             _ => MeldFrom::Myself,    // 自家（通常ここには来ない）
+        }
+    }
+
+    /// サーバイベントを受信キューへ積む。適用は [`process_events`](Self::process_events) が行う。
+    pub fn queue_event(&mut self, event: ServerEvent) {
+        self.pending_events.push_back(event);
+    }
+
+    /// キュー内のイベントを順に適用する。毎フレーム呼ぶこと。
+    ///
+    /// 宣言（鳴き・リーチ・北抜き・和了・九種九牌）を伴うイベントでは
+    /// 宣言バナーを表示し、[`CALL_HOLD_SECS`]（和了系は [`WIN_HOLD_SECS`]）の間
+    /// 後続イベントの適用を保留する。これにより「発声 → 実際の挙動」の順に
+    /// 見え、プレイヤーが宣言に気付きやすくなる。和了・九種九牌はイベント
+    /// 自体の適用（結果画面への遷移）も保留する。
+    pub fn process_events(&mut self, now: f64) {
+        // 表示時間を過ぎたバナーを片付ける
+        for slot in &mut self.call_banners {
+            if slot.is_some_and(|b| now - b.shown_at >= CALL_BANNER_SECS) {
+                *slot = None;
+            }
+        }
+
+        loop {
+            if now < self.event_hold_until || self.pending_events.is_empty() {
+                return;
+            }
+
+            if !self.head_announced
+                && let Some(decl) = self.declaration_for(&self.pending_events[0])
+            {
+                for &(wind, label) in &decl.banners {
+                    let rel = self.relative_player_index(wind);
+                    self.call_banners[rel] = Some(CallBanner {
+                        label,
+                        shown_at: now,
+                    });
+                }
+                self.event_hold_until = now + decl.hold_secs;
+                if decl.before_apply {
+                    // 宣言だけ見せて、イベントの適用は保留が明けてから行う。
+                    // 保留中に古い操作UI（ロン・ツモボタン等）が残らないよう畳む。
+                    self.head_announced = true;
+                    self.available_calls.clear();
+                    self.can_tsumo = false;
+                    self.can_riichi = false;
+                } else {
+                    let event = self.pending_events.pop_front().expect("front checked");
+                    self.handle_event(event);
+                }
+                continue;
+            }
+
+            let event = self.pending_events.pop_front().expect("front checked");
+            self.head_announced = false;
+            self.handle_event(event);
+        }
+    }
+
+    /// イベントが宣言（発声）を伴う場合、その表示内容を返す。
+    fn declaration_for(&self, event: &ServerEvent) -> Option<Declaration> {
+        match event {
+            ServerEvent::PlayerCalled {
+                player, call_type, ..
+            } => {
+                let label = match call_type {
+                    CallType::Pon => Key::Pon,
+                    CallType::Chi => Key::Chi,
+                    CallType::Ankan | CallType::Daiminkan | CallType::Kakan => Key::Kan,
+                    // ロンは RoundWon 側で宣言する（サーバは通常送らない）
+                    CallType::Ron => return None,
+                };
+                Some(Declaration {
+                    banners: vec![(*player, label)],
+                    hold_secs: CALL_HOLD_SECS,
+                    before_apply: false,
+                })
+            }
+            ServerEvent::PlayerRiichi { player, .. } => Some(Declaration {
+                banners: vec![(*player, Key::Riichi)],
+                hold_secs: CALL_HOLD_SECS,
+                before_apply: false,
+            }),
+            ServerEvent::PeiDeclared { player, .. } => Some(Declaration {
+                banners: vec![(*player, Key::Pei)],
+                hold_secs: CALL_HOLD_SECS,
+                before_apply: false,
+            }),
+            ServerEvent::RoundWon { .. } if self.phase == GamePhase::Playing => {
+                // ダブロン・トリロンでは RoundWon が連続で届くため、
+                // キュー内の和了者すべてのバナーを同時に表示する。
+                let banners: Vec<(Wind, Key)> = self
+                    .pending_events
+                    .iter()
+                    .filter_map(|ev| match ev {
+                        ServerEvent::RoundWon { winner, loser, .. } => {
+                            let label = if loser.is_some() {
+                                Key::Ron
+                            } else {
+                                Key::Tsumo
+                            };
+                            Some((*winner, label))
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                Some(Declaration {
+                    banners,
+                    hold_secs: WIN_HOLD_SECS,
+                    before_apply: true,
+                })
+            }
+            ServerEvent::RoundDraw {
+                declarer: Some(declarer),
+                ..
+            } if self.phase == GamePhase::Playing => Some(Declaration {
+                banners: vec![(*declarer, Key::NineTerminals)],
+                hold_secs: WIN_HOLD_SECS,
+                before_apply: true,
+            }),
+            _ => None,
         }
     }
 

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -422,3 +422,231 @@ fn test_can_discard_for_riichi_after_ankan_uses_opened_melds() {
     assert!(state.can_discard_for_riichi(Some(Tile::new(Tile::M5))));
     assert!(state.can_discard_for_riichi(Some(Tile::new(Tile::M7))));
 }
+
+// ─── 宣言バナー（鳴き・リーチ・和了の発声表示）のテスト ──────────────────────
+
+fn queued_pon(player: Wind) -> ServerEvent {
+    let tile = Tile::new(Tile::P3);
+    ServerEvent::PlayerCalled {
+        player,
+        call_type: CallType::Pon,
+        called_tile: tile,
+        tiles: vec![tile, tile, tile],
+    }
+}
+
+fn round_won_tsumo(winner: Wind) -> ServerEvent {
+    ServerEvent::RoundWon {
+        winner,
+        loser: None,
+        winning_tile: Tile::new(Tile::P1),
+        scores: [25000; 4],
+        yaku_list: vec![],
+        han: 1,
+        fu: 30,
+        score_points: 1000,
+        rank: mahjong_core::scoring::score::ScoreRank::Normal,
+        has_opened: false,
+        uradora_indicators: vec![],
+        riichi_sticks: 0,
+        player_hands: vec![],
+    }
+}
+
+fn round_won_ron(winner: Wind, loser: Wind) -> ServerEvent {
+    match round_won_tsumo(winner) {
+        ServerEvent::RoundWon {
+            winner,
+            winning_tile,
+            scores,
+            yaku_list,
+            han,
+            fu,
+            score_points,
+            rank,
+            has_opened,
+            uradora_indicators,
+            riichi_sticks,
+            player_hands,
+            ..
+        } => ServerEvent::RoundWon {
+            winner,
+            loser: Some(loser),
+            winning_tile,
+            scores,
+            yaku_list,
+            han,
+            fu,
+            score_points,
+            rank,
+            has_opened,
+            uradora_indicators,
+            riichi_sticks,
+            player_hands,
+        },
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_call_banner_shown_and_following_events_held() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+
+    // 下家（南）のポン → バナー表示・ポン自体は即適用
+    state.queue_event(queued_pon(Wind::South));
+    state.queue_event(ServerEvent::OtherPlayerDrew {
+        player: Wind::South,
+        remaining_tiles: 60,
+    });
+    state.process_events(100.0);
+
+    assert!(matches!(
+        state.call_banners[1],
+        Some(CallBanner {
+            label: Key::Pon,
+            ..
+        })
+    ));
+    assert_eq!(state.other_players[0].melds.len(), 1);
+    // 後続の OtherPlayerDrew は保留され、残り枚数は未更新
+    assert_eq!(state.remaining_tiles, 70);
+
+    // 保留明けに適用される
+    state.process_events(100.0 + CALL_HOLD_SECS);
+    assert_eq!(state.remaining_tiles, 60);
+}
+
+#[test]
+fn test_riichi_banner_holds_declaration_discard() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+
+    state.queue_event(ServerEvent::PlayerRiichi {
+        player: Wind::West,
+        scores: [25000, 25000, 24000, 25000],
+        riichi_sticks: 1,
+    });
+    state.queue_event(ServerEvent::TileDiscarded {
+        player: Wind::West,
+        tile: Tile::new(Tile::M1),
+        is_tsumogiri: true,
+    });
+    state.process_events(100.0);
+
+    // リーチは即適用（点数・供託が更新）、宣言牌の打牌は保留
+    assert!(matches!(
+        state.call_banners[2],
+        Some(CallBanner {
+            label: Key::Riichi,
+            ..
+        })
+    ));
+    assert_eq!(state.riichi_sticks, 1);
+    assert!(state.discards[2].is_empty());
+
+    state.process_events(100.0 + CALL_HOLD_SECS);
+    assert_eq!(state.discards[2].len(), 1);
+    assert!(state.discards[2][0].is_riichi);
+}
+
+#[test]
+fn test_round_won_deferred_until_banner_hold_elapses() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+
+    state.queue_event(round_won_tsumo(Wind::South));
+    state.process_events(100.0);
+
+    // ツモ宣言バナーだけ表示され、結果画面への遷移は保留される
+    assert!(matches!(
+        state.call_banners[1],
+        Some(CallBanner {
+            label: Key::Tsumo,
+            ..
+        })
+    ));
+    assert_eq!(state.phase, GamePhase::Playing);
+
+    // 保留中は再処理しても遷移しない
+    state.process_events(100.0 + WIN_HOLD_SECS / 2.0);
+    assert_eq!(state.phase, GamePhase::Playing);
+
+    // 保留明けに結果画面へ
+    state.process_events(100.0 + WIN_HOLD_SECS);
+    assert_eq!(state.phase, GamePhase::RoundResult);
+}
+
+#[test]
+fn test_double_ron_shows_banners_for_all_winners() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+
+    state.queue_event(round_won_ron(Wind::South, Wind::East));
+    state.queue_event(round_won_ron(Wind::West, Wind::East));
+    state.process_events(100.0);
+
+    // 2人分のロンバナーが同時に表示される
+    assert!(matches!(
+        state.call_banners[1],
+        Some(CallBanner {
+            label: Key::Ron,
+            ..
+        })
+    ));
+    assert!(matches!(
+        state.call_banners[2],
+        Some(CallBanner {
+            label: Key::Ron,
+            ..
+        })
+    ));
+    assert_eq!(state.phase, GamePhase::Playing);
+
+    // 保留明けに両方の RoundWon が適用される（2ページ分の結果）
+    state.process_events(100.0 + WIN_HOLD_SECS);
+    assert_eq!(state.phase, GamePhase::RoundResult);
+    assert_eq!(state.win_results.len(), 2);
+}
+
+#[test]
+fn test_banner_expires_after_display_duration() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+
+    state.queue_event(queued_pon(Wind::South));
+    state.process_events(100.0);
+    assert!(state.call_banners[1].is_some());
+
+    state.process_events(100.0 + CALL_BANNER_SECS);
+    assert!(state.call_banners[1].is_none());
+}
+
+#[test]
+fn test_banners_cleared_on_new_round() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+
+    state.queue_event(queued_pon(Wind::South));
+    state.process_events(100.0);
+    assert!(state.call_banners[1].is_some());
+
+    state.queue_event(game_started_4p(Wind::East, 1));
+    state.process_events(100.0 + CALL_HOLD_SECS);
+    assert!(state.call_banners[1].is_none());
+}
+
+#[test]
+fn test_win_announcement_collapses_stale_action_ui() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    state.available_calls = vec![AvailableCall::Ron];
+    state.can_tsumo = true;
+
+    // ロン宣言の保留中は古いロン・ツモボタンを畳む
+    state.queue_event(round_won_ron(Wind::East, Wind::South));
+    state.process_events(100.0);
+    assert!(state.available_calls.is_empty());
+    assert!(!state.can_tsumo);
+    assert_eq!(state.phase, GamePhase::Playing);
+}

--- a/crates/mahjong-client/src/main.rs
+++ b/crates/mahjong-client/src/main.rs
@@ -210,11 +210,13 @@ async fn main() {
         }
 
         // アダプターを毎フレーム進め、イベントを反映する
+        // （宣言バナー表示中は process_events が後続イベントの適用を保留する）
         if let Some(adp) = &mut adapter {
             adp.tick();
             for event in adp.poll_events() {
-                game_state.handle_event(event);
+                game_state.queue_event(event);
             }
+            game_state.process_events(get_time());
             // 対局中の接続バナー（ローカル対戦では常に None）
             game_state.online_state.status_line = adp.status_text(game_state.lang);
             game_state.online_state.status_is_error = game_state.online_state.status_line.is_some();
@@ -288,8 +290,9 @@ async fn main() {
                             new_adapter.start_game();
                             let events = new_adapter.poll_events();
                             for event in events {
-                                game_state.handle_event(event);
+                                game_state.queue_event(event);
                             }
+                            game_state.process_events(get_time());
                             adapter = Some(Box::new(new_adapter));
                         }
                         SetupAction::ApplyOnline => {

--- a/crates/mahjong-client/src/renderer/banners.rs
+++ b/crates/mahjong-client/src/renderer/banners.rs
@@ -1,0 +1,107 @@
+//! 鳴き・リーチ・和了などの宣言バナー（吹き出し）の描画
+//!
+//! 各家が発声すべき場面（ポン・チー・カン・リーチ・北抜き・ロン・ツモ・
+//! 九種九牌）で、その家の手牌・捨て牌の近くに吹き出しを一定時間表示する。
+//! バナーの生成と寿命管理は `GameState::process_events` が行い、ここでは
+//! `state.call_banners` を描画するだけ。
+
+use macroquad::prelude::*;
+
+use super::{BOARD_CENTER_Y, DESIGN_W, rotation_index, theme};
+use crate::game::{CALL_BANNER_SECS, GameState};
+
+/// バナー文字サイズ（`USED_FONT_SIZES` に含まれるサイズを使うこと）
+const BANNER_FONT: u16 = 26;
+/// フェードアウトにかける時間（秒）
+const FADE_SECS: f64 = 0.35;
+/// 吹き出しの高さ
+const BUBBLE_H: f32 = 46.0;
+/// 吹き出しのしっぽ（三角形）の長さ
+const TAIL_LEN: f32 = 12.0;
+
+/// しっぽの向き（吹き出しからプレイヤーの手牌方向を指す）
+enum TailDir {
+    Down,
+    Right,
+    Up,
+    Left,
+}
+
+/// 描画スロット（[`super::PLAYER_ROTATIONS`] と同じ並び）ごとの
+/// 吹き出し中心座標としっぽの向き。
+fn banner_anchor(slot: usize) -> (f32, f32, TailDir) {
+    match slot {
+        // 自分: 手牌（y=680）の上
+        0 => (DESIGN_W / 2.0, 600.0, TailDir::Down),
+        // 下家: 右側の手牌の内側
+        1 => (890.0, BOARD_CENTER_Y, TailDir::Right),
+        // 対面: 上側の手牌の下
+        2 => (DESIGN_W / 2.0, 165.0, TailDir::Up),
+        // 上家: 左側の手牌の内側
+        _ => (390.0, BOARD_CENTER_Y, TailDir::Left),
+    }
+}
+
+/// アクティブな宣言バナーをすべて描画する。
+pub(super) fn draw_call_banners(state: &GameState, font: Option<&Font>) {
+    let now = get_time();
+    let tr = state.tr();
+
+    for rel in 0..state.player_count {
+        let Some(banner) = &state.call_banners[rel] else {
+            continue;
+        };
+        let age = now - banner.shown_at;
+        if !(0.0..CALL_BANNER_SECS).contains(&age) {
+            continue;
+        }
+        let alpha = ((CALL_BANNER_SECS - age) / FADE_SECS).clamp(0.0, 1.0) as f32;
+        let slot = rotation_index(rel, state.player_count);
+        draw_banner_bubble(font, slot, tr.get(banner.label), alpha);
+    }
+}
+
+/// 吹き出しを1つ描画する。
+fn draw_banner_bubble(font: Option<&Font>, slot: usize, text: &str, alpha: f32) {
+    let (cx, cy, tail) = banner_anchor(slot);
+
+    let dims = theme::measure_scaled(font, text, BANNER_FONT);
+    let w = dims.width + 44.0;
+    let h = BUBBLE_H;
+    let x = cx - w / 2.0;
+    let y = cy - h / 2.0;
+
+    let fill = theme::rgba(0x050e08, 0.94 * alpha);
+    let border = theme::rgba(0xc9a227, 0.95 * alpha);
+
+    // しっぽ（本体に少し食い込ませて隙間をなくす）
+    let (t1, t2, t3) = match tail {
+        TailDir::Down => (
+            vec2(cx - 9.0, y + h - 1.0),
+            vec2(cx + 9.0, y + h - 1.0),
+            vec2(cx, y + h + TAIL_LEN),
+        ),
+        TailDir::Up => (
+            vec2(cx - 9.0, y + 1.0),
+            vec2(cx + 9.0, y + 1.0),
+            vec2(cx, y - TAIL_LEN),
+        ),
+        TailDir::Right => (
+            vec2(x + w - 1.0, cy - 9.0),
+            vec2(x + w - 1.0, cy + 9.0),
+            vec2(x + w + TAIL_LEN, cy),
+        ),
+        TailDir::Left => (
+            vec2(x + 1.0, cy - 9.0),
+            vec2(x + 1.0, cy + 9.0),
+            vec2(x - TAIL_LEN, cy),
+        ),
+    };
+    draw_triangle(t1, t2, t3, border);
+
+    theme::draw_rounded_rect(x, y, w, h, 10.0, fill);
+    theme::draw_rounded_rect_lines(x, y, w, h, 10.0, 2.0, border);
+
+    let text_color = Color::new(theme::TEXT_BR.r, theme::TEXT_BR.g, theme::TEXT_BR.b, alpha);
+    theme::draw_text_centered(font, text, cx, cy + 9.0, BANNER_FONT, text_color);
+}

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! 埋め込みPNGを使って麻雀牌を描画する。
 
+mod banners;
 mod board;
 mod labels;
 mod menu;
@@ -448,6 +449,7 @@ pub fn draw_game(
             draw_hand(state, font, tile_textures);
             draw_top_bar(state, font, tile_textures);
             let click = overlay::draw_action_buttons(state, font, tile_textures);
+            banners::draw_call_banners(state, font);
             online::draw_connection_banner(state, font);
             online::draw_turn_timer(state, font);
             click
@@ -461,6 +463,8 @@ pub fn draw_game(
             draw_hand(state, font, tile_textures);
             draw_top_bar(state, font, tile_textures);
             draw_result(state, font, tile_textures);
+            // 結果画面へ切り替わった直後もフェード中のロン・ツモ宣言を出し切る
+            banners::draw_call_banners(state, font);
             online::draw_connection_banner(state, font);
             None
         }


### PR DESCRIPTION
## Summary
- Closes #244. Calls (pon/chi/kan), riichi, pei (kita-nuki), wins (ron/tsumo), and nine-terminals declarations were previously silent, making it hard for players to notice them since there's no voice/text for what a real player would announce out loud.
- Server events are now queued in `GameState` and drained by `process_events()`. When an event carries a declaration, a speech-bubble banner appears near the declaring player's hand/discards, and subsequent events are held briefly so the declaration is visible before its effect (e.g. "Riichi!" shows before the sideways discard tile appears).
- Ron/tsumo and nine-terminals defer the event itself (not just the banner), so the banner appears over the board before transitioning to the result screen. Double/triple ron shows all winners' banners simultaneously.

## Test plan
- [x] `cargo build && cargo test` (workspace) — all pass
- [x] `cargo fmt` / `cargo clippy --all-targets` — no warnings
- [x] `cargo build -p mahjong-client --target wasm32-unknown-unknown --release` — builds
- [x] Native client smoke-launch confirmed the app starts without panicking
- [x] Added 7 new unit tests covering: banner display + held follow-up event, riichi declaration delaying the discard, RoundWon deferral until hold elapses, double-ron showing both banners at once, banner expiry, banners clearing on new round, and collapsing stale action UI (ron/tsumo buttons) during a win announcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)