### PR TITLE
Show turn indicator on the center panel

### DIFF
--- a/crates/mahjong-client/src/game/events.rs
+++ b/crates/mahjong-client/src/game/events.rs
@@ -68,6 +68,7 @@ impl GameState {
                 ];
                 self.last_discarder = None;
                 self.call_banners = [None; 4];
+                self.turn_player = None;
             }
 
             ServerEvent::TileDrawn {
@@ -82,6 +83,7 @@ impl GameState {
                 self.riichi_auto_discard_at = None;
                 self.remaining_tiles = remaining_tiles;
                 self.is_my_turn = true;
+                self.turn_player = self.seat_wind;
                 self.can_tsumo = can_tsumo;
                 self.can_riichi = can_riichi;
                 self.is_furiten = is_furiten;
@@ -105,6 +107,7 @@ impl GameState {
                 remaining_tiles,
             } => {
                 self.remaining_tiles = remaining_tiles;
+                self.turn_player = Some(player);
                 let relative_idx = self.relative_player_index(player);
                 if relative_idx > 0 {
                     // ツモ牌は手牌の右に張り出して表示する（手牌の枚数には含めない）
@@ -188,6 +191,11 @@ impl GameState {
                 self.available_calls.clear();
                 self.call_target_tile = None;
                 self.refresh_self_kan_options();
+
+                // 鳴いたプレイヤーに手番が移る（ロンは局が終わるので対象外）
+                if !matches!(call_type, CallType::Ron) {
+                    self.turn_player = Some(player);
+                }
 
                 // CallType → MeldType 変換
                 let category = Self::call_type_to_meld_type(&call_type);
@@ -493,6 +501,7 @@ impl GameState {
                     self.apply_current_win_result();
                     self.phase = GamePhase::RoundResult;
                     self.is_my_turn = false;
+                    self.turn_player = None;
                     self.available_calls.clear();
                     self.clear_riichi_selection();
                     self.self_kan_options.clear();
@@ -531,6 +540,7 @@ impl GameState {
                 self.result_message = Some(msg);
                 self.phase = GamePhase::RoundResult;
                 self.is_my_turn = false;
+                self.turn_player = None;
                 self.available_calls.clear();
                 self.clear_riichi_selection();
                 self.self_kan_options.clear();

--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -211,6 +211,8 @@ pub struct GameState {
     pub win_result_index: usize,
     /// 自分の手番か
     pub is_my_turn: bool,
+    /// 現在手番のプレイヤーの席風（ツモ・鳴きイベントで更新。局の開始・終了で None）
+    pub turn_player: Option<Wind>,
     /// ゲームフェーズ
     pub phase: GamePhase,
     /// 鳴き可能な選択肢
@@ -346,6 +348,7 @@ impl GameState {
             win_results: Vec::new(),
             win_result_index: 0,
             is_my_turn: false,
+            turn_player: None,
             phase: GamePhase::TopMenu,
             available_calls: Vec::new(),
             call_target_tile: None,

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -1017,3 +1017,62 @@ fn test_sanma_pei_with_drawn_keeps_hand_count() {
     assert_eq!(other.concealed_count, 13);
     assert!(!other.has_drawn);
 }
+
+/// 手番プレイヤー（turn_player）がイベントに追従して更新されること。
+/// 中央パネルの手番インジケーター表示に使う（#307）。
+#[test]
+fn test_turn_player_tracks_events() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    assert_eq!(state.turn_player, None, "局開始直後は手番未確定");
+
+    // 自分（東）のツモで自分の手番になる
+    state.handle_event(ServerEvent::TileDrawn {
+        tile: Tile::new(Tile::P2),
+        remaining_tiles: 69,
+        can_tsumo: false,
+        can_riichi: false,
+        is_furiten: false,
+    });
+    assert_eq!(state.turn_player, Some(Wind::East));
+
+    // 打牌後、下家（南）のツモで手番が移る
+    state.handle_event(ServerEvent::TileDiscarded {
+        player: Wind::East,
+        tile: Tile::new(Tile::P2),
+        is_tsumogiri: true,
+        hand_index: None,
+    });
+    state.handle_event(ServerEvent::OtherPlayerDrew {
+        player: Wind::South,
+        remaining_tiles: 68,
+    });
+    assert_eq!(state.turn_player, Some(Wind::South));
+
+    // 南の打牌を西がポン → 手番は西へ飛ぶ
+    let tile = Tile::new(Tile::S5);
+    state.handle_event(ServerEvent::TileDiscarded {
+        player: Wind::South,
+        tile,
+        is_tsumogiri: false,
+        hand_index: None,
+    });
+    state.handle_event(ServerEvent::PlayerCalled {
+        player: Wind::West,
+        call_type: CallType::Pon,
+        called_tile: tile,
+        tiles: vec![tile, tile],
+    });
+    assert_eq!(state.turn_player, Some(Wind::West));
+
+    // 流局で手番表示は消える
+    state.handle_event(ServerEvent::RoundDraw {
+        scores: [25000; 4],
+        reason: mahjong_server::protocol::DrawReason::Exhaustive,
+        tenpai: vec![],
+        riichi_sticks: 0,
+        player_hands: vec![],
+        declarer: None,
+    });
+    assert_eq!(state.turn_player, None, "流局後も手番表示が残っている");
+}

--- a/crates/mahjong-client/src/renderer/board.rs
+++ b/crates/mahjong-client/src/renderer/board.rs
@@ -273,6 +273,11 @@ pub(super) fn draw_center_panel(state: &GameState, font: Option<&Font>) {
 
         set_camera(&make_board_camera(rotation));
 
+        // 手番プレイヤー側の辺を発光させる（テキストより先に描いて重なりを避ける）
+        if state.turn_player == Some(display_wind) {
+            draw_turn_indicator_edge(BOARD_CENTER_X - half, BOARD_CENTER_Y + half, panel_size);
+        }
+
         // 風（ゴールド）＋得点（千点単位）を中心の各方向に描画
         theme::draw_text_centered(
             font,
@@ -331,6 +336,28 @@ pub(super) fn draw_center_panel(state: &GameState, font: Option<&Font>) {
         21,
         theme::TEXT_BR,
     );
+}
+
+/// 中央パネルの手番プレイヤー側の辺に、ゆっくり明滅するゴールドのグローを描く。
+///
+/// `(x, y)` は辺の左端、`w` は辺の長さ。各プレイヤーの回転カメラ内で
+/// 手前側（下辺）に描かれる前提なので、呼び出し側で回転を切り替える。
+fn draw_turn_indicator_edge(x: f32, y: f32, w: f32) {
+    // 約2秒周期でゆるやかに明滅させる（強すぎない範囲で強弱をつける）
+    let pulse = 0.775 + 0.225 * (get_time() * std::f64::consts::TAU / 2.0).sin() as f32;
+
+    // パネルの角丸（半径5）にかからないよう辺の内側に収める
+    let inset = 6.0;
+    let (x, w) = (x + inset, w - 2.0 * inset);
+
+    // 中心線から外側へ薄くなる帯を重ねてグローを表現する
+    for i in 0..4 {
+        let spread = 2.0 + i as f32 * 2.0;
+        let alpha = 0.16 * pulse / (i as f32 + 1.0);
+        draw_rectangle(x, y - spread, w, spread * 2.0, theme::rgba(0xffd84a, alpha));
+    }
+    // 中心の明るいライン
+    draw_rectangle(x, y - 1.5, w, 3.0, theme::rgba(0xffe066, 0.95 * pulse));
 }
 
 pub(super) fn draw_discards(state: &GameState, tile_textures: &TileTextures) {


### PR DESCRIPTION
## Summary
Closes #307

The board previously gave no clear indication of whose turn it is. This PR adds a turn indicator to the center info panel: the edge of the panel facing the active player now glows with a slowly pulsing gold light.

## Changes
- **`GameState.turn_player`** — new field tracking the seat wind of the player whose turn it is:
  - Set on `TileDrawn` (own turn) and `OtherPlayerDrew` (other player's turn)
  - Set on `PlayerCalled` for chi/pon/kan (the caller must discard next); ron is excluded since the round ends
  - Cleared on `GameStarted`, `RoundWon`, and `RoundDraw`
- **`draw_center_panel`** — draws a pulsing gold glow (layered translucent bands plus a bright core line, ~2s cycle) along the panel edge facing the turn player, reusing the existing per-player rotated camera loop so it works for both 4-player and 3-player games
- Works for local and online matches since it is driven purely by client-side event handling

## Testing
- `cargo build && cargo test` — all tests pass
- `cargo fmt` / `cargo clippy` — clean
- Added `test_turn_player_tracks_events` covering draw, discard, call (pon), and round-end transitions
- Manually verified in the game that the glowing edge follows the active player

🤖 Generated with [Claude Code](https://claude.com/claude-code)