### PR TITLE
Resync the client hand when a discard or riichi is rejected

### DIFF
--- a/crates/mahjong-server/src/driver.rs
+++ b/crates/mahjong-server/src/driver.rs
@@ -313,7 +313,21 @@ impl GameDriver {
         }
         match round.phase {
             TurnPhase::WaitForDiscard if round.current_player == seat => {
-                Some(ClientAction::Discard { tile: None })
+                // 鳴き直後の打牌待ちにはツモ牌がなく、ツモ切り指定（None）は
+                // 失敗する。その場合は喰い替え禁止でない手牌の牌を選ぶ。
+                let player = &round.players[seat];
+                let tile = if player.hand.drawn().is_some() {
+                    None
+                } else {
+                    player
+                        .hand
+                        .tiles()
+                        .iter()
+                        .rev()
+                        .copied()
+                        .find(|t| !player.is_swap_call_forbidden(*t))
+                };
+                Some(ClientAction::Discard { tile })
             }
             TurnPhase::WaitForCalls => {
                 let pending = round
@@ -884,6 +898,34 @@ mod tests {
             driver.pending_cpu_batches.front().unwrap().actions,
             vec![(1, ClientAction::Discard { tile: None })]
         );
+    }
+
+    /// 鳴き直後（ツモ牌なし）の既定アクションが手牌から打牌することを確認
+    ///
+    /// ツモ切り指定（None）はツモ牌が無いと失敗するため、切断・タイムアウト
+    /// 代行やCPUフォールバックが鳴き直後の打牌待ちで空振りし、局が停止していた。
+    /// 喰い替え禁止の牌は避けて選ぶ。
+    #[test]
+    fn test_force_default_action_discards_from_hand_without_drawn() {
+        let mut driver = driver_with_three_cpus();
+        driver.table_mut().start_round();
+        {
+            let round = driver.table_mut().current_round_mut().unwrap();
+            let seat_wind = round.players[0].seat_wind;
+            let hand = Hand::from("1m2m3m4m5m6m7m8m9m1p2p3p 4p");
+            round.players[0] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
+            // 鳴き直後の状態を作る: ツモ牌なし・末尾の3pは喰い替え禁止
+            round.players[0].set_forbidden_discards(vec![Tile::P3]);
+            round.current_player = 0;
+            round.phase = TurnPhase::WaitForDiscard;
+            round.drain_events();
+        }
+
+        assert!(driver.force_default_action(0));
+        let round = driver.table().current_round().unwrap();
+        assert_eq!(round.players[0].discards.len(), 1, "既定打牌が空振りした");
+        // 喰い替え禁止の3pを避け、それ以外で最後尾の2pを捨てる
+        assert_eq!(round.players[0].discards[0].tile.get(), Tile::P2);
     }
 
     /// 却下されたCPUアクションが既定アクションにフォールバックすることを確認（#296）

--- a/crates/mahjong-server/src/round/turn.rs
+++ b/crates/mahjong-server/src/round/turn.rs
@@ -237,6 +237,45 @@ impl Round {
         self.push_draw_events(player_idx, tile, "kan_draw");
     }
 
+    /// 却下した打牌・リーチ宣言の送り主に正しい手牌を送り返して再同期させる
+    ///
+    /// クライアントは打牌をローカルの手牌へ楽観的に適用してから送信するため、
+    /// サーバが黙って却下するとクライアントの手牌が食い違ったままになり、
+    /// 以降その牌の打牌が却下され続けて進行が止まって見える（#294）。
+    /// `HandUpdated` で手牌を戻し、手番でツモ牌があれば `TileDrawn` も
+    /// 再送して打牌をやり直させる（本人のみ。`OtherPlayerDrew` は送らない）。
+    pub(crate) fn resync_hand(&mut self, player_idx: usize) {
+        if player_idx >= self.player_count {
+            return;
+        }
+
+        self.events.push((
+            player_idx,
+            ServerEvent::HandUpdated {
+                hand: self.players[player_idx].hand.tiles().to_vec(),
+            },
+        ));
+
+        if self.phase == TurnPhase::WaitForDiscard
+            && self.current_player == player_idx
+            && let Some(drawn) = self.players[player_idx].hand.drawn()
+        {
+            let can_tsumo = self.can_tsumo();
+            let can_riichi = self.can_player_riichi(player_idx);
+            let is_furiten = self.players[player_idx].is_furiten();
+            self.events.push((
+                player_idx,
+                ServerEvent::TileDrawn {
+                    tile: drawn,
+                    remaining_tiles: self.wall.remaining(),
+                    can_tsumo,
+                    can_riichi,
+                    is_furiten,
+                },
+            ));
+        }
+    }
+
     /// ツモ直後の通知イベントを積む
     ///
     /// 本人には牌と可能アクションを含む `TileDrawn`、

--- a/crates/mahjong-server/src/table.rs
+++ b/crates/mahjong-server/src/table.rs
@@ -207,13 +207,15 @@ impl Table {
         match action {
             // === 手番アクション（current_player のみ） ===
             ClientAction::Discard { tile } => {
-                if round.current_player != player_idx {
-                    return false;
+                let accepted = round.current_player == player_idx
+                    && round.phase == TurnPhase::WaitForDiscard
+                    && round.do_discard(tile);
+                if !accepted {
+                    // クライアントは打牌をローカル適用済みのため、黙殺すると
+                    // 手牌が食い違ったままになる。正しい手牌を送り返す（#294）
+                    round.resync_hand(player_idx);
                 }
-                if round.phase != TurnPhase::WaitForDiscard {
-                    return false;
-                }
-                round.do_discard(tile)
+                accepted
             }
             ClientAction::Tsumo => {
                 if round.current_player != player_idx {
@@ -222,10 +224,12 @@ impl Table {
                 round.do_tsumo()
             }
             ClientAction::Riichi { tile } => {
-                if round.current_player != player_idx {
-                    return false;
+                let accepted = round.current_player == player_idx && round.do_riichi(tile);
+                if !accepted {
+                    // リーチ宣言牌もクライアントでローカル適用済み（#294）
+                    round.resync_hand(player_idx);
                 }
-                round.do_riichi(tile)
+                accepted
             }
 
             // === 鳴きアクション（WaitForCalls フェーズで対象プレイヤーのみ） ===
@@ -360,6 +364,138 @@ impl Table {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::player::Player;
+    use mahjong_core::hand::Hand;
+
+    /// 却下された打牌が本人へ HandUpdated + TileDrawn の再同期を送ること（#294）
+    ///
+    /// クライアントは打牌をローカル適用してから送信するため、黙殺すると
+    /// 手牌が食い違ったままになり、以降の打牌が却下され続けて
+    /// フリーズしたように見えていた。
+    #[test]
+    fn test_rejected_discard_resyncs_hand() {
+        let mut table = Table::new(GameSettings::default());
+        table.start_round();
+        {
+            let round = table.current_round_mut().unwrap();
+            let seat_wind = round.players[0].seat_wind;
+            let hand = Hand::from("1m2m3m4m5m6m7m8m9m1p2p3p1s 5z");
+            round.players[0] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
+            round.players[0].draw(hand.drawn().unwrap());
+            round.current_player = 0;
+            round.phase = TurnPhase::WaitForDiscard;
+            round.drain_events();
+        }
+
+        // 手牌に存在しない牌（東）の打牌は却下される
+        let accepted = table.handle_action(
+            0,
+            ClientAction::Discard {
+                tile: Some(Tile::new(Tile::Z1)),
+            },
+        );
+        assert!(!accepted);
+
+        // サーバの状態は変わらない
+        let expected_hand = {
+            let round = table.current_round().unwrap();
+            assert_eq!(round.phase, TurnPhase::WaitForDiscard);
+            assert!(round.players[0].discards.is_empty());
+            round.players[0].hand.tiles().to_vec()
+        };
+
+        // 本人にだけ HandUpdated + TileDrawn（同じツモ牌）が届く
+        let events = table.drain_events();
+        assert!(
+            events.iter().any(|(seat, e)| *seat == 0
+                && matches!(e, ServerEvent::HandUpdated { hand } if *hand == expected_hand)),
+            "HandUpdated が送られていない"
+        );
+        assert!(
+            events.iter().any(|(seat, e)| *seat == 0
+                && matches!(e, ServerEvent::TileDrawn { tile, .. } if tile.get() == Tile::Z5)),
+            "TileDrawn が再送されていない"
+        );
+        assert!(
+            events.iter().all(|(seat, _)| *seat == 0),
+            "他プレイヤーへイベントが送られている"
+        );
+    }
+
+    /// ツモ牌が無い打牌待ち（鳴き直後）での却下は HandUpdated のみ送ること
+    #[test]
+    fn test_rejected_discard_without_drawn_resyncs_hand_only() {
+        let mut table = Table::new(GameSettings::default());
+        table.start_round();
+        {
+            let round = table.current_round_mut().unwrap();
+            round.current_player = 0;
+            round.phase = TurnPhase::WaitForDiscard;
+            round.drain_events();
+        }
+
+        // ツモ牌が無いのでツモ切り指定は却下される
+        let accepted = table.handle_action(0, ClientAction::Discard { tile: None });
+        assert!(!accepted);
+
+        let events = table.drain_events();
+        assert!(
+            events
+                .iter()
+                .any(|(seat, e)| *seat == 0 && matches!(e, ServerEvent::HandUpdated { .. })),
+            "HandUpdated が送られていない"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|(_, e)| matches!(e, ServerEvent::TileDrawn { .. })),
+            "ツモ牌が無いのに TileDrawn が送られている"
+        );
+    }
+
+    /// 却下されたリーチ宣言も再同期を送ること（#294）
+    ///
+    /// リーチ宣言牌もクライアントでローカル適用済みのため、黙殺すると
+    /// 打牌の場合と同じ手牌不整合になる。
+    #[test]
+    fn test_rejected_riichi_resyncs_hand() {
+        let mut table = Table::new(GameSettings::default());
+        table.start_round();
+        {
+            let round = table.current_round_mut().unwrap();
+            let seat_wind = round.players[0].seat_wind;
+            // テンパイしていない手（リーチ不可）
+            let hand = Hand::from("1m4m7m2p5p8p3s6s9s1z2z3z4z 5z");
+            round.players[0] = Player::new(seat_wind, hand.tiles().to_vec(), 25000);
+            round.players[0].draw(hand.drawn().unwrap());
+            round.current_player = 0;
+            round.phase = TurnPhase::WaitForDiscard;
+            round.drain_events();
+        }
+
+        let accepted = table.handle_action(0, ClientAction::Riichi { tile: None });
+        assert!(!accepted);
+
+        // リーチは成立していない
+        {
+            let round = table.current_round().unwrap();
+            assert!(!round.players[0].is_riichi);
+            assert_eq!(round.riichi_sticks, 0);
+        }
+
+        let events = table.drain_events();
+        assert!(
+            events
+                .iter()
+                .any(|(seat, e)| *seat == 0 && matches!(e, ServerEvent::HandUpdated { .. })),
+            "HandUpdated が送られていない"
+        );
+        assert!(
+            events.iter().any(|(seat, e)| *seat == 0
+                && matches!(e, ServerEvent::TileDrawn { tile, .. } if tile.get() == Tile::Z5)),
+            "TileDrawn が再送されていない"
+        );
+    }
 
     #[test]
     fn test_table_new() {


### PR DESCRIPTION
## Summary

Fixes #294: the client applies a discard to its local hand optimistically before sending it. When the server rejected the action (`Round::do_discard` / `do_riichi` returning `false`), it emitted no event — a desynced client kept a wrong hand forever, waiting for a `TileDiscarded` that never came while the server waited for a valid discard. To the player this looked like a frozen game. The root cause that produced such desyncs was fixed in #293/#295, but this makes any future desync self-healing instead of fatal.

## Changes

- **`Round::resync_hand`** (new): sends the rejected player their authoritative hand via `HandUpdated`, and re-sends `TileDrawn` when they are on turn with a drawn tile — the same re-prompt pattern already used when a player declines nine terminals. Sent only to that player (no `OtherPlayerDrew`), so other clients are unaffected.
- **`Table::handle_action`**: rejected `Discard` and `Riichi` actions now trigger the resync. These are the only two actions the client applies optimistically; kan/pei/call rejections leave the client state untouched and still fail silently as before.
- **Default-action fix**: `GameDriver::default_action_for` returned tsumogiri (`Discard { tile: None }`) unconditionally, but `try_discard(None)` fails when nothing was drawn — i.e. in the discard wait right after a call. The timeout/disconnect takeover (`force_default_action`) and the #296 CPU rejection fallback could therefore no-op and stall in that state. The default action now picks a hand tile that is not swap-call forbidden when there is no drawn tile.

No client changes are needed: the existing `HandUpdated`/`TileDrawn` handlers restore the hand and drawn tile, and input stays blocked while the resync events are pending (#295).

## Testing

- New regression tests: rejected discard resyncs hand + re-sends the drawn tile to that seat only; rejected discard without a drawn tile sends `HandUpdated` only; rejected riichi resyncs and rolls back cleanly; default action discards a non-forbidden hand tile when nothing was drawn.
- `cargo build && cargo test` (whole workspace) passes; `cargo fmt` / `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)