### PR TITLE
Separate honba points in win result display

### DIFF
--- a/crates/mahjong-client/src/game/events.rs
+++ b/crates/mahjong-client/src/game/events.rs
@@ -421,6 +421,8 @@ impl GameState {
                 has_opened,
                 uradora_indicators,
                 riichi_sticks,
+                honba,
+                honba_points,
                 player_hands,
             } => {
                 self.scores = scores;
@@ -529,6 +531,8 @@ impl GameState {
                     rank,
                     yakuman_multiplier,
                     riichi_sticks,
+                    honba,
+                    honba_points,
                 });
 
                 // The first RoundWon initializes the phase and display.

--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -62,8 +62,8 @@ struct Declaration {
 
 /// Value of one riichi deposit stick, in points. Mirrors the server's
 /// private `RIICHI_STICK_VALUE`; needed here because `WinResult::score_points`
-/// only carries the merged total plus a raw stick count, and the result
-/// screen displays the deposit portion separately.
+/// carries the merged total and the result screen displays the deposit
+/// portion separately.
 pub(crate) const RIICHI_STICK_VALUE: i32 = 1000;
 
 /// Heading used by the message-style hand result panel.
@@ -102,6 +102,22 @@ pub struct WinResult {
     pub yakuman_multiplier: u32,
     /// Riichi deposits collected with this win
     pub riichi_sticks: usize,
+    /// Continuance counter collected with this win
+    pub honba: usize,
+    /// Points collected for the continuance counter
+    pub honba_points: i32,
+}
+
+impl WinResult {
+    /// Riichi-deposit portion of the merged winner gain.
+    pub(crate) fn riichi_points(&self) -> i32 {
+        self.riichi_sticks as i32 * RIICHI_STICK_VALUE
+    }
+
+    /// Hand payment before table bonuses.
+    pub(crate) fn hand_points(&self) -> i32 {
+        self.score_points - self.riichi_points() - self.honba_points
+    }
 }
 
 /// Display info for one discard.

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -744,6 +744,8 @@ fn round_won_tsumo(winner: Wind) -> ServerEvent {
         has_opened: false,
         uradora_indicators: vec![],
         riichi_sticks: 0,
+        honba: 0,
+        honba_points: 0,
         player_hands: vec![],
     }
 }
@@ -762,6 +764,8 @@ fn round_won_ron(winner: Wind, loser: Wind) -> ServerEvent {
             has_opened,
             uradora_indicators,
             riichi_sticks,
+            honba,
+            honba_points,
             player_hands,
             ..
         } => ServerEvent::RoundWon {
@@ -777,6 +781,8 @@ fn round_won_ron(winner: Wind, loser: Wind) -> ServerEvent {
             has_opened,
             uradora_indicators,
             riichi_sticks,
+            honba,
+            honba_points,
             player_hands,
         },
         _ => unreachable!(),
@@ -797,6 +803,8 @@ fn round_won_with_score(yaku_list: Vec<(ScoreItem, u32)>, han: u32) -> ServerEve
         has_opened: false,
         uradora_indicators: vec![],
         riichi_sticks: 0,
+        honba: 0,
+        honba_points: 0,
         player_hands: vec![],
     }
 }
@@ -956,6 +964,36 @@ fn test_round_won_deferred_until_banner_hold_elapses() {
     // The result screen appears once the hold ends.
     state.process_events(100.0 + WIN_HOLD_SECS);
     assert_eq!(state.phase, GamePhase::RoundResult);
+}
+
+#[test]
+fn test_round_won_separates_honba_and_deposits_from_hand_points() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+
+    let mut event = round_won_ron(Wind::South, Wind::East);
+    let ServerEvent::RoundWon {
+        score_points,
+        riichi_sticks,
+        honba,
+        honba_points,
+        ..
+    } = &mut event
+    else {
+        unreachable!("helper always returns RoundWon")
+    };
+    // 5,200 hand points + 1,000 deposit points + two honba (600).
+    *score_points = 6_800;
+    *riichi_sticks = 1;
+    *honba = 2;
+    *honba_points = 600;
+
+    state.handle_event(event);
+    let result = state.current_win_result().expect("win result");
+    assert_eq!(result.hand_points(), 5_200);
+    assert_eq!(result.riichi_points(), 1_000);
+    assert_eq!(result.honba, 2);
+    assert_eq!(result.honba_points, 600);
 }
 
 #[test]

--- a/crates/mahjong-client/src/i18n/mod.rs
+++ b/crates/mahjong-client/src/i18n/mod.rs
@@ -128,6 +128,16 @@ impl Translator {
         }
     }
 
