### PR TITLE
Implement Sankantsu (Three Quads) yaku

### DIFF
--- a/crates/mahjong-core/src/winning_hand/check_2_han.rs
+++ b/crates/mahjong-core/src/winning_hand/check_2_han.rs
@@ -387,6 +387,27 @@ pub fn check_little_dragons(
         Ok((name, false, 0))
     }
 }
+/// 三槓子
+pub fn check_three_quads(
+    hand_analyzer: &HandAnalyzer,
+    status: &Status,
+    settings: &Settings,
+) -> Result<(&'static str, bool, u32)> {
+    let name = get(
+        Kind::ThreeQuads,
+        status.has_claimed_open,
+        settings.display_lang,
+    );
+    if !hand_analyzer.shanten.has_won() {
+        return Ok((name, false, 0));
+    }
+    // 三槓子: 槓子がちょうど3つ（4つの場合は四槓子となるため対象外）
+    if status.kan_count == 3 {
+        Ok((name, true, 2))
+    } else {
+        Ok((name, false, 0))
+    }
+}
 
 /// ユニットテスト
 #[cfg(test)]
@@ -572,6 +593,51 @@ mod tests {
         assert_eq!(
             check_little_dragons(&test_analyzer, &status, &settings).unwrap(),
             ("小三元", true, 2)
+        );
+    }
+    #[test]
+    /// 三槓子で和了った（暗槓・明槓・加槓の組み合わせ）
+    fn test_three_quads() {
+        let test_str = "111333m444s1777z 1z";
+        let test = Hand::from(test_str);
+        let test_analyzer = HandAnalyzer::new(&test).unwrap();
+        let mut status = Status::new();
+        let settings = Settings::new();
+        status.kan_count = 3;
+        status.is_self_drawn = true;
+        assert_eq!(
+            check_three_quads(&test_analyzer, &status, &settings).unwrap(),
+            ("三槓子", true, 2)
+        );
+    }
+    #[test]
+    /// 槓子が2つでは三槓子は成立しない
+    fn test_three_quads_not_win_with_two_kans() {
+        let test_str = "111333m444s1777z 1z";
+        let test = Hand::from(test_str);
+        let test_analyzer = HandAnalyzer::new(&test).unwrap();
+        let mut status = Status::new();
+        let settings = Settings::new();
+        status.kan_count = 2;
+        status.is_self_drawn = true;
+        assert_eq!(
+            check_three_quads(&test_analyzer, &status, &settings).unwrap(),
+            ("三槓子", false, 0)
+        );
+    }
+    #[test]
+    /// 槓子が4つのときは四槓子のみで三槓子と二重計上しない
+    fn test_three_quads_not_win_with_four_kans() {
+        let test_str = "111333m444s1777z 1z";
+        let test = Hand::from(test_str);
+        let test_analyzer = HandAnalyzer::new(&test).unwrap();
+        let mut status = Status::new();
+        let settings = Settings::new();
+        status.kan_count = 4;
+        status.is_self_drawn = true;
+        assert_eq!(
+            check_three_quads(&test_analyzer, &status, &settings).unwrap(),
+            ("三槓子", false, 0)
         );
     }
 }

--- a/crates/mahjong-core/src/winning_hand/checker.rs
+++ b/crates/mahjong-core/src/winning_hand/checker.rs
@@ -157,6 +157,11 @@ pub fn check(
         Kind::LittleDragons,
         check_little_dragons(analyzer, status, settings)?,
     );
