### PR TITLE
Implement yakuman pao (liability payment) (#134)

### DIFF
--- a/crates/mahjong-core/src/settings.rs
+++ b/crates/mahjong-core/src/settings.rs
@@ -53,6 +53,10 @@ pub struct Settings {
     /// 北抜きドラありかなしか（三人麻雀のみ有効。デフォルトはあり）
     /// ありの場合: 手番中に北風牌を晒して1枚につきドラ1として扱い、牌山から補充する。
     pub nuki_dora: bool,
+    /// 役満の包（責任払い）ありかなしか（デフォルトはあり）
+    /// ありの場合: 大三元・大四喜・四槓子を確定させる鳴きをさせたプレイヤーが、
+    /// ツモ和了なら全額、他家への放銃なら放銃者と折半で支払う。
+    pub yakuman_pao: bool,
 }
 
 impl Default for Settings {
@@ -75,6 +79,7 @@ impl Settings {
             forbid_swap_calling: true,
             three_player: false,
             nuki_dora: true,
+            yakuman_pao: true,
         }
     }
 

--- a/crates/mahjong-server/src/round/calls.rs
+++ b/crates/mahjong-server/src/round/calls.rs
@@ -1,6 +1,8 @@
 //! 鳴き（ロン・ポン・カン・チー）の判定と解決
 
+use mahjong_core::hand_info::meld::MeldType;
 use mahjong_core::tile::{Tile, TileType};
+use mahjong_core::winning_hand::name::Kind;
 
 use crate::player::Player;
 use crate::protocol::{AvailableCall, CallType, DrawReason, ServerEvent};
@@ -391,13 +393,27 @@ impl Round {
             );
 
             let winner_is_dealer = self.players[winner].is_dealer();
-            let deltas = scoring::calculate_ron_score_deltas(
-                winner,
-                loser,
-                &score_result,
-                winner_is_dealer,
-                honba_for_this,
-            );
+            // 包（責任払い）: 対象役満が成立していれば包のプレイヤーが放銃者と折半で支払う
+            let deltas = if let Some(pao_player) =
+                self.pao_player_for_win(winner, &score_result.yaku_list)
+            {
+                scoring::calculate_ron_score_deltas_with_pao(
+                    winner,
+                    loser,
+                    pao_player,
+                    &score_result,
+                    winner_is_dealer,
+                    honba_for_this,
+                )
+            } else {
+                scoring::calculate_ron_score_deltas(
+                    winner,
+                    loser,
+                    &score_result,
+                    winner_is_dealer,
+                    honba_for_this,
+                )
+            };
 
             // 供託棒は打順最優先の和了者（winner_data の先頭）のみ取得
             let riichi_bonus = if winner_data.is_empty() {
@@ -481,6 +497,48 @@ impl Round {
         });
     }
 
