### PR TITLE
Fix game stall when CPU declares pei after drawing the last tile

### DIFF
--- a/crates/mahjong-client/src/game/input.rs
+++ b/crates/mahjong-client/src/game/input.rs
@@ -149,6 +149,11 @@ impl GameState {
         if !self.is_three_player() || !self.nuki_dora {
             return;
         }
+        // 生牌山が空（海底ツモ）では補充ツモができず北抜き不可。
+        // サーバも却下するため、押しても無反応なボタンを出さない（#296）。
+        if self.remaining_tiles == 0 {
+            return;
+        }
         let drawn_is_north = self.drawn.is_some_and(|t| t.get() == Tile::Z4);
         if self.is_riichi {
             self.can_pei = drawn_is_north;

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -214,6 +214,25 @@ fn test_sanma_can_pei_with_north_in_hand() {
     assert!(state.can_pei, "リーチ中のツモ北で北抜き不可");
 }
 
+/// 海底ツモ（山残り0）では北抜きボタンを出さないこと（#296 の回帰テスト）。
+/// サーバは補充ツモ不能で北抜きを却下するため、表示しても無反応になる。
+#[test]
+fn test_sanma_no_pei_on_last_draw() {
+    let mut state = GameState::new();
+    state.handle_event(sanma_game_started(Wind::East));
+    state.hand = vec![Tile::new(Tile::Z4)];
+
+    // 海底牌のツモ: 北を持っていても北抜き不可
+    state.handle_event(ServerEvent::TileDrawn {
+        tile: Tile::new(Tile::Z4),
+        remaining_tiles: 0,
+        can_tsumo: false,
+        can_riichi: false,
+        is_furiten: false,
+    });
+    assert!(!state.can_pei, "海底ツモで北抜き可になっている");
+}
+
 #[test]
 fn test_setup_state_build_game_settings() {
     let mut setup = SetupState::new();

--- a/crates/mahjong-server/src/cpu/client.rs
+++ b/crates/mahjong-server/src/cpu/client.rs
@@ -427,6 +427,12 @@ impl CpuClient {
             return None;
         }
 
+        // 生牌山が空（海底ツモ後）は補充ツモができずサーバに却下されるため
+        // 宣言しない。却下されたCPUは再打診されず局が停止する（#296）。
+        if self.state.remaining_tiles == 0 {
+            return None;
+        }
+
         let drawn_is_north = self.state.my_drawn.is_some_and(|t| t.get() == Tile::Z4);
 
         if self.state.is_riichi {

--- a/crates/mahjong-server/src/cpu/client_tests.rs
+++ b/crates/mahjong-server/src/cpu/client_tests.rs
@@ -77,6 +77,7 @@ fn test_consider_pei_declares_with_north_in_hand() {
     let mut client = CpuClient::new(config);
     client.state.three_player = true;
     client.state.nuki_dora = true;
+    client.state.remaining_tiles = 30;
     // 北入りの普通の手（国士狙いではない）
     client.state.my_hand = vec![
         Tile::new(Tile::P2),
@@ -152,12 +153,30 @@ fn test_consider_pei_riichi_only_drawn_north() {
     client.state.three_player = true;
     client.state.nuki_dora = true;
     client.state.is_riichi = true;
+    client.state.remaining_tiles = 30;
     client.state.my_hand = vec![Tile::new(Tile::Z4)]; // リーチ中の手牌は抜けない
 
     assert_eq!(client.consider_pei(), None);
 
     client.state.my_drawn = Some(Tile::new(Tile::Z4));
     assert_eq!(client.consider_pei(), Some(ClientAction::Pei));
+}
+
+/// 回帰テスト（#296）: 生牌山が空（海底ツモ後）は北抜きを宣言しない
+///
+/// 補充ツモができないためサーバに却下され、却下されたCPUは再打診
+/// されないため局が永久に停止していた。
+#[test]
+fn test_consider_pei_none_when_wall_empty() {
+    let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+    let mut client = CpuClient::new(config);
+    client.state.three_player = true;
+    client.state.nuki_dora = true;
+    client.state.remaining_tiles = 0;
+    client.state.my_hand = vec![Tile::new(Tile::P2), Tile::new(Tile::Z4)];
+    client.state.my_drawn = Some(Tile::new(Tile::Z4));
+
+    assert_eq!(client.consider_pei(), None);
 }
 
 #[test]

--- a/crates/mahjong-server/src/driver.rs
+++ b/crates/mahjong-server/src/driver.rs
@@ -297,36 +297,53 @@ impl GameDriver {
     }
 
     fn force_default_action_impl(&mut self, seat: usize, now: Option<f64>) -> bool {
-        let action = {
-            let round = match self.table.current_round() {
-                Some(r) => r,
-                None => return false,
-            };
-            if round.is_over() {
-                return false;
-            }
-            match round.phase {
-                TurnPhase::WaitForDiscard if round.current_player == seat => {
-                    ClientAction::Discard { tile: None }
-                }
-                TurnPhase::WaitForCalls => {
-                    let pending = round
-                        .call_state
-                        .as_ref()
-                        .map(|cs| !cs.responded[seat])
-                        .unwrap_or(false);
-                    if !pending {
-                        return false;
-                    }
-                    ClientAction::Pass
-                }
-                TurnPhase::WaitForNineTerminals if round.current_player == seat => {
-                    ClientAction::NineTerminals { declare: false }
-                }
-                _ => return false,
-            }
+        let Some(action) = self.default_action_for(seat) else {
+            return false;
         };
         self.handle_action_impl(seat, action, now)
+    }
+
+    /// 指定した座席の既定アクション（ツモ切り/パス/九種続行）を返す
+    ///
+    /// その座席の入力待ちでなければ None を返す。
+    fn default_action_for(&self, seat: usize) -> Option<ClientAction> {
+        let round = self.table.current_round()?;
+        if round.is_over() {
+            return None;
+        }
+        match round.phase {
+            TurnPhase::WaitForDiscard if round.current_player == seat => {
+                Some(ClientAction::Discard { tile: None })
+            }
+            TurnPhase::WaitForCalls => {
+                let pending = round
+                    .call_state
+                    .as_ref()
+                    .map(|cs| !cs.responded[seat])
+                    .unwrap_or(false);
+                pending.then_some(ClientAction::Pass)
+            }
+            TurnPhase::WaitForNineTerminals if round.current_player == seat => {
+                Some(ClientAction::NineTerminals { declare: false })
+            }
+            _ => None,
+        }
+    }
+
+    /// CPUのアクションを適用する。サーバに却下された場合は既定アクションへ
+    /// フォールバックする
+    ///
+    /// 却下されたCPUは新しいイベントが出ないかぎり再打診されないため、
+    /// 放置するとその座席の入力待ちのまま局が永久に停止する
+    /// （例: 海底ツモでの北抜き宣言は補充ツモ不能で却下される。#296）。
+    /// フォールバックにより、CPUの判断とサーバの検証がずれても局は進行する。
+    fn apply_cpu_action(&mut self, seat: usize, action: ClientAction) {
+        if self.table.handle_action(seat, action) {
+            return;
+        }
+        if let Some(fallback) = self.default_action_for(seat) {
+            self.table.handle_action(seat, fallback);
+        }
     }
 
     /// CPU進行やツモのために tick が必要か（人間の入力待ちなら false）
@@ -435,7 +452,7 @@ impl GameDriver {
         // 残っている待機バッチがあれば先に適用する（遅延未使用なら常に空）
         while let Some(batch) = self.pending_cpu_batches.pop_front() {
             for (seat, action) in batch.actions {
-                self.table.handle_action(seat, action);
+                self.apply_cpu_action(seat, action);
             }
         }
 
@@ -456,7 +473,7 @@ impl GameDriver {
 
             // CPUのアクションをサーバに送信（これが新たなイベントを生成する）
             for (seat, action) in cpu_actions {
-                self.table.handle_action(seat, action);
+                self.apply_cpu_action(seat, action);
             }
         }
     }
@@ -532,7 +549,7 @@ impl GameDriver {
 
         let pending = self.pending_cpu_batches.pop_front().unwrap();
         for (seat, action) in pending.actions {
-            self.table.handle_action(seat, action);
+            self.apply_cpu_action(seat, action);
         }
 
         true
@@ -866,6 +883,38 @@ mod tests {
         assert_eq!(
             driver.pending_cpu_batches.front().unwrap().actions,
             vec![(1, ClientAction::Discard { tile: None })]
+        );
+    }
+
+    /// 却下されたCPUアクションが既定アクションにフォールバックすることを確認（#296）
+    ///
+    /// CPUの判断とサーバの検証がずれた場合（例: 海底ツモでの北抜き宣言）に、
+    /// そのまま放置するとCPUは再打診されず局が永久に停止していた。
+    #[test]
+    fn test_rejected_cpu_action_falls_back_to_default() {
+        let mut driver = driver_with_three_cpus();
+        driver.set_cpu_action_delay(1.0);
+        driver.table_mut().start_round();
+
+        // 座席1（CPU）の打牌待ちにする
+        {
+            let round = driver.table_mut().current_round_mut().unwrap();
+            round.current_player = 1;
+            round.phase = TurnPhase::WaitForDiscard;
+            round.players[1].draw(Tile::new(Tile::Z7));
+            round.drain_events();
+        }
+
+        // 四麻では北抜きは常に却下される無効アクション
+        driver.schedule_cpu_actions(vec![(1, ClientAction::Pei)], 1.0, 10.0);
+        driver.tick_at(20.0);
+
+        // 却下後にツモ切りへフォールバックし、局が進行している
+        let round = driver.table().current_round().unwrap();
+        assert_eq!(
+            round.players[1].discards.len(),
+            1,
+            "却下されたCPUアクションがフォールバックされず局が停止している"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #296: in three-player games with nuki-dora, the CPU declared pei whenever it held or drew a north tile without checking the live wall. On the haitei draw (live wall empty), the server rejects pei because no replacement tile is available — but a rejected CPU action is silently dropped, no event re-prompts the CPU, and the room's action timeout only rescues human seats, so the round stalled forever. This appeared as a rare, seed-dependent timeout of `test_sanma_full_game_with_two_humans` in CI (and would freeze local sanma games the same way).

## Changes

- **Direct fix**: `CpuClient::consider_pei` returns `None` when `remaining_tiles == 0`, matching the server-side validation in `Round::do_pei`.
- **Systemic safeguard**: `GameDriver` now applies CPU actions through `apply_cpu_action`, which falls back to the seat's default action (tsumogiri / pass / decline nine terminals) when the server rejects the CPU's action. Any future mismatch between CPU judgment and server validation degrades to a safe default instead of stalling the game. `force_default_action` shares the same `default_action_for` helper.
- **Client UX**: the human player had the same blind spot — the pei button was shown on the haitei draw and silently did nothing when clicked (no stall: the player can still discard normally). `refresh_can_pei` now hides the button when the live wall is empty.
- Regression tests for all three layers, plus `remaining_tiles` now set explicitly in the existing pei tests it gates.

## Testing

- `cargo build && cargo test` (whole workspace) passes
- `test_sanma_full_game_with_two_humans` passed 5 consecutive local runs
- `cargo fmt` / `cargo clippy --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)