### PR TITLE
Decide sanma meld direction by East-1 winds to match fixed seats

### DIFF
--- a/crates/mahjong-client/src/game/events.rs
+++ b/crates/mahjong-client/src/game/events.rs
@@ -206,7 +206,7 @@ impl GameState {
                     CallType::Kakan => MeldFrom::Myself,
                     _ => {
                         if let Some(discarder) = self.call_discarder.or(self.last_discarder) {
-                            Self::compute_meld_direction(player, discarder)
+                            self.compute_meld_direction(player, discarder)
                         } else {
                             MeldFrom::Previous
                         }

--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -477,6 +477,11 @@ impl GameState {
         (their_idx + self.player_count - my_idx) % self.player_count
     }
 
+    /// 現在の局の風から、そのプレイヤーの東1局開始時の風インデックスを返す。
+    fn initial_wind_index(&self, wind: Wind) -> usize {
+        (self.my_initial_wind_index() + self.relative_player_index(wind)) % self.player_count
+    }
+
     /// CallType → MeldType 変換
     fn call_type_to_meld_type(call_type: &CallType) -> MeldType {
         match call_type {
@@ -489,9 +494,21 @@ impl GameState {
     }
 
     /// 鳴いたプレイヤー(caller)から見て、鳴き元(discarder)がどの位置かを返す
-    fn compute_meld_direction(caller: Wind, discarder: Wind) -> MeldFrom {
-        let caller_idx = caller.to_index();
-        let discarder_idx = discarder.to_index();
+    ///
+    /// 三麻では席が東1局開始時の位置で固定表示されるため（#309）、現在の局の
+    /// 風ではなく開始時の風の差分で判定する（#311）。現在の風のままだと風が
+    /// 0〜2で回る三麻では mod 4 の差分が局ごとに変わり、倒す牌の位置が画面上の
+    /// 鳴き元の席と一致しない局が生じる。四麻は風の差分 mod 4 が局によらず
+    /// 不変なので、現在の風をそのまま使う（挙動は従来どおり）。
+    fn compute_meld_direction(&self, caller: Wind, discarder: Wind) -> MeldFrom {
+        let (caller_idx, discarder_idx) = if self.player_count == 3 {
+            (
+                self.initial_wind_index(caller),
+                self.initial_wind_index(discarder),
+            )
+        } else {
+            (caller.to_index(), discarder.to_index())
+        };
         let rel = (discarder_idx + 4 - caller_idx) % 4;
         match rel {
             3 => MeldFrom::Previous,  // 上家

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -153,6 +153,102 @@ fn test_sanma_initial_wind_index_is_fixed_across_rounds() {
     assert_eq!(state.my_initial_wind_index(), 2);
 }
 
+/// 三麻の鳴き方向は「東1局開始時の風の差分」で決まること（#311 の回帰テスト）。
+///
+/// 席は東1局開始時の位置で固定表示されるため（#309）、現在の局の風で
+/// mod 4 の差分を取ると、風が回った局で倒す牌の位置が画面上の鳴き元の
+/// 席とずれる。
+#[test]
+fn test_sanma_meld_direction_uses_initial_winds() {
+    // 自分（座席0）が東1局で東家: 下家（開始時南家）は画面右、
+    // 上家（開始時西家）は画面対面に固定表示される。
+    let mut state = GameState::new();
+    state.handle_event(sanma_game_started_at(Wind::East, 0));
+    assert_eq!(
+        state.compute_meld_direction(Wind::East, Wind::South),
+        MeldFrom::Following
+    );
+    assert_eq!(
+        state.compute_meld_direction(Wind::East, Wind::West),
+        MeldFrom::Opposite
+    );
+
+    // 東2局: 自分は西家に回り、画面右の相手は東家、画面対面の相手は南家になる。
+    // 現在の風で計算すると右の相手が Opposite・対面の相手が Following になり、
+    // 倒す位置が席と一致しなくなる。
+    state.handle_event(sanma_game_started_at(Wind::West, 1));
+    assert_eq!(
+        state.compute_meld_direction(Wind::West, Wind::East),
+        MeldFrom::Following
+    );
+    assert_eq!(
+        state.compute_meld_direction(Wind::West, Wind::South),
+        MeldFrom::Opposite
+    );
+
+    // 東3局: 自分は南家、画面右は西家、画面対面は東家。
+    state.handle_event(sanma_game_started_at(Wind::South, 2));
+    assert_eq!(
+        state.compute_meld_direction(Wind::South, Wind::West),
+        MeldFrom::Following
+    );
+    assert_eq!(
+        state.compute_meld_direction(Wind::South, Wind::East),
+        MeldFrom::Opposite
+    );
+}
+
+/// 他家同士の鳴きでも、倒す位置が固定表示の席の位置関係と一致すること。
+#[test]
+fn test_sanma_meld_direction_between_opponents() {
+    // 自分が東1局で東家、東2局で西家に回った局面。
+    // 画面右の相手（開始時南家）は東家、画面対面の相手（開始時西家）は南家。
+    let mut state = GameState::new();
+    state.handle_event(sanma_game_started_at(Wind::East, 0));
+    state.handle_event(sanma_game_started_at(Wind::West, 1));
+
+    // 画面右の相手が自分から鳴く: 自分（画面下）は右の席から見て上家の位置
+    assert_eq!(
+        state.compute_meld_direction(Wind::East, Wind::West),
+        MeldFrom::Previous
+    );
+    // 画面対面の相手が画面右の相手から鳴く: 対面の席から見て右の席は上家の位置
+    assert_eq!(
+        state.compute_meld_direction(Wind::South, Wind::East),
+        MeldFrom::Previous
+    );
+}
+
+/// 四麻の鳴き方向は従来どおり現在の風の差分で決まること（挙動不変の確認）。
+#[test]
+fn test_4p_meld_direction_uses_current_winds() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    assert_eq!(
+        state.compute_meld_direction(Wind::East, Wind::North),
+        MeldFrom::Previous
+    );
+    assert_eq!(
+        state.compute_meld_direction(Wind::East, Wind::West),
+        MeldFrom::Opposite
+    );
+    assert_eq!(
+        state.compute_meld_direction(Wind::East, Wind::South),
+        MeldFrom::Following
+    );
+
+    // 四麻は風の差分 mod 4 が局によらず不変なので、局が進んでも結果は同じ
+    state.handle_event(game_started_4p(Wind::North, 1));
+    assert_eq!(
+        state.compute_meld_direction(Wind::East, Wind::North),
+        MeldFrom::Previous
+    );
+    assert_eq!(
+        state.compute_meld_direction(Wind::South, Wind::East),
+        MeldFrom::Previous
+    );
+}
+
 #[test]
 fn test_sanma_game_started_sets_player_count() {
     let mut state = GameState::new();


### PR DESCRIPTION
Closes #311

## Problem

#310 fixed each player's display seat at its East-1 position in three-player games, with the nonexistent North seat always vacant. However, `compute_meld_direction` in `crates/mahjong-client/src/game/mod.rs` still decided `MeldFrom` (Previous/Opposite/Following) from the **current round's** wind difference mod 4. Since sanma winds cycle through 0–2, the same physical opponent yields a different mod-4 difference in later rounds, so the tilted tile in a called meld could point at a position that does not match the discarder's fixed on-screen seat.

Example (you are East in East 1, so your shimocha sits on the right for the whole game): calling from that opponent in East 1 gives a difference of 1 → `Following` (correct), but in East 2 you are West and they are East, giving a difference of 2 → `Opposite`, tilting the middle tile even though they are still on your right.

## Change

`compute_meld_direction` is now a method on `GameState`. For three-player games it maps both the caller's and the discarder's current winds back to their East-1 wind indices (via the new `initial_wind_index` helper built on `my_initial_wind_index`) and takes the difference in four-wind space, matching the fixed seat layout introduced in #310. The tilted tile therefore always points at the discarder's on-screen seat, including for calls between two CPU opponents.

Four-player behavior is unchanged: the wind difference mod 4 is round-invariant there, and the 4p code path still uses the current winds directly.

## Tests

- `test_sanma_meld_direction_uses_initial_winds` — regression test: the direction stays keyed to the fixed screen position across East 1 → East 3 as the winds rotate.
- `test_sanma_meld_direction_between_opponents` — calls between two opponents also match the fixed seat geometry.
- `test_4p_meld_direction_uses_current_winds` — four-player results are unchanged and round-invariant.
- `cargo build`, `cargo test` (all crates), `cargo fmt`, `cargo clippy --all-targets` all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)