+    /// 包（責任払い）の成立を判定して記録する
+    ///
+    /// ポン・大明カンの直後に呼ぶ。鳴きによって役満が確定した場合、
+    /// 鳴かせたプレイヤー（discarder）を責任払いの対象として記録する。
+    /// - 大三元: 3種類目の三元牌の刻子を鳴きで完成させた
+    /// - 大四喜: 4種類目の風牌の刻子を鳴きで完成させた
+    /// - 四槓子: 4回目のカンを大明カンで完成させた
+    fn record_pao_if_confirmed(
+        &mut self,
+        caller: usize,
+        discarder: usize,
+        called_tile: Tile,
+        is_daiminkan: bool,
+    ) {
+        if !self.settings.yakuman_pao {
+            return;
+        }
+
+        let tt = called_tile.get();
+        let count_melds_in = |range: std::ops::RangeInclusive<TileType>| {
+            self.players[caller]
+                .hand
+                .melds()
+                .iter()
+                .filter(|meld| meld.category != MeldType::Chi)
+                .filter(|meld| range.contains(&meld.tiles[0].get()))
+                .count()
+        };
+        let dragon_meld_count = count_melds_in(Tile::Z5..=Tile::Z7);
+        let wind_meld_count = count_melds_in(Tile::Z1..=Tile::Z4);
+
+        if (Tile::Z5..=Tile::Z7).contains(&tt) && dragon_meld_count == 3 {
+            self.pao[caller].push((Kind::BigDragons, discarder));
+        }
+        if (Tile::Z1..=Tile::Z4).contains(&tt) && wind_meld_count == 4 {
+            self.pao[caller].push((Kind::BigWinds, discarder));
+        }
+        if is_daiminkan && self.players[caller].kan_count() == 4 {
+            self.pao[caller].push((Kind::FourQuads, discarder));
+        }
+    }
+
     /// ポンを実行する
     pub(super) fn execute_pon(
         &mut self,
@@ -491,6 +549,7 @@ impl Round {
     ) {
         let from = Player::meld_from_relative(caller, discarder, self.player_count);
         self.players[caller].do_pon(called_tile, hand_tile_types, from);
+        self.record_pao_if_confirmed(caller, discarder, called_tile, false);
 
         // 捨て牌を「鳴かれた」としてマーク
         self.mark_last_discard_as_called(discarder);
@@ -538,6 +597,7 @@ impl Round {
     pub(super) fn execute_daiminkan(&mut self, caller: usize, discarder: usize, called_tile: Tile) {
         let from = Player::meld_from_relative(caller, discarder, self.player_count);
         self.players[caller].do_daiminkan(called_tile, from);
+        self.record_pao_if_confirmed(caller, discarder, called_tile, true);
 
         self.mark_last_discard_as_called(discarder);
         self.invalidate_first_turn_flags();

--- a/crates/mahjong-server/src/round/mod.rs
+++ b/crates/mahjong-server/src/round/mod.rs
@@ -12,8 +12,10 @@ mod test_helpers;
 mod turn;
 mod win;
 
+use mahjong_core::scoring::score::ScoreItem;
 use mahjong_core::settings::Settings;
 use mahjong_core::tile::{Tile, TileType, Wind};
+use mahjong_core::winning_hand::name::Kind;
 
 use crate::player::Player;
 use crate::protocol::{AvailableCall, CallType, MeldTiles, PlayerHandInfo, ServerEvent};
@@ -118,6 +120,9 @@ pub struct Round {
     pub call_state: Option<CallState>,
     /// 直前のツモが嶺上牌か
     pub last_draw_was_dead_wall: bool,
+    /// 包（責任払い）の記録。プレイヤーごとの (確定した役満, 責任を負うプレイヤー) のリスト。
+    /// 大三元・大四喜・四槓子を確定させる鳴きが発生した時点で記録される。
+    pub pao: [Vec<(Kind, usize)>; 4],
     /// プレイヤー人数（四麻=4、三麻=3。三麻ではシート3はダミー）
     pub player_count: usize,
     /// ゲーム設定
@@ -253,9 +258,29 @@ impl Round {
             events,
             call_state: None,
             last_draw_was_dead_wall: false,
+            pao: std::array::from_fn(|_| Vec::new()),
             player_count,
             settings,
         }
+    }
+
+    /// 和了役に包（責任払い）の対象役満が含まれる場合、責任を負うプレイヤーを返す
+    ///
+    /// 複数の包が記録されている場合は、後から成立した包を優先する。
+    pub(super) fn pao_player_for_win(
+        &self,
+        winner: usize,
+        yaku_list: &[(ScoreItem, u32)],
+    ) -> Option<usize> {
+        self.pao[winner]
+            .iter()
+            .rev()
+            .find_map(|(pao_kind, liable)| {
+                yaku_list
+                    .iter()
+                    .any(|(item, _)| matches!(item, ScoreItem::Yaku(kind) if kind == pao_kind))
+                    .then_some(*liable)
+            })
     }
 
     /// 指定プレイヤーの次の手番プレイヤーを返す（プレイヤー人数で循環）

--- a/crates/mahjong-server/src/round/tests.rs
+++ b/crates/mahjong-server/src/round/tests.rs
@@ -1607,6 +1607,175 @@ fn test_pei_win_adds_pei_dora() {
     );
 }
 
+// ===== 役満の包（責任払い #134） =====
+
+/// 3種類目の三元牌をポンさせたプレイヤーが包として記録される
+#[test]
+fn test_pao_recorded_on_third_dragon_pon() {
+    let mut round =
+        Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
+    // プレイヤー1: 白・發をポン済みで、手牌に中が2枚
+    round.players[1].hand = Hand::from("34m88s77z 555z 666z");
+
+    round.execute_pon(
+        1,
+        0,
+        Tile::new(Tile::Z7),
+        [Tile::new(Tile::Z7), Tile::new(Tile::Z7)],
+    );
+
+    assert_eq!(round.pao[1], vec![(Kind::BigDragons, 0)]);
+}
+
+/// 2種類目の三元牌のポンでは包は記録されない
+#[test]
+fn test_pao_not_recorded_on_second_dragon_pon() {
+    let mut round =
+        Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
+    // プレイヤー1: 白のみポン済み
+    round.players[1].hand = Hand::from("34m88s66z77z 555z");
+
+    round.execute_pon(
+        1,
+        0,
+        Tile::new(Tile::Z6),
+        [Tile::new(Tile::Z6), Tile::new(Tile::Z6)],
+    );
+
+    assert!(round.pao[1].is_empty());
+}
+
+/// 4種類目の風牌をポンさせたプレイヤーが包として記録される
+#[test]
+fn test_pao_recorded_on_fourth_wind_pon() {
+    let mut round =
+        Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
+    // プレイヤー1: 東・南・西をポン済みで、手牌に北が2枚
+    round.players[1].hand = Hand::from("88s44z 111z 222z 333z");
+
+    round.execute_pon(
+        1,
+        2,
+        Tile::new(Tile::Z4),
+        [Tile::new(Tile::Z4), Tile::new(Tile::Z4)],
+    );
+
+    assert_eq!(round.pao[1], vec![(Kind::BigWinds, 2)]);
+}
+
+/// 4回目のカンを大明カンさせたプレイヤーが包として記録される
+#[test]
+fn test_pao_recorded_on_fourth_kan_daiminkan() {
+    let mut round =
+        Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
+    // プレイヤー1: 3回カン済みで、手牌に東が3枚
+    round.players[1].hand = Hand::from("44p111z 1111m 2222s 9999p");
+
+    round.execute_daiminkan(1, 0, Tile::new(Tile::Z1));
+
+    assert_eq!(round.pao[1], vec![(Kind::FourQuads, 0)]);
+}
+
+/// yakuman_pao 無効時は包が記録されない
+#[test]
+fn test_pao_not_recorded_when_disabled() {
+    let settings = Settings {
+        yakuman_pao: false,
+        ..Settings::new()
+    };
+    let mut round = Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, 4, settings);
+    round.players[1].hand = Hand::from("34m88s77z 555z 666z");
+
+    round.execute_pon(
+        1,
+        0,
+        Tile::new(Tile::Z7),
+        [Tile::new(Tile::Z7), Tile::new(Tile::Z7)],
+    );
+
+    assert!(round.pao[1].is_empty());
+}
+
+/// 包ありの大三元ツモ: 包のプレイヤーが全額を支払う
+#[test]
+fn test_pao_tsumo_daisangen_full_payment() {
+    let mut round =
+        Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
+    round.drain_events();
+    round.pao[1] = vec![(Kind::BigDragons, 0)];
+    round.players[1].hand = Hand::from("34m88s 555z 666z 777z 2m");
+    round.players[1].is_first_turn = false;
+    round.current_player = 1;
+    round.phase = TurnPhase::WaitForDiscard;
+
+    assert!(round.do_tsumo());
+
+    // 子の役満ツモ32000点を包のプレイヤー0が全額支払う
+    assert_eq!(round.players[0].score, 25000 - 32000);
+    assert_eq!(round.players[1].score, 25000 + 32000);
+    assert_eq!(round.players[2].score, 25000);
+    assert_eq!(round.players[3].score, 25000);
+}
+
+/// 包ありの大三元ロン（他家に放銃）: 放銃者と包のプレイヤーで折半
+#[test]
+fn test_pao_ron_daisangen_split_payment() {
+    let mut round =
+        Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
+    round.drain_events();
+    round.pao[1] = vec![(Kind::BigDragons, 0)];
+    round.players[1].hand = Hand::from("34m88s 555z 666z 777z");
+    round.players[1].is_first_turn = false;
+
+    round.execute_ron(vec![1], 3, Tile::new(Tile::M2), false);
+
+    // 子の役満ロン32000点を放銃者3と包のプレイヤー0で折半
+    assert_eq!(round.players[0].score, 25000 - 16000);
+    assert_eq!(round.players[1].score, 25000 + 32000);
+    assert_eq!(round.players[2].score, 25000);
+    assert_eq!(round.players[3].score, 25000 - 16000);
+}
+
+/// 包のプレイヤー自身への放銃: 通常のロンと同じ（全額支払い）
+#[test]
+fn test_pao_ron_from_pao_player_pays_full_amount() {
+    let mut round =
+        Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
+    round.drain_events();
+    round.pao[1] = vec![(Kind::BigDragons, 0)];
+    round.players[1].hand = Hand::from("34m88s 555z 666z 777z");
+    round.players[1].is_first_turn = false;
+
+    round.execute_ron(vec![1], 0, Tile::new(Tile::M2), false);
+
+    assert_eq!(round.players[0].score, 25000 - 32000);
+    assert_eq!(round.players[1].score, 25000 + 32000);
+    assert_eq!(round.players[2].score, 25000);
+    assert_eq!(round.players[3].score, 25000);
+}
+
+/// 記録された包と異なる役満で和了した場合は通常の支払い
+#[test]
+fn test_pao_not_applied_for_unrelated_yakuman() {
+    let mut round =
+        Round::new_with_seed(42, Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
+    round.drain_events();
+    // 四槓子の包が記録されているが、和了は大三元（四槓子は不成立）
+    round.pao[1] = vec![(Kind::FourQuads, 0)];
+    round.players[1].hand = Hand::from("34m88s 555z 666z 777z 2m");
+    round.players[1].is_first_turn = false;
+    round.current_player = 1;
+    round.phase = TurnPhase::WaitForDiscard;
+
+    assert!(round.do_tsumo());
+
+    // 通常のツモ支払い: 親16000・子8000ずつ
+    assert_eq!(round.players[0].score, 25000 - 16000);
+    assert_eq!(round.players[1].score, 25000 + 32000);
+    assert_eq!(round.players[2].score, 25000 - 8000);
+    assert_eq!(round.players[3].score, 25000 - 8000);
+}
+
 #[test]
 fn test_sanma_three_winds_draw() {
     let mut round = sanma_round(42, 0);

--- a/crates/mahjong-server/src/round/win.rs
+++ b/crates/mahjong-server/src/round/win.rs
@@ -234,7 +234,7 @@ impl Round {
         );
 
         // 点数移動を計算（三麻はツモ損: いない北家分は貰えない）
-        let deltas = scoring::calculate_tsumo_score_deltas(
+        let mut deltas = scoring::calculate_tsumo_score_deltas(
             winner,
             &score_result,
             winner_is_dealer,
@@ -242,6 +242,10 @@ impl Round {
             self.honba,
             self.player_count,
         );
+        // 包（責任払い）: 対象役満が成立していれば包のプレイヤーが全額を支払う
+        if let Some(pao_player) = self.pao_player_for_win(winner, &score_result.yaku_list) {
+            scoring::apply_pao_to_tsumo_deltas(&mut deltas, winner, pao_player);
+        }
         let riichi_sticks = self.riichi_sticks;
 
         // 点数を適用

--- a/crates/mahjong-server/src/scoring.rs
+++ b/crates/mahjong-server/src/scoring.rs
@@ -277,6 +277,64 @@ pub fn calculate_tsumo_score_deltas(
     deltas
 }
 
+/// ツモ和了の点数移動に包（責任払い）を適用する
+///
+/// 包のプレイヤーが他のプレイヤー全員分の支払いを肩代わりする。
+/// 本場ボーナスやツモ損（三麻）を含む支払い総額がそのまま包のプレイヤーに移る。
+///
+/// - `deltas`: `calculate_tsumo_score_deltas` の結果
+/// - `winner`: 和了プレイヤーのインデックス
+/// - `pao_player`: 責任払いを負うプレイヤーのインデックス（winner とは異なること）
+pub fn apply_pao_to_tsumo_deltas(deltas: &mut [i32; 4], winner: usize, pao_player: usize) {
+    let mut total_payment = 0i32;
+    for (i, delta) in deltas.iter_mut().enumerate() {
+        if i != winner {
+            total_payment += *delta;
+            *delta = 0;
+        }
+    }
+    deltas[pao_player] = total_payment;
+}
+
+/// ロン和了の点数移動を包（責任払い）込みで計算する
+///
+/// 包のプレイヤーと放銃者が和了点を折半して支払う。
+/// 本場ボーナスは放銃者が支払う。
+/// 放銃者自身が包のプレイヤーの場合は通常のロンと同じ（全額支払い）。
+///
+/// 戻り値: 各プレイヤーの点数変動 (正=増加、負=減少)。合計は必ず0。
+pub fn calculate_ron_score_deltas_with_pao(
+    winner: usize,
+    loser: usize,
+    pao_player: usize,
+    score_result: &ScoreResult,
+    winner_is_dealer: bool,
+    honba: usize,
+) -> [i32; 4] {
+    if pao_player == loser {
+        return calculate_ron_score_deltas(winner, loser, score_result, winner_is_dealer, honba);
+    }
+
+    let mut deltas = [0i32; 4];
+    let honba_bonus = honba as i32 * 300;
+
+    let ron_points = if winner_is_dealer {
+        score_result.dealer_ron as i32
+    } else {
+        score_result.non_dealer_ron as i32
+    };
+
+    // 折半（端数が出る場合は放銃者が多く支払う）
+    let pao_half = ron_points / 2;
+    let loser_half = ron_points - pao_half;
+
+    deltas[winner] = ron_points + honba_bonus;
+    deltas[loser] = -(loser_half + honba_bonus);
+    deltas[pao_player] = -pao_half;
+
+    deltas
+}
+
 /// 和了結果にドラ・赤ドラ・裏ドラの翻を加算する
 ///
 /// 役判定後の点数計算結果にドラ関連の翻を追加し、
@@ -618,6 +676,99 @@ mod tests {
         );
         // 1（タンヤオ）+ 2（北ドラ）+ 2（表示牌ドラ）= 5翻
         assert_eq!(score.han, 5);
+    }
+
+    fn make_yakuman_score() -> ScoreResult {
+        ScoreResult {
+            han: 13,
+            fu: 0,
+            rank: ScoreRank::Yakuman,
+            dealer_ron: 48000,
+            dealer_tsumo_all: 16000,
+            non_dealer_ron: 32000,
+            non_dealer_tsumo_dealer: 16000,
+            non_dealer_tsumo_non_dealer: 8000,
+            yaku_list: vec![(ScoreItem::Yaku(Kind::BigDragons), 13)],
+            has_opened: true,
+            fu_result: FuResult {
+                total: 0,
+                details: vec![],
+            },
+        }
+    }
+
+    /// 包のツモ和了: 包のプレイヤーが全額を支払う
+    #[test]
+    fn test_pao_tsumo_non_dealer_yakuman() {
+        let score = make_yakuman_score();
+        let mut deltas = calculate_tsumo_score_deltas(1, &score, false, 0, 0, 4);
+        apply_pao_to_tsumo_deltas(&mut deltas, 1, 2);
+        assert_eq!(deltas[0], 0);
+        assert_eq!(deltas[1], 32000); // 16000 + 8000 + 8000
+        assert_eq!(deltas[2], -32000); // 包が全額支払い
+        assert_eq!(deltas[3], 0);
+        assert_eq!(deltas.iter().sum::<i32>(), 0);
+    }
+
+    /// 包のツモ和了（本場あり）: 本場ボーナスも包のプレイヤーが支払う
+    #[test]
+    fn test_pao_tsumo_dealer_yakuman_with_honba() {
+        let score = make_yakuman_score();
+        let mut deltas = calculate_tsumo_score_deltas(0, &score, true, 0, 2, 4);
+        apply_pao_to_tsumo_deltas(&mut deltas, 0, 3);
+        assert_eq!(deltas[0], 48600); // (16000+200) * 3
+        assert_eq!(deltas[1], 0);
+        assert_eq!(deltas[2], 0);
+        assert_eq!(deltas[3], -48600);
+        assert_eq!(deltas.iter().sum::<i32>(), 0);
+    }
+
+    /// 三麻の包ツモ: ツモ損による欠損はそのまま（総額のみ肩代わり）
+    #[test]
+    fn test_pao_tsumo_sanma_tsumo_loss() {
+        let score = make_yakuman_score();
+        let mut deltas = calculate_tsumo_score_deltas(1, &score, false, 0, 0, 3);
+        apply_pao_to_tsumo_deltas(&mut deltas, 1, 2);
+        assert_eq!(deltas[0], 0);
+        assert_eq!(deltas[1], 24000); // 16000 + 8000（ツモ損）
+        assert_eq!(deltas[2], -24000);
+        assert_eq!(deltas[3], 0);
+        assert_eq!(deltas.iter().sum::<i32>(), 0);
+    }
+
+    /// 包のロン和了（他家への放銃）: 放銃者と包のプレイヤーで折半
+    #[test]
+    fn test_pao_ron_split_between_loser_and_pao() {
+        let score = make_yakuman_score();
+        let deltas = calculate_ron_score_deltas_with_pao(1, 3, 0, &score, false, 0);
+        assert_eq!(deltas[1], 32000);
+        assert_eq!(deltas[3], -16000); // 放銃者が半額
+        assert_eq!(deltas[0], -16000); // 包が半額
+        assert_eq!(deltas[2], 0);
+        assert_eq!(deltas.iter().sum::<i32>(), 0);
+    }
+
+    /// 包のロン和了（本場あり）: 本場ボーナスは放銃者が支払う
+    #[test]
+    fn test_pao_ron_honba_paid_by_loser() {
+        let score = make_yakuman_score();
+        let deltas = calculate_ron_score_deltas_with_pao(1, 3, 0, &score, false, 2);
+        assert_eq!(deltas[1], 32600);
+        assert_eq!(deltas[3], -16600); // 半額 + 本場600
+        assert_eq!(deltas[0], -16000);
+        assert_eq!(deltas.iter().sum::<i32>(), 0);
+    }
+
+    /// 包のプレイヤー自身への放銃: 通常のロンと同じ（全額支払い）
+    #[test]
+    fn test_pao_ron_from_pao_player_pays_full() {
+        let score = make_yakuman_score();
+        let deltas = calculate_ron_score_deltas_with_pao(1, 0, 0, &score, false, 1);
+        assert_eq!(deltas[1], 32300);
+        assert_eq!(deltas[0], -32300);
+        assert_eq!(deltas[2], 0);
+        assert_eq!(deltas[3], 0);
+        assert_eq!(deltas.iter().sum::<i32>(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements pao (包 / sekinin-barai, liability payment) for yakuman, per docs/glossary.md and standard riichi rules. Closes #134.

### Rules implemented

Pao is recorded at the moment a call confirms one of the following yakuman:

- **Big Dragons (大三元)**: a pon/open kan completes the third dragon triplet as a meld
- **Big Winds (大四喜)**: a pon/open kan completes the fourth wind triplet as a meld
- **Four Quads (四槓子)**: the fourth kan is an open kan (daiminkan)

Payment when the winner's hand includes the confirmed yakuman:

- **Tsumo**: the liable player pays the full amount (including honba; the sanma tsumo-loss total is carried over as-is)
- **Ron off another player**: the liable player and the discarder each pay half; honba is paid by the discarder
- **Ron off the liable player**: normal full payment

Added kans (kakan) and concealed kans do not trigger pao, since the fourth tile is self-supplied.

### Implementation notes

- `Round.pao` records `(Kind, liable player)` per player; detection runs right after `execute_pon` / `execute_daiminkan`
- Payment is applied in `do_tsumo` (redirect all payments to the liable player) and `execute_ron` (split calculation), only when the recorded yakuman actually appears in the winning yaku list
- New `Settings::yakuman_pao` rule flag (default: on), following the existing rule-flag pattern; old clients' JSON still deserializes via the struct-level `serde(default)`
- Since yakuman do not stack in this codebase (base points fixed at 8000), pao applies to the whole payment when the confirmed yakuman is present

## Test plan

- Unit tests for the new score-delta functions (tsumo full payment, ron split, honba handling, sanma tsumo loss, ron off the liable player)
- Round integration tests: pao recording for 3rd dragon pon / 4th wind pon / 4th kan daiminkan, negative cases (2nd dragon, flag disabled), and end-to-end score movement for tsumo/ron with pao
- `cargo test` (all crates), `cargo fmt`, `cargo clippy` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)