### PR TITLE
Place the sanma empty seat at the North position

### DIFF
--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -457,8 +457,13 @@ impl GameState {
         rankings
     }
 
+    /// 自分の座席の風インデックスを返す（未設定時は0）。
+    pub fn my_wind_index(&self) -> usize {
+        self.seat_wind.map(|w| w.to_index()).unwrap_or(0)
+    }
+
     fn relative_player_index(&self, wind: Wind) -> usize {
-        let my_idx = self.seat_wind.map(|w| w.to_index()).unwrap_or(0);
+        let my_idx = self.my_wind_index();
         let their_idx = wind.to_index();
         // 三麻では風インデックスは0〜2で循環する
         (their_idx + self.player_count - my_idx) % self.player_count

--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -462,6 +462,14 @@ impl GameState {
         self.seat_wind.map(|w| w.to_index()).unwrap_or(0)
     }
 
+    /// 東1局開始時の自分の風インデックスを返す。
+    ///
+    /// 三麻の描画スロットはこの値で固定するため、局が進んで風が
+    /// 回っても各家の表示位置は動かない。
+    pub fn my_initial_wind_index(&self) -> usize {
+        (self.my_seat + self.player_count - self.initial_dealer_seat) % self.player_count
+    }
+
     fn relative_player_index(&self, wind: Wind) -> usize {
         let my_idx = self.my_wind_index();
         let their_idx = wind.to_index();

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -116,19 +116,41 @@ fn test_final_rankings_sanma_excludes_dummy_seat() {
 }
 
 fn sanma_game_started(seat_wind: Wind) -> ServerEvent {
+    sanma_game_started_at(seat_wind, 0)
+}
+
+fn sanma_game_started_at(seat_wind: Wind, round_number: usize) -> ServerEvent {
     ServerEvent::GameStarted {
         seat_wind,
         hand: vec![Tile::new(Tile::P1); 13],
         scores: [35000, 35000, 35000, 0],
         round_wind: Wind::East,
         dora_indicators: vec![Tile::new(Tile::P5)],
-        round_number: 0,
+        round_number,
         total_rounds: 3,
         honba: 0,
         riichi_sticks: 0,
         three_player: true,
         nuki_dora: true,
     }
+}
+
+#[test]
+fn test_sanma_initial_wind_index_is_fixed_across_rounds() {
+    // 東1局: 自分（座席0）が西家 → 開始時の風インデックスは西（2）
+    let mut state = GameState::new();
+    state.handle_event(sanma_game_started_at(Wind::West, 0));
+    assert_eq!(state.my_initial_wind_index(), 2);
+
+    // 東2局: 自分の風は南へ回るが、開始時の風インデックスは変わらない
+    // （描画スロットはこの値で固定され、各家の表示位置が動かない）
+    state.handle_event(sanma_game_started_at(Wind::South, 1));
+    assert_eq!(state.seat_wind, Some(Wind::South));
+    assert_eq!(state.my_initial_wind_index(), 2);
+
+    // 東3局: 自分が親（東家）になっても同様
+    state.handle_event(sanma_game_started_at(Wind::East, 2));
+    assert_eq!(state.my_initial_wind_index(), 2);
 }
 
 #[test]

--- a/crates/mahjong-client/src/renderer/banners.rs
+++ b/crates/mahjong-client/src/renderer/banners.rs
@@ -56,7 +56,7 @@ pub(super) fn draw_call_banners(state: &GameState, font: Option<&Font>) {
             continue;
         }
         let alpha = ((CALL_BANNER_SECS - age) / FADE_SECS).clamp(0.0, 1.0) as f32;
-        let slot = rotation_index(rel, state.player_count);
+        let slot = rotation_index(rel, state.player_count, state.my_wind_index());
         draw_banner_bubble(font, slot, tr.get(banner.label), alpha);
     }
 }

--- a/crates/mahjong-client/src/renderer/banners.rs
+++ b/crates/mahjong-client/src/renderer/banners.rs
@@ -56,7 +56,7 @@ pub(super) fn draw_call_banners(state: &GameState, font: Option<&Font>) {
             continue;
         }
         let alpha = ((CALL_BANNER_SECS - age) / FADE_SECS).clamp(0.0, 1.0) as f32;
-        let slot = rotation_index(rel, state.player_count, state.my_wind_index());
+        let slot = rotation_index(rel, state.player_count, state.my_initial_wind_index());
         draw_banner_bubble(font, slot, tr.get(banner.label), alpha);
     }
 }

