### PR TITLE
Only treat HandUpdated as a post-call discard prompt after own pon/chi

### DIFF
--- a/crates/mahjong-server/src/cpu/client_tests.rs
+++ b/crates/mahjong-server/src/cpu/client_tests.rs
@@ -1,6 +1,7 @@
 //! `CpuClient` のユニットテスト
 
 use super::*;
+use crate::protocol::CallType;
 use mahjong_core::tile::Wind;
 
 fn game_started_event(seat_wind: Wind, hand: Vec<Tile>) -> ServerEvent {
@@ -177,6 +178,49 @@ fn test_consider_pei_none_when_wall_empty() {
     client.state.my_drawn = Some(Tile::new(Tile::Z4));
 
     assert_eq!(client.consider_pei(), None);
+}
+
+/// 回帰テスト: 自分の鳴きを伴わない HandUpdated（打牌却下時の再同期 #294）
+/// に打牌を返さないこと
+///
+/// 返してしまうと「却下 → 再同期 HandUpdated → 再打牌 → 却下」の無限ループで
+/// CPU（代打ち含む）の手番が進まなくなり、局全体が停止する。
+#[test]
+fn test_resync_hand_updated_does_not_trigger_discard() {
+    let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced);
+    let mut client = CpuClient::new(config);
+    client.state.my_seat_wind = Wind::South;
+
+    let hand = vec![
+        Tile::new(Tile::M1),
+        Tile::new(Tile::M2),
+        Tile::new(Tile::M3),
+        Tile::new(Tile::P4),
+        Tile::new(Tile::P5),
+        Tile::new(Tile::P6),
+        Tile::new(Tile::S7),
+        Tile::new(Tile::S8),
+        Tile::new(Tile::S9),
+        Tile::new(Tile::Z1),
+        Tile::new(Tile::Z1),
+    ];
+
+    // 再同期の HandUpdated（自分の鳴きなし）: 打牌しない
+    let action = client.handle_event(&ServerEvent::HandUpdated { hand: hand.clone() });
+    assert_eq!(action, None, "再同期の HandUpdated に打牌を返している");
+
+    // 自分のポンに続く HandUpdated: 従来どおり打牌する
+    client.handle_event(&ServerEvent::PlayerCalled {
+        player: Wind::South,
+        call_type: CallType::Pon,
+        called_tile: Tile::new(Tile::Z5),
+        tiles: vec![Tile::new(Tile::Z5); 3],
+    });
+    let action = client.handle_event(&ServerEvent::HandUpdated { hand });
+    assert!(
+        matches!(action, Some(ClientAction::Discard { .. })),
+        "ポン直後の HandUpdated で打牌していない"
+    );
 }
 
 #[test]

--- a/crates/mahjong-server/src/cpu/state.rs
+++ b/crates/mahjong-server/src/cpu/state.rs
@@ -72,6 +72,12 @@ pub struct CpuGameState {
     pub need_discard_after_call: bool,
     /// 直前の鳴きがカン系（嶺上ツモ待ち）か
     pub pending_kan_draw: bool,
+    /// 自分のポン・チーが成立し、直後の HandUpdated で打牌判断が必要か
+    ///
+    /// HandUpdated は打牌却下時の再同期（#294）にも使われるため、
+    /// 受信しただけでは打牌が必要とは限らない。自分の PlayerCalled
+    /// （ポン・チー）に続く HandUpdated のみを打牌トリガーにする。
+    pub pending_call_discard: bool,
 }
 
 impl CpuGameState {
@@ -104,6 +110,7 @@ impl CpuGameState {
             pending_call_tile: None,
             need_discard_after_call: false,
             pending_kan_draw: false,
+            pending_call_discard: false,
         }
     }
 