+    // 三槓子
+    result.insert(
+        Kind::ThreeQuads,
+        check_three_quads(analyzer, status, settings)?,
+    );
     // 混一色
     result.insert(
         Kind::CommonFlush,

--- a/crates/mahjong-core/src/winning_hand/name.rs
+++ b/crates/mahjong-core/src/winning_hand/name.rs
@@ -89,6 +89,8 @@ pub enum Kind {
     CommonTerminals,
     /// 小三元
     LittleDragons,
+    /// 三槓子
+    ThreeQuads,
     /// 混一色
     CommonFlush,
     /// 清一色
@@ -225,6 +227,8 @@ fn get_en(hand_kind: Kind, has_openned: bool) -> &'static str {
         Kind::CommonTerminals => "Common Terminals",
         // 小三元
         Kind::LittleDragons => "Little Dragons",
+        // 三槓子
+        Kind::ThreeQuads => "Three Quads",
         // 混一色
         Kind::CommonFlush => {
             openned_name!("Common Flush", has_openned, Lang::En)
@@ -328,6 +332,8 @@ fn get_ja(hand_kind: Kind, has_openned: bool) -> &'static str {
         Kind::CommonTerminals => "混老頭",
         // 小三元
         Kind::LittleDragons => "小三元",
+        // 三槓子
+        Kind::ThreeQuads => "三槓子",
         // 混一色
         Kind::CommonFlush => {
             openned_name!("混一色", has_openned, Lang::Ja)
@@ -414,6 +420,7 @@ mod tests {
             (Kind::PerfectEnds, "Perfect Ends"),
             (Kind::CommonTerminals, "Common Terminals"),
             (Kind::LittleDragons, "Little Dragons"),
+            (Kind::ThreeQuads, "Three Quads"),
             (Kind::CommonFlush, "Common Flush"),
             (Kind::PerfectFlush, "Perfect Flush"),
             (Kind::ThirteenOrphans, "Thirteen Orphans"),
@@ -485,6 +492,7 @@ mod tests {
             (Kind::ValueHonourRedDragon, "Value Honour (Red dragon)"),
             (Kind::CommonTerminals, "Common Terminals"),
             (Kind::LittleDragons, "Little Dragons"),
+            (Kind::ThreeQuads, "Three Quads"),
             (Kind::ThirteenOrphans, "Thirteen Orphans"),
             (Kind::FourConcealedTriplets, "Four Concealed Triplets"),
             (
@@ -541,6 +549,7 @@ mod tests {
             (Kind::PerfectEnds, "純全帯么九"),
             (Kind::CommonTerminals, "混老頭"),
             (Kind::LittleDragons, "小三元"),
+            (Kind::ThreeQuads, "三槓子"),
             (Kind::CommonFlush, "混一色"),
             (Kind::PerfectFlush, "清一色"),
             (Kind::ThirteenOrphans, "国士無双"),
@@ -608,6 +617,7 @@ mod tests {
             (Kind::ValueHonourRedDragon, "役牌（中）"),
             (Kind::CommonTerminals, "混老頭"),
             (Kind::LittleDragons, "小三元"),
+            (Kind::ThreeQuads, "三槓子"),
             (Kind::ThirteenOrphans, "国士無双"),
             (Kind::FourConcealedTriplets, "四暗刻"),
             (Kind::FourConcealedTripletsPairWait, "四暗刻単騎待ち"),

--- a/docs/glossary.ja.md
+++ b/docs/glossary.ja.md
@@ -197,7 +197,7 @@
 | 三色同刻 | Sanshoku Dōkō | Mixed Triplets | `MixedTriplets` | 2 | |
 | 対々和 | Toitoi | All Triplets | `AllTriplets` | 2 | |
 | 三暗刻 | San'ankō | Three Concealed Triplets | `ThreeConcealedTriplets` | 2 | |
-| 三槓子 | Sankantsu | Three Quads | — | 2 | **未実装。** |
+| 三槓子 | Sankantsu | Three Quads | `ThreeQuads` | 2 | 鳴き有無を問わず成立。 |
 | 混全帯么九 | Chanta | Common Ends | `CommonEnds` | 2 / 1 | |
 | 混老頭 | Honrōtō | Common Terminals | `CommonTerminals` | 2 | |
 | 小三元 | Shōsangen | Little Dragons | `LittleDragons` | 2 | 三元牌の役牌で別途 +2 翻。 |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -198,7 +198,7 @@ means the yaku is not currently implemented in the codebase.
 | 三色同刻 | Sanshoku Dōkō | Mixed Triplets | `MixedTriplets` | 2 | |
 | 対々和 | Toitoi | All Triplets | `AllTriplets` | 2 | |
 | 三暗刻 | San'ankō | Three Concealed Triplets | `ThreeConcealedTriplets` | 2 | |
-| 三槓子 | Sankantsu | Three Quads | — | 2 | **Not implemented.** |
+| 三槓子 | Sankantsu | Three Quads | `ThreeQuads` | 2 | No open/closed distinction. |
 | 混全帯么九 | Chanta | Common Ends | `CommonEnds` | 2 / 1 | |
 | 混老頭 | Honrōtō | Common Terminals | `CommonTerminals` | 2 | |
 | 小三元 | Shōsangen | Little Dragons | `LittleDragons` | 2 | Plus 2 han from the dragon Value Honours. |


### PR DESCRIPTION
## Summary
- Add `Kind::ThreeQuads` for the 2-han yaku Sankantsu (三槓子): three kans of any kind (concealed/open/added), win either open or closed with no fu discount.
- `check_three_quads` checks `status.kan_count == 3`, mirroring the existing `check_four_quads` (`kan_count == 4`) so the two yaku never double-count when all four kans are present.
- Update `docs/glossary.md` / `docs/glossary.ja.md` to drop the "Not implemented" note.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (all passing, incl. new tests: 3-kan win, 2-kan no-win, 4-kan exclusivity with Four Quads)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets` (no warnings)

Closes #248