--- a/crates/mahjong-client/src/renderer/board.rs
+++ b/crates/mahjong-client/src/renderer/board.rs
@@ -258,7 +258,7 @@ pub(super) fn draw_center_panel(state: &GameState, font: Option<&Font>) {
     );
 
     // 各家の風と得点をそれぞれの向きで描画
-    let my_wind_idx = state.seat_wind.map(|w| w.to_index()).unwrap_or(0);
+    let my_wind_idx = state.my_wind_index();
     let label_dist: f32 = 64.0; // 中心からラベルまでの距離
 
     for rel in 0..state.player_count {
@@ -269,7 +269,7 @@ pub(super) fn draw_center_panel(state: &GameState, font: Option<&Font>) {
         let display_wind =
             mahjong_core::tile::Wind::from_index((my_wind_idx + rel) % state.player_count);
         let score = state.scores[seat];
-        let rotation = PLAYER_ROTATIONS[rotation_index(rel, state.player_count)];
+        let rotation = PLAYER_ROTATIONS[rotation_index(rel, state.player_count, my_wind_idx)];
 
         set_camera(&make_board_camera(rotation));
 
@@ -378,11 +378,11 @@ pub(super) fn draw_discards(state: &GameState, tile_textures: &TileTextures) {
     let start_x = BOARD_CENTER_X - half_width;
     let start_y = BOARD_CENTER_Y + discard_offset;
 
-    let my_wind_idx = state.seat_wind.map(|w| w.to_index()).unwrap_or(0);
+    let my_wind_idx = state.my_wind_index();
 
     for rel in 0..state.player_count {
         let discards = &state.discards[rel];
-        let rotation = PLAYER_ROTATIONS[rotation_index(rel, state.player_count)];
+        let rotation = PLAYER_ROTATIONS[rotation_index(rel, state.player_count, my_wind_idx)];
 
         set_camera(&make_board_camera(rotation));
 

--- a/crates/mahjong-client/src/renderer/board.rs
+++ b/crates/mahjong-client/src/renderer/board.rs
@@ -259,6 +259,7 @@ pub(super) fn draw_center_panel(state: &GameState, font: Option<&Font>) {
 
     // 各家の風と得点をそれぞれの向きで描画
     let my_wind_idx = state.my_wind_index();
+    let my_initial_wind_idx = state.my_initial_wind_index();
     let label_dist: f32 = 64.0; // 中心からラベルまでの距離
 
     for rel in 0..state.player_count {
@@ -269,7 +270,8 @@ pub(super) fn draw_center_panel(state: &GameState, font: Option<&Font>) {
         let display_wind =
             mahjong_core::tile::Wind::from_index((my_wind_idx + rel) % state.player_count);
         let score = state.scores[seat];
-        let rotation = PLAYER_ROTATIONS[rotation_index(rel, state.player_count, my_wind_idx)];
+        let rotation =
+            PLAYER_ROTATIONS[rotation_index(rel, state.player_count, my_initial_wind_idx)];
 
         set_camera(&make_board_camera(rotation));
 
@@ -379,10 +381,12 @@ pub(super) fn draw_discards(state: &GameState, tile_textures: &TileTextures) {
     let start_y = BOARD_CENTER_Y + discard_offset;
 
     let my_wind_idx = state.my_wind_index();
+    let my_initial_wind_idx = state.my_initial_wind_index();
 
     for rel in 0..state.player_count {
         let discards = &state.discards[rel];
-        let rotation = PLAYER_ROTATIONS[rotation_index(rel, state.player_count, my_wind_idx)];
+        let rotation =
+            PLAYER_ROTATIONS[rotation_index(rel, state.player_count, my_initial_wind_idx)];
 
         set_camera(&make_board_camera(rotation));
 

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -88,11 +88,13 @@ const PLAYER_ROTATIONS: [f32; 4] = [0.0, -90.0, 180.0, 90.0];
 /// 相対位置を回転テーブル [`PLAYER_ROTATIONS`] のインデックスへ変換する。
 ///
 /// 四麻: そのまま（0=自分, 1=下家=右, 2=対面=上, 3=上家=左）。
-/// 三麻: 相対2が上家になるため、左（90°）の描画パスを再利用する
-/// （自分=下、下家=右、上家=左、上辺は空席）。
-fn rotation_index(relative_idx: usize, player_count: usize) -> usize {
-    if player_count == 3 && relative_idx == 2 {
-        3
+/// 三麻: 四麻の方角に合わせ、自分の風から見た風の差分（mod 4）で
+/// スロットを決める。存在しない「北」の位置が常に空席になる
+/// （例: 自分が西家なら下家の東家は対面＝上に描かれ、右が空席）。
+fn rotation_index(relative_idx: usize, player_count: usize, my_wind_idx: usize) -> usize {
+    if player_count == 3 && relative_idx > 0 {
+        let their_wind_idx = (my_wind_idx + relative_idx) % 3;
+        (their_wind_idx + 4 - my_wind_idx) % 4
     } else {
         relative_idx
     }

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -88,13 +88,14 @@ const PLAYER_ROTATIONS: [f32; 4] = [0.0, -90.0, 180.0, 90.0];
 /// 相対位置を回転テーブル [`PLAYER_ROTATIONS`] のインデックスへ変換する。
 ///
 /// 四麻: そのまま（0=自分, 1=下家=右, 2=対面=上, 3=上家=左）。
-/// 三麻: 四麻の方角に合わせ、自分の風から見た風の差分（mod 4）で
-/// スロットを決める。存在しない「北」の位置が常に空席になる
-/// （例: 自分が西家なら下家の東家は対面＝上に描かれ、右が空席）。
-fn rotation_index(relative_idx: usize, player_count: usize, my_wind_idx: usize) -> usize {
+/// 三麻: 東1局開始時の風の差分（mod 4）で四麻の方角に合わせて
+/// スロットを決め、存在しない「北」の位置を空席にする
+/// （例: 東1で自分が西家なら下家の東家は対面＝上に描かれ、右が空席）。
+/// 開始時の風で固定するため、局が進んで風が回っても席は動かない。
+fn rotation_index(relative_idx: usize, player_count: usize, my_initial_wind_idx: usize) -> usize {
     if player_count == 3 && relative_idx > 0 {
-        let their_wind_idx = (my_wind_idx + relative_idx) % 3;
-        (their_wind_idx + 4 - my_wind_idx) % 4
+        let their_wind_idx = (my_initial_wind_idx + relative_idx) % 3;
+        (their_wind_idx + 4 - my_initial_wind_idx) % 4
     } else {
         relative_idx
     }

--- a/crates/mahjong-client/src/renderer/tests.rs
+++ b/crates/mahjong-client/src/renderer/tests.rs
@@ -94,15 +94,25 @@ fn sanma_seat_mapping_wraps_at_three() {
 }
 
 #[test]
-fn sanma_rotation_maps_kamicha_to_left() {
-    // 三麻: 相対2（上家）は左（90°）の描画パスを使う。
-    assert_eq!(rotation_index(0, 3), 0);
-    assert_eq!(rotation_index(1, 3), 1);
-    assert_eq!(rotation_index(2, 3), 3);
-    assert_eq!(PLAYER_ROTATIONS[rotation_index(2, 3)], 90.0);
-    // 四麻は恒等写像。
-    for rel in 0..4 {
-        assert_eq!(rotation_index(rel, 4), rel);
+fn sanma_rotation_leaves_north_position_empty() {
+    // 三麻: 四麻の方角に合わせて配置し、「北」の位置が常に空席になる（#309）。
+    // 自分が東家: 南家（下家）=右、西家（上家）=対面、左（北）が空席。
+    assert_eq!(rotation_index(0, 3, 0), 0);
+    assert_eq!(rotation_index(1, 3, 0), 1);
+    assert_eq!(rotation_index(2, 3, 0), 2);
+    // 自分が南家: 西家（下家）=右、東家（上家）=左、上（北）が空席。
+    assert_eq!(rotation_index(0, 3, 1), 0);
+    assert_eq!(rotation_index(1, 3, 1), 1);
+    assert_eq!(rotation_index(2, 3, 1), 3);
+    // 自分が西家: 東家（下家）=対面、南家（上家）=左、右（北）が空席。
+    assert_eq!(rotation_index(0, 3, 2), 0);
+    assert_eq!(rotation_index(1, 3, 2), 2);
+    assert_eq!(rotation_index(2, 3, 2), 3);
+    // 四麻は自分の風にかかわらず恒等写像。
+    for wind in 0..4 {
+        for rel in 0..4 {
+            assert_eq!(rotation_index(rel, 4, wind), rel);
+        }
     }
 }
 

--- a/crates/mahjong-client/src/renderer/tests.rs
+++ b/crates/mahjong-client/src/renderer/tests.rs
@@ -95,20 +95,21 @@ fn sanma_seat_mapping_wraps_at_three() {
 
 #[test]
 fn sanma_rotation_leaves_north_position_empty() {
-    // 三麻: 四麻の方角に合わせて配置し、「北」の位置が常に空席になる（#309）。
-    // 自分が東家: 南家（下家）=右、西家（上家）=対面、左（北）が空席。
+    // 三麻: 東1局開始時の風で四麻の方角に合わせて席を固定し、
+    // 「北」の位置が常に空席になる（#309）。以降は席固定で風だけが回る。
+    // 東1で自分が東家: 南家（下家）=右、西家（上家）=対面、左（北）が空席。
     assert_eq!(rotation_index(0, 3, 0), 0);
     assert_eq!(rotation_index(1, 3, 0), 1);
     assert_eq!(rotation_index(2, 3, 0), 2);
-    // 自分が南家: 西家（下家）=右、東家（上家）=左、上（北）が空席。
+    // 東1で自分が南家: 西家（下家）=右、東家（上家）=左、上（北）が空席。
     assert_eq!(rotation_index(0, 3, 1), 0);
     assert_eq!(rotation_index(1, 3, 1), 1);
     assert_eq!(rotation_index(2, 3, 1), 3);
-    // 自分が西家: 東家（下家）=対面、南家（上家）=左、右（北）が空席。
+    // 東1で自分が西家: 東家（下家）=対面、南家（上家）=左、右（北）が空席。
     assert_eq!(rotation_index(0, 3, 2), 0);
     assert_eq!(rotation_index(1, 3, 2), 2);
     assert_eq!(rotation_index(2, 3, 2), 3);
-    // 四麻は自分の風にかかわらず恒等写像。
+    // 四麻は開始時の風にかかわらず恒等写像。
     for wind in 0..4 {
         for rel in 0..4 {
             assert_eq!(rotation_index(rel, 4, wind), rel);

--- a/crates/mahjong-client/src/renderer/tiles.rs
+++ b/crates/mahjong-client/src/renderer/tiles.rs
@@ -533,7 +533,8 @@ pub(super) fn draw_other_player_hands(state: &GameState, tile_textures: &TileTex
         let start_x = BOARD_CENTER_X - total_width / 2.0;
 
         set_camera(&make_board_camera(
-            PLAYER_ROTATIONS[rotation_index(relative_idx, state.player_count)],
+            PLAYER_ROTATIONS
+                [rotation_index(relative_idx, state.player_count, state.my_wind_index())],
         ));
 
         // 進行中の手出しアニメーション（完了していれば無視する）

--- a/crates/mahjong-client/src/renderer/tiles.rs
+++ b/crates/mahjong-client/src/renderer/tiles.rs
@@ -533,8 +533,11 @@ pub(super) fn draw_other_player_hands(state: &GameState, tile_textures: &TileTex
         let start_x = BOARD_CENTER_X - total_width / 2.0;
 
         set_camera(&make_board_camera(
-            PLAYER_ROTATIONS
-                [rotation_index(relative_idx, state.player_count, state.my_wind_index())],
+            PLAYER_ROTATIONS[rotation_index(
+                relative_idx,
+                state.player_count,
+                state.my_initial_wind_index(),
+            )],
         ));
 
         // 進行中の手出しアニメーション（完了していれば無視する）


### PR DESCRIPTION
Closes #309

## Problem

In three-player (sanma) games, the vacant seat was always rendered across from the player (top of the screen). Display slots were assigned by relative seat index mod 3: self=bottom, shimocha=right, kamicha=left, top always empty. This does not match four-player wind geometry.

## Change

Assign display slots by the wind difference in four-wind space (mod 4) **using each player's wind at East 1**, so the table starts out laid out exactly like a four-player game with the nonexistent North seat vacant, and seats then stay fixed for the whole game while only the winds rotate:

- You start as East: South (shimocha) on the right, West (kamicha) across, **left (North) vacant**
- You start as South: West (shimocha) on the right, East (kamicha) on the left, **top (North) vacant**
- You start as West: East (shimocha) across, South (kamicha) on the left, **right (North) vacant**

`rotation_index` now takes the player's East-1 wind index, provided by the new `GameState::my_initial_wind_index()` (derived from `my_seat` and `initial_dealer_seat`, so it is stable across rounds and works online with a nonzero seat). The four call sites (center panel, discards, call banners, opponent hands) pass it through. Four-player rendering is unchanged.

## Tests

- `sanma_rotation_leaves_north_position_empty` covers the slot assignment for all three starting winds and the four-player identity mapping.
- `test_sanma_initial_wind_index_is_fixed_across_rounds` verifies the slot key stays constant while the seat wind rotates East 1 → East 3.
- `cargo build`, `cargo test` (all crates), `cargo fmt`, `cargo clippy --all-targets` all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)