@@ -168,6 +175,7 @@ impl CpuGameState {
                 self.pending_call_tile = None;
                 self.need_discard_after_call = false;
                 self.pending_kan_draw = false;
+                self.pending_call_discard = false;
             }
 
             ServerEvent::TileDrawn {
@@ -183,6 +191,7 @@ impl CpuGameState {
                 self.can_riichi = *can_riichi;
                 self.is_furiten = *is_furiten;
                 self.need_discard_after_call = false;
+                self.pending_call_discard = false;
             }
 
             ServerEvent::OtherPlayerDrew {
@@ -281,6 +290,9 @@ impl CpuGameState {
                     call_type,
                     CallType::Ankan | CallType::Daiminkan | CallType::Kakan
                 );
+                // 自分のポン・チーなら直後の HandUpdated で打牌判断が必要
+                self.pending_call_discard = *player == self.my_seat_wind
+                    && matches!(call_type, CallType::Pon | CallType::Chi);
             }
 
             ServerEvent::PlayerRiichi {
@@ -316,10 +328,14 @@ impl CpuGameState {
                 if self.pending_kan_draw {
                     // カン系: 嶺上ツモ（TileDrawn）が来るまで打牌不要
                     self.pending_kan_draw = false;
-                } else {
+                } else if self.pending_call_discard {
                     // ポン/チー後: 打牌が必要
+                    self.pending_call_discard = false;
                     self.need_discard_after_call = true;
                 }
+                // それ以外は打牌却下時の再同期（#294）など手牌の同期のみで、
+                // 打牌してはいけない。ここで打牌すると「却下 → 再同期 →
+                // 再打牌 → 却下」の無限ループで局が停止する。
             }
 
             ServerEvent::RoundWon { scores, .. } => {
@@ -820,6 +836,8 @@ mod tests {
     fn test_hand_updated_after_open_call_requires_discard() {
         let mut state = CpuGameState::new();
         state.my_drawn = Some(Tile::new(Tile::S9));
+        // 自分のポン・チー（PlayerCalled）を受けた直後の状態
+        state.pending_call_discard = true;
 
         state.update(&ServerEvent::HandUpdated {
             hand: vec![Tile::new(Tile::M1), Tile::new(Tile::M2)],
@@ -831,7 +849,64 @@ mod tests {
         );
         assert_eq!(state.my_drawn, None);
         assert!(state.need_discard_after_call);
+        assert!(!state.pending_call_discard);
         assert!(!state.pending_kan_draw);
+    }
+
+    /// 回帰テスト: 自分の鳴きを伴わない HandUpdated（打牌却下時の再同期 #294）
+    /// では打牌判断を始めないこと。ここで打牌すると「却下 → 再同期 →
+    /// 再打牌 → 却下」の無限ループでCPU代打ち中の局が停止していた。
+    #[test]
+    fn test_hand_updated_without_own_call_is_resync_only() {
+        let mut state = CpuGameState::new();
+        state.my_drawn = Some(Tile::new(Tile::S9));
+
+        state.update(&ServerEvent::HandUpdated {
+            hand: vec![Tile::new(Tile::M1), Tile::new(Tile::M2)],
+        });
+
+        // 手牌は同期されるが、打牌は要求されない
+        assert_eq!(
+            state.my_hand,
+            vec![Tile::new(Tile::M1), Tile::new(Tile::M2)]
+        );
+        assert_eq!(state.my_drawn, None);
+        assert!(!state.need_discard_after_call);
+    }
+
+    /// 自分のポン・チーの PlayerCalled だけが pending_call_discard を立てること
+    #[test]
+    fn test_pending_call_discard_set_only_by_own_open_call() {
+        let mut state = CpuGameState::new();
+        state.my_seat_wind = Wind::South;
+
+        // 他家（西）のポンでは立たない
+        state.update(&ServerEvent::PlayerCalled {
+            player: Wind::West,
+            call_type: CallType::Pon,
+            called_tile: Tile::new(Tile::M2),
+            tiles: vec![Tile::new(Tile::M2); 3],
+        });
+        assert!(!state.pending_call_discard);
+
+        // 自分（南）のポンで立つ
+        state.update(&ServerEvent::PlayerCalled {
+            player: Wind::South,
+            call_type: CallType::Pon,
+            called_tile: Tile::new(Tile::M3),
+            tiles: vec![Tile::new(Tile::M3); 3],
+        });
+        assert!(state.pending_call_discard);
+
+        // 自分のカンでは立たない（嶺上ツモ待ち）
+        state.update(&ServerEvent::PlayerCalled {
+            player: Wind::South,
+            call_type: CallType::Ankan,
+            called_tile: Tile::new(Tile::S7),
+            tiles: vec![Tile::new(Tile::S7); 4],
+        });
+        assert!(!state.pending_call_discard);
+        assert!(state.pending_kan_draw);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #299: a regression introduced by #298. The CPU state treated **any** `HandUpdated` (unless waiting for a rinshan draw) as "my pon/chi completed — discard now". Since #298 answers a rejected discard/riichi with a `HandUpdated` resync, one rejected CPU discard entered an endless loop: rejection → resync `HandUpdated` → spurious discard → rejection → … The pending CPU batch queue never drained, so `GameDriver::tick_impl` returned early forever and the round stalled. This surfaced as a flaky main-CI timeout of `test_reconnect_resyncs_and_resumes`, where CPU takeover plus paced (delayed) actions make stale, rejectable discards likely.

Bisection: the test fails 2/12 runs on main (with #298) and 0/12 on the commit before it; with this fix it passes 15/15 consecutive local runs.

## Changes

- `CpuGameState` gains `pending_call_discard`, set only by a `PlayerCalled` for the CPU's **own pon/chi** and consumed by the following `HandUpdated`, which is now the only `HandUpdated` that triggers the post-call discard decision. Kan/pei keep the existing `pending_kan_draw` path. Any other `HandUpdated` — such as the #294 resync — only synchronizes the hand.
- The flag is reset on `GameStarted` and on any `TileDrawn`, mirroring `need_discard_after_call`.
- Regression tests at both the state level (resync `HandUpdated` sets no discard flag; only own pon/chi sets the new flag) and the client level (resync `HandUpdated` returns no action; post-pon `HandUpdated` still discards).

## Testing

- `test_reconnect_resyncs_and_resumes`: 15 consecutive local passes with the fix (main fails ~2/12 without it)
- `cargo build && cargo test` (whole workspace) passes
- `cargo fmt` / `cargo clippy --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)