### PR TITLE
Add link to the playable web client in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Implementation for Japanese Riichi Mahjong in Rust.
 
+**You can [play it here](https://riichi-mahjong-rs.vercel.app).**
+
 ![Screenshot of gameplay](./docs/image1.png)
 
 ## Current status

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -6,6 +6,8 @@
 
 麻雀（一般的なリーチ麻雀）のRustでの実装です。
 
+**[こちら](https://riichi-mahjong-rs.vercel.app) でプレイすることができます。**
+
 ![プレイ中の画面](./image1.png)
 
 ## 現在の実装状況


### PR DESCRIPTION
## Summary

Add a prominent play link pointing to the deployed Vercel web client (https://riichi-mahjong-rs.vercel.app) in both the English and Japanese READMEs, just below the project description.

## Changes

- `README.md`: **You can [play it here](https://riichi-mahjong-rs.vercel.app).**
- `docs/README.ja.md`: **[こちら](https://riichi-mahjong-rs.vercel.app) でプレイすることができます。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)