+    /// Continuance-points caption shown under the score
+    /// (JA 「＋{n}本場　{s}点」 / EN "+{n} honba: {s} pts"); `s` is
+    /// pre-formatted.
+    pub fn honba_points(&self, n: usize, s: &str) -> String {
+        match self.lang {
+            Lang::Ja => format!("＋{n}本場　{s}点"),
+            Lang::En => format!("+{n} honba: {s} pts"),
+        }
+    }
+
     /// Lobby room-code heading.
     pub fn room_code(&self, code: &str) -> String {
         match self.lang {
@@ -748,6 +758,16 @@ mod tests {
         assert_eq!(en.personality_label(0), "Balanced");
         assert_eq!(ja.cpu_slot(1), "CPU 2");
         assert_eq!(en.cpu_slot(2), "CPU 3");
+    }
+
+    #[test]
+    fn bonus_point_labels() {
+        let ja = Translator::new(Lang::Ja);
+        let en = Translator::new(Lang::En);
+        assert_eq!(ja.deposit_points(1, "1,000"), "＋供託1本　1,000点");
+        assert_eq!(ja.honba_points(2, "600"), "＋2本場　600点");
+        assert_eq!(en.deposit_points(1, "1,000"), "+deposit 1: 1,000 pts");
+        assert_eq!(en.honba_points(2, "600"), "+2 honba: 600 pts");
     }
 
     /// The empty-seat row must localize its CPU config note (#245).

--- a/crates/mahjong-client/src/renderer/result.rs
+++ b/crates/mahjong-client/src/renderer/result.rs
@@ -82,9 +82,10 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
     };
     let tr = state.tr();
     let yaku_count = wr.yaku.len().max(1);
-    let kyoutaku_points = wr.riichi_sticks as i32 * crate::game::RIICHI_STICK_VALUE;
+    let kyoutaku_points = wr.riichi_points();
+    let has_bonus_line = kyoutaku_points > 0 || wr.honba_points > 0;
     let panel_w = 700.0;
-    let panel_h = 326.0 + yaku_count as f32 * 22.0 + if kyoutaku_points > 0 { 26.0 } else { 0.0 };
+    let panel_h = 326.0 + yaku_count as f32 * 22.0 + if has_bonus_line { 26.0 } else { 0.0 };
     let (panel_x, panel_y, panel_right) = draw_overlay_panel(panel_w, panel_h);
     let cx = panel_x + panel_w / 2.0;
     let content_l = panel_x + 40.0;
@@ -214,10 +215,9 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
         draw_jp_text(font, &hanfu, content_l, y + 24.0, 13, theme::TEXT_DIM);
     }
 
-    // The hand score is shown separately from any riichi deposit collected
-    // with the win, so a big number never silently includes the deposit.
-    let hand_points = wr.score_points - kyoutaku_points;
-    let pts = tr.points(&format_score(hand_points));
+    // Keep the hand score separate from table bonuses, whose breakdown is
+    // shown on the line below.
+    let pts = tr.points(&format_score(wr.hand_points()));
     let pw = theme::measure_scaled(font, &pts, 28).width;
     let pts_x = content_r - pw;
     draw_jp_text(font, &pts, pts_x, y + 28.0, 28, theme::GOLD_LT);
@@ -236,11 +236,18 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
     }
     y += 44.0;
 
-    if kyoutaku_points > 0 {
+    if has_bonus_line {
         y += 6.0;
-        let deposit_text = tr.deposit_points(wr.riichi_sticks, &format_score(kyoutaku_points));
-        let dw = theme::measure_scaled(font, &deposit_text, 13).width;
-        draw_jp_text(font, &deposit_text, content_r - dw, y, 13, theme::TEXT_DIM);
+        let mut bonus_parts = Vec::with_capacity(2);
+        if kyoutaku_points > 0 {
+            bonus_parts.push(tr.deposit_points(wr.riichi_sticks, &format_score(kyoutaku_points)));
+        }
+        if wr.honba_points > 0 {
+            bonus_parts.push(tr.honba_points(wr.honba, &format_score(wr.honba_points)));
+        }
+        let bonus_text = bonus_parts.join(" ");
+        let bw = theme::measure_scaled(font, &bonus_text, 13).width;
+        draw_jp_text(font, &bonus_text, content_r - bw, y, 13, theme::TEXT_DIM);
         y += 20.0;
     }
 

--- a/crates/mahjong-server/src/cpu/state.rs
+++ b/crates/mahjong-server/src/cpu/state.rs
@@ -949,6 +949,8 @@ mod tests {
             has_opened: false,
             uradora_indicators: Vec::new(),
             riichi_sticks: 0,
+            honba: 0,
+            honba_points: 0,
             player_hands: Vec::new(),
         });
         assert_eq!(state.scores, [35000, 15000, 25000, 25000]);

