### PR TITLE
Fix hand desync when discarding during the call banner hold

### DIFF
--- a/crates/mahjong-client/src/game/input.rs
+++ b/crates/mahjong-client/src/game/input.rs
@@ -212,6 +212,13 @@ impl GameState {
             return None;
         }
 
+        // 未適用のサーバイベントが残っている間（宣言バナーの保留中など）は
+        // 入力を受け付けない。画面は古い状態のままなので、それに基づく操作は
+        // サーバの状態と食い違うため。
+        if !self.pending_events.is_empty() {
+            return None;
+        }
+
         // リーチ中はツモ切り自動処理（マウス入力不要）
         if self.is_my_turn && self.is_riichi && self.drawn.is_some() && !self.can_tsumo {
             self.drawn.take();

--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -492,6 +492,16 @@ impl GameState {
                 } else {
                     let event = self.pending_events.pop_front().expect("front checked");
                     self.handle_event(event);
+                    // 自分の鳴きでは PlayerCalled の直後に HandUpdated が届く。
+                    // これを保留すると、保留中の打牌が保留明けの HandUpdated で
+                    // 巻き戻されて手牌がサーバと食い違うため、同時に適用する。
+                    if matches!(
+                        self.pending_events.front(),
+                        Some(ServerEvent::HandUpdated { .. })
+                    ) {
+                        let event = self.pending_events.pop_front().expect("front checked");
+                        self.handle_event(event);
+                    }
                 }
                 continue;
             }

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -636,6 +636,66 @@ fn test_banners_cleared_on_new_round() {
     assert!(state.call_banners[1].is_none());
 }
 
+/// 自分の鳴き（PlayerCalled）の直後に届く HandUpdated は、宣言バナーの
+/// 保留を待たず同一フレームで適用されること（回帰テスト）。
+/// 保留すると、その間の打牌が保留明けの HandUpdated で巻き戻され、
+/// 手牌がサーバと恒久的に食い違う（捨てた牌が手牌に復活する）。
+#[test]
+fn test_own_call_applies_hand_update_in_same_frame() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+
+    // 自分（東）のポン: サーバは PlayerCalled → HandUpdated の順で送る
+    state.queue_event(queued_pon(Wind::East));
+    let new_hand = vec![Tile::new(Tile::M1); 11];
+    state.queue_event(ServerEvent::HandUpdated {
+        hand: new_hand.clone(),
+    });
+    state.queue_event(ServerEvent::OtherPlayerDrew {
+        player: Wind::South,
+        remaining_tiles: 60,
+    });
+    state.process_events(100.0);
+
+    // ポンと手牌更新が同一フレームで適用され、手牌は最新になる
+    assert_eq!(state.melds.len(), 1);
+    assert_eq!(state.hand, new_hand);
+    assert!(state.is_my_turn);
+
+    // 宣言バナーの保留自体は維持され、さらに後続のイベントは適用されない
+    assert_eq!(state.remaining_tiles, 70);
+    state.process_events(100.0 + CALL_HOLD_SECS);
+    assert_eq!(state.remaining_tiles, 60);
+}
+
+/// 未適用のサーバイベントが残っている間は入力を受け付けないこと
+/// （回帰テスト）。画面が古い状態のまま打牌すると、その打牌が
+/// 後続イベントの適用で巻き戻されてサーバと食い違う。
+#[test]
+fn test_input_blocked_while_events_pending() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    // リーチ中のツモ切り自動打牌はマウス入力なしで発火する
+    state.is_my_turn = true;
+    state.is_riichi = true;
+    state.drawn = Some(Tile::new(Tile::M1));
+
+    // 未適用イベントが残っている間は入力（自動打牌含む）を受け付けない
+    state.queue_event(ServerEvent::OtherPlayerDrew {
+        player: Wind::South,
+        remaining_tiles: 60,
+    });
+    assert!(state.handle_input(None).is_none());
+    assert!(state.drawn.is_some());
+
+    // キューを消化すれば打牌できる
+    state.process_events(100.0);
+    assert!(matches!(
+        state.handle_input(None),
+        Some(ClientAction::Discard { tile: None })
+    ));
+}
+
 #[test]
 fn test_win_announcement_collapses_stale_action_ui() {
     let mut state = GameState::new();


### PR DESCRIPTION
## Summary

Fixes #293: after making a call (pon/chi/kan), the client held the follow-up `HandUpdated` event in the queue for the `CALL_HOLD_SECS` (0.9s) banner delay while already accepting discard input against the stale pre-call hand. A discard made in that window was later rolled back by the held `HandUpdated` (a pre-discard snapshot), leaving the client hand permanently one tile out of sync with the server — the discarded tile appeared both in the river and in the hand. Discarding the phantom tile later was silently ignored by the server, freezing the game.

## Changes

- `process_events`: when applying a call's `PlayerCalled` event, also apply an immediately following `HandUpdated` in the same frame, before the banner hold takes effect. The hand is never stale while input is possible, and the called tiles leave the hand at the same moment the meld appears.
- `handle_input`: as a defensive layer, ignore all input (including the riichi auto-discard) while unapplied server events remain queued.
- Added regression tests for both behaviors.

The server-side hardening found during the investigation (silently ignoring invalid discards instead of resyncing) is tracked separately in #294.

## Testing

- `cargo build && cargo test` (whole workspace) passes
- `cargo fmt` / `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)