### PR TITLE
Show riichi deposit separately from the hand score on the win screen

### DIFF
--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -59,6 +59,12 @@ struct Declaration {
     before_apply: bool,
 }
 
+/// Value of one riichi deposit stick, in points. Mirrors the server's
+/// private `RIICHI_STICK_VALUE`; needed here because `WinResult::score_points`
+/// only carries the merged total plus a raw stick count, and the result
+/// screen displays the deposit portion separately.
+pub(crate) const RIICHI_STICK_VALUE: i32 = 1000;
+
 /// One winner's result (one page of the result screen).
 #[derive(Debug, Clone)]
 pub struct WinResult {

--- a/crates/mahjong-client/src/i18n/mod.rs
+++ b/crates/mahjong-client/src/i18n/mod.rs
@@ -127,6 +127,15 @@ impl Translator {
         }
     }
 
+    /// Deposit-points caption shown under the score (JA 「＋供託 {s}点」 /
+    /// EN "+deposit {s} pts"); `s` is pre-formatted.
+    pub fn deposit_points(&self, s: &str) -> String {
+        match self.lang {
+            Lang::Ja => format!("＋供託 {s}点"),
+            Lang::En => format!("+deposit {s} pts"),
+        }
+    }
+
     /// Lobby room-code heading.
     pub fn room_code(&self, code: &str) -> String {
         match self.lang {

--- a/crates/mahjong-client/src/i18n/mod.rs
+++ b/crates/mahjong-client/src/i18n/mod.rs
@@ -111,14 +111,6 @@ impl Translator {
         }
     }
 
-    /// Riichi-deposit caption (JA 「供託 {n}本」 / EN "Deposit {n}").
-    pub fn riichi_deposit(&self, n: usize) -> String {
-        match self.lang {
-            Lang::Ja => format!("供託 {n}本"),
-            Lang::En => format!("Deposit {n}"),
-        }
-    }
-
     /// Points caption (JA 「{s}点」 / EN "{s} pts"); `s` is pre-formatted.
     pub fn points(&self, s: &str) -> String {
         match self.lang {
@@ -127,12 +119,12 @@ impl Translator {
         }
     }
 
-    /// Deposit-points caption shown under the score (JA 「＋供託 {s}点」 /
-    /// EN "+deposit {s} pts"); `s` is pre-formatted.
-    pub fn deposit_points(&self, s: &str) -> String {
+    /// Deposit-points caption shown under the score (JA 「＋供託{n}本　{s}点」 /
+    /// EN "+deposit {n}: {s} pts"); `s` is pre-formatted.
+    pub fn deposit_points(&self, n: usize, s: &str) -> String {
         match self.lang {
-            Lang::Ja => format!("＋供託 {s}点"),
-            Lang::En => format!("+deposit {s} pts"),
+            Lang::Ja => format!("＋供託{n}本　{s}点"),
+            Lang::En => format!("+deposit {n}: {s} pts"),
         }
     }
 

--- a/crates/mahjong-client/src/renderer/result.rs
+++ b/crates/mahjong-client/src/renderer/result.rs
@@ -82,8 +82,9 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
     };
     let tr = state.tr();
     let yaku_count = wr.yaku.len().max(1);
+    let kyoutaku_points = wr.riichi_sticks as i32 * crate::game::RIICHI_STICK_VALUE;
     let panel_w = 700.0;
-    let panel_h = 326.0 + yaku_count as f32 * 22.0;
+    let panel_h = 326.0 + yaku_count as f32 * 22.0 + if kyoutaku_points > 0 { 20.0 } else { 0.0 };
     let (panel_x, panel_y, panel_right) = draw_overlay_panel(panel_w, panel_h);
     let cx = panel_x + panel_w / 2.0;
     let content_l = panel_x + 40.0;
@@ -213,7 +214,10 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
     }
     draw_jp_text(font, &hanfu, content_l, y + 24.0, 13, theme::TEXT_DIM);
 
-    let pts = tr.points(&format_score(wr.score_points));
+    // The hand score is shown separately from any riichi deposit collected
+    // with the win, so a big number never silently includes the deposit.
+    let hand_points = wr.score_points - kyoutaku_points;
+    let pts = tr.points(&format_score(hand_points));
     let pw = theme::measure_scaled(font, &pts, 28).width;
     let pts_x = content_r - pw;
     draw_jp_text(font, &pts, pts_x, y + 28.0, 28, theme::GOLD_LT);
@@ -231,6 +235,13 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
         );
     }
     y += 44.0;
+
+    if kyoutaku_points > 0 {
+        let deposit_text = tr.deposit_points(&format_score(kyoutaku_points));
+        let dw = theme::measure_scaled(font, &deposit_text, 13).width;
+        draw_jp_text(font, &deposit_text, content_r - dw, y, 13, theme::TEXT_DIM);
+        y += 20.0;
+    }
 
     draw_result_next_button(state, font, cx, y, panel_w - 80.0);
 }

--- a/crates/mahjong-client/src/renderer/result.rs
+++ b/crates/mahjong-client/src/renderer/result.rs
@@ -84,7 +84,7 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
     let yaku_count = wr.yaku.len().max(1);
     let kyoutaku_points = wr.riichi_sticks as i32 * crate::game::RIICHI_STICK_VALUE;
     let panel_w = 700.0;
-    let panel_h = 326.0 + yaku_count as f32 * 22.0 + if kyoutaku_points > 0 { 20.0 } else { 0.0 };
+    let panel_h = 326.0 + yaku_count as f32 * 22.0 + if kyoutaku_points > 0 { 26.0 } else { 0.0 };
     let (panel_x, panel_y, panel_right) = draw_overlay_panel(panel_w, panel_h);
     let cx = panel_x + panel_w / 2.0;
     let content_l = panel_x + 40.0;
@@ -207,11 +207,7 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
     y += 8.0;
 
     // Totals: small han/fu on the left, rank + big score on the right.
-    let mut hanfu = tr.han_fu(wr.han, wr.fu);
-    if wr.riichi_sticks > 0 {
-        hanfu.push_str("  ");
-        hanfu.push_str(&tr.riichi_deposit(wr.riichi_sticks));
-    }
+    let hanfu = tr.han_fu(wr.han, wr.fu);
     draw_jp_text(font, &hanfu, content_l, y + 24.0, 13, theme::TEXT_DIM);
 
     // The hand score is shown separately from any riichi deposit collected
@@ -237,7 +233,8 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
     y += 44.0;
 
     if kyoutaku_points > 0 {
-        let deposit_text = tr.deposit_points(&format_score(kyoutaku_points));
+        y += 6.0;
+        let deposit_text = tr.deposit_points(wr.riichi_sticks, &format_score(kyoutaku_points));
         let dw = theme::measure_scaled(font, &deposit_text, 13).width;
         draw_jp_text(font, &deposit_text, content_r - dw, y, 13, theme::TEXT_DIM);
         y += 20.0;


### PR DESCRIPTION
## Summary
- The win result panel's big score number used to include any riichi deposit (kyoutaku / 供託) merged into the total, making it unclear how much was the hand's own score vs. deposit sticks.
- The hand score is now shown on its own; when a deposit was collected, a smaller "＋供託 ○点" line is drawn beneath it.

Closes #318

## Test plan
- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] `cargo clippy`
- [x] `cargo test -p mahjong-client` (86 passed)
- [ ] Manual visual check of the win screen with a riichi deposit in an actual match (not exercised in this session — no runtime surface to drive without playing a full round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)