### PR TITLE
Show the drawn tile for 1 second before auto-discarding after riichi

### DIFF
--- a/crates/mahjong-client/src/game/events.rs
+++ b/crates/mahjong-client/src/game/events.rs
@@ -78,6 +78,8 @@ impl GameState {
                 is_furiten,
             } => {
                 self.drawn = Some(tile);
+                // 新しいツモに対して自動ツモ切りの待ち時間を取り直す
+                self.riichi_auto_discard_at = None;
                 self.remaining_tiles = remaining_tiles;
                 self.is_my_turn = true;
                 self.can_tsumo = can_tsumo;

--- a/crates/mahjong-client/src/game/input.rs
+++ b/crates/mahjong-client/src/game/input.rs
@@ -210,6 +210,7 @@ impl GameState {
     pub fn handle_input(
         &mut self,
         overlay_click: Option<crate::renderer::OverlayClick>,
+        now: f64,
     ) -> Option<ClientAction> {
         use crate::renderer::OverlayClick;
 
@@ -224,8 +225,16 @@ impl GameState {
             return None;
         }
 
-        // リーチ中はツモ切り自動処理（マウス入力不要）
+        // リーチ中はツモ切り自動処理（マウス入力不要）。
+        // ツモ牌をプレイヤーが確認できるよう、表示してから一定時間待って捨てる（#291）。
         if self.is_my_turn && self.is_riichi && self.drawn.is_some() && !self.can_tsumo {
+            let deadline = *self
+                .riichi_auto_discard_at
+                .get_or_insert(now + RIICHI_AUTO_DISCARD_SECS);
+            if now < deadline {
+                return None;
+            }
+            self.riichi_auto_discard_at = None;
             self.drawn.take();
             return Some(ClientAction::Discard { tile: None });
         }

--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -36,6 +36,8 @@ pub const CALL_HOLD_SECS: f64 = 0.9;
 pub const WIN_HOLD_SECS: f64 = 1.2;
 /// 宣言バナーの表示時間（秒）
 pub const CALL_BANNER_SECS: f64 = 1.5;
+/// リーチ中の自動ツモ切りまでの待ち時間（秒）。ツモ牌を見せてから捨てる。
+pub const RIICHI_AUTO_DISCARD_SECS: f64 = 1.0;
 
 /// 鳴き・リーチなどの宣言バナー（発声の代わりに画面へ表示する吹き出し）
 #[derive(Debug, Clone, Copy)]
@@ -158,6 +160,8 @@ pub struct GameState {
     pub self_kan_options: Vec<Tile>,
     /// 自分がリーチ中か
     pub is_riichi: bool,
+    /// リーチ中の自動ツモ切りを実行する時刻（ツモ牌を見せる待機中のみ Some）
+    riichi_auto_discard_at: Option<f64>,
     /// リーチ宣言のための打牌選択中か
     pub riichi_selection_mode: bool,
     /// リーチ可能な手牌インデックス
@@ -354,6 +358,7 @@ impl GameState {
             nuki_dora: false,
             pei_counts: [0; 4],
             can_pei: false,
+            riichi_auto_discard_at: None,
             call_banners: [None; 4],
             pending_events: VecDeque::new(),
             event_hold_until: 0.0,

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -704,15 +704,90 @@ fn test_input_blocked_while_events_pending() {
         player: Wind::South,
         remaining_tiles: 60,
     });
-    assert!(state.handle_input(None).is_none());
+    assert!(state.handle_input(None, 100.0).is_none());
     assert!(state.drawn.is_some());
 
-    // キューを消化すれば打牌できる
+    // キューを消化すれば打牌できる（待ち時間経過後）
     state.process_events(100.0);
+    assert!(state.handle_input(None, 100.0).is_none());
     assert!(matches!(
-        state.handle_input(None),
+        state.handle_input(None, 100.0 + RIICHI_AUTO_DISCARD_SECS),
         Some(ClientAction::Discard { tile: None })
     ));
+}
+
+/// リーチ中の自動ツモ切りはツモ牌を表示したまま一定時間待ってから発火する
+/// （#291 回帰テスト）。以前は即時に打牌されツモ牌を確認できなかった。
+#[test]
+fn test_riichi_auto_discard_waits_before_firing() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    state.is_riichi = true;
+    state.handle_event(ServerEvent::TileDrawn {
+        tile: Tile::new(Tile::M1),
+        remaining_tiles: 60,
+        can_tsumo: false,
+        can_riichi: false,
+        is_furiten: false,
+    });
+
+    // 待ち時間中は打牌されず、ツモ牌が表示されたまま
+    assert!(state.handle_input(None, 100.0).is_none());
+    assert!(state.drawn.is_some());
+    assert!(
+        state
+            .handle_input(None, 100.0 + RIICHI_AUTO_DISCARD_SECS / 2.0)
+            .is_none()
+    );
+    assert!(state.drawn.is_some());
+
+    // 待ち時間が経過したら自動でツモ切りする
+    assert!(matches!(
+        state.handle_input(None, 100.0 + RIICHI_AUTO_DISCARD_SECS),
+        Some(ClientAction::Discard { tile: None })
+    ));
+    assert!(state.drawn.is_none());
+}
+
+/// 自動ツモ切りの待ち時間は新しいツモのたびに取り直されること。
+/// 前巡の待機時刻が残ると、次のツモが即時に切られてしまう。
+#[test]
+fn test_riichi_auto_discard_timer_resets_on_new_draw() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    state.is_riichi = true;
+    state.handle_event(ServerEvent::TileDrawn {
+        tile: Tile::new(Tile::M1),
+        remaining_tiles: 60,
+        can_tsumo: false,
+        can_riichi: false,
+        is_furiten: false,
+    });
+
+    // 1巡目: 待機開始 → 発火
+    assert!(state.handle_input(None, 100.0).is_none());
+    assert!(
+        state
+            .handle_input(None, 100.0 + RIICHI_AUTO_DISCARD_SECS)
+            .is_some()
+    );
+
+    // 2巡目のツモ: 待ち時間が取り直され、即時には切られない
+    state.handle_event(ServerEvent::TileDrawn {
+        tile: Tile::new(Tile::M2),
+        remaining_tiles: 56,
+        can_tsumo: false,
+        can_riichi: false,
+        is_furiten: false,
+    });
+    let now = 110.0;
+    assert!(state.handle_input(None, now).is_none());
+    assert!(state.drawn.is_some());
+    assert!(
+        state
+            .handle_input(None, now + RIICHI_AUTO_DISCARD_SECS)
+            .is_some()
+    );
 }
 
 #[test]

--- a/crates/mahjong-client/src/main.rs
+++ b/crates/mahjong-client/src/main.rs
@@ -406,7 +406,7 @@ async fn main() {
 
             GamePhase::Playing => {
                 if let Some(ref mut adp) = adapter {
-                    let action = game_state.handle_input(overlay_click);
+                    let action = game_state.handle_input(overlay_click, get_time());
                     if let Some(act) = action {
                         adp.send_action(act);
                     }


### PR DESCRIPTION
## Summary

Closes #291.

After the player declares riichi, the automatic tsumogiri used to fire on the very next frame, so the drawn tile was never visible on screen. This PR makes the client show the drawn tile, wait 1 second, and then auto-discard it — matching the pacing of CPU discards (`CPU_ACTION_DELAY_SECONDS`).

## Changes

- Added `RIICHI_AUTO_DISCARD_SECS` (1.0 s) and a `riichi_auto_discard_at: Option<f64>` deadline field to `GameState` (`game/mod.rs`).
- `GameState::handle_input` now takes `now: f64` (same clock as `process_events`). During riichi, the auto-discard arms the deadline on the first frame and keeps `drawn` displayed until it elapses, then sends `Discard { tile: None }` (`game/input.rs`).
- The deadline is cleared on every `TileDrawn` event so each new draw gets a fresh 1-second wait, including after a rejected-discard resync (`game/events.rs`).
- `main.rs` passes `get_time()` to `handle_input`.

## Tests

- Updated `test_input_blocked_while_events_pending` for the new signature and delayed firing.
- Added `test_riichi_auto_discard_waits_before_firing`: no discard during the wait, drawn tile stays visible, discard fires after the delay.
- Added `test_riichi_auto_discard_timer_resets_on_new_draw`: a new draw re-arms the timer instead of reusing a stale deadline.

`cargo build`, `cargo test`, `cargo fmt`, and `cargo clippy` all pass with no warnings.

## Note

While working on this I noticed a pre-existing issue (not addressed here): during riichi in sanma with nuki dora, drawing a north sets `can_pei` and renders the pei button, but the auto-tsumogiri path returns before overlay clicks are processed, so the button is unclickable. With this PR the button is now visible for the 1-second wait, making the conflict easier to notice. This should be handled as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)