--- a/crates/mahjong-server/src/protocol/mod.rs
+++ b/crates/mahjong-server/src/protocol/mod.rs
@@ -232,7 +232,8 @@ pub enum ServerEvent {
         han: u32,
         /// Fu (minipoints)
         fu: u32,
-        /// Points gained by the winner
+        /// Total points gained by the winner, including continuance bonuses
+        /// and riichi deposits
         score_points: i32,
         /// Score rank (mangan etc.; usually `ScoreRank::Normal`)
         rank: ScoreRank,
@@ -243,6 +244,11 @@ pub enum ServerEvent {
         uradora_indicators: Vec<Tile>,
         /// Riichi deposits on the table before the win
         riichi_sticks: usize,
+        /// Continuance counter awarded to this winner. Later winners in a
+        /// simultaneous ron receive zero.
+        honba: usize,
+        /// Points awarded for the continuance counter
+        honba_points: i32,
         /// Every player's revealed hand
         player_hands: Vec<PlayerHandInfo>,
     },

--- a/crates/mahjong-server/src/protocol/net.rs
+++ b/crates/mahjong-server/src/protocol/net.rs
@@ -514,6 +514,8 @@ mod tests {
             has_opened: true,
             uradora_indicators: vec![Tile::new(Tile::P3)],
             riichi_sticks: 1,
+            honba: 2,
+            honba_points: 600,
             player_hands: Vec::new(),
         });
 

--- a/crates/mahjong-server/src/round/calls.rs
+++ b/crates/mahjong-server/src/round/calls.rs
@@ -391,6 +391,8 @@ impl Round {
             deltas: [i32; 4],
             uradora_indicators: Vec<Tile>,
             score_points: i32,
+            honba: usize,
+            honba_points: i32,
         }
 
         let mut winner_data: Vec<WinnerData> = Vec::new();
@@ -461,6 +463,7 @@ impl Round {
                 0
             };
             let score_points = deltas[winner] + riichi_bonus;
+            let honba_points = honba_for_this as i32 * 300;
 
             winner_data.push(WinnerData {
                 winner,
@@ -468,6 +471,8 @@ impl Round {
                 deltas,
                 uradora_indicators,
                 score_points,
+                honba: honba_for_this,
+                honba_points,
             });
         }
 
@@ -520,6 +525,8 @@ impl Round {
                         has_opened,
                         uradora_indicators: wd.uradora_indicators.clone(),
                         riichi_sticks: event_riichi_sticks,
+                        honba: wd.honba,
+                        honba_points: wd.honba_points,
                         player_hands: player_hands.clone(),
                     },
                 ));

--- a/crates/mahjong-server/src/round/tests.rs
+++ b/crates/mahjong-server/src/round/tests.rs
@@ -1416,8 +1416,9 @@ fn test_double_ron_scores() {
 
 #[test]
 fn test_double_ron_events_generated() {
-    // A double ron emits one RoundWon per winner.
-    let mut round = Round::new(Wind::East, 0, [25000; 4], 0, 0, 0, 4, Settings::new());
+    // A double ron emits one RoundWon per winner, and only the first event
+    // carries the honba breakdown.
+    let mut round = Round::new(Wind::East, 0, [25000; 4], 1, 0, 0, 4, Settings::new());
     setup_triple_ron(&mut round);
     round.drain_events();
 
@@ -1436,6 +1437,24 @@ fn test_double_ron_events_generated() {
         2,
         "ダブロンで2件のRoundWonイベントが生成されること"
     );
+    let ServerEvent::RoundWon {
+        honba: first_honba,
+        honba_points: first_honba_points,
+        ..
+    } = &won_events[0].1
+    else {
+        unreachable!("filtered to RoundWon")
+    };
+    let ServerEvent::RoundWon {
+        honba: second_honba,
+        honba_points: second_honba_points,
+        ..
+    } = &won_events[1].1
+    else {
+        unreachable!("filtered to RoundWon")
+    };
+    assert_eq!((*first_honba, *first_honba_points), (1, 300));
+    assert_eq!((*second_honba, *second_honba_points), (0, 0));
 }
 
 #[test]

--- a/crates/mahjong-server/src/round/win.rs
+++ b/crates/mahjong-server/src/round/win.rs
@@ -257,6 +257,7 @@ impl Round {
         let rank = score_result.rank;
         let has_opened = score_result.has_opened;
         let player_hands = self.build_player_hands();
+        let honba_points = self.honba as i32 * 100 * (self.player_count as i32 - 1);
 
         for i in 0..self.player_count {
             self.events.push((
@@ -274,6 +275,8 @@ impl Round {
                     has_opened,
                     uradora_indicators: uradora_indicators.clone(),
                     riichi_sticks,
+                    honba: self.honba,
+                    honba_points,
                     player_hands: player_hands.clone(),
                 },
             ));


### PR DESCRIPTION
## Summary

- show the hand score without riichi deposits or honba bonuses
- display riichi deposits and honba points together on the bonus breakdown line
- carry awarded honba counts and points in `RoundWon` events so tsumo, sanma, and simultaneous ron results remain accurate
- add Japanese and English labels plus regression coverage

## Why

Honba points were previously included silently in the large score while only riichi deposits were shown separately. This made the displayed total difficult to reconcile with the hand value.

For example, a 5,200-point ron with two honba and one riichi deposit now displays:

```text
5,200点
＋供託1本　1,000点 ＋2本場　600点
```

## User impact

The result screen now clearly separates the hand value from table bonuses without changing the actual score settlement.

## Validation

- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features`
- `git diff --check`