### PR TITLE
Improve hand tile inspection and public tile highlighting

### DIFF
--- a/crates/mahjong-client/src/game/input.rs
+++ b/crates/mahjong-client/src/game/input.rs
@@ -251,10 +251,9 @@ impl GameState {
             return None;
         }
 
-        // Swap-calling-forbidden tiles cannot be discarded: keep the
-        // selected (raised) look and show the warning, but do not emit a
-        // discard. Outside our turn they are ordinary reference
-        // selections, so no discard warning is needed.
+        // Keep forbidden tiles selected so the raised tile and warning
+        // explain the rejected discard. Outside our turn no discard is
+        // attempted, so showing that warning would be misleading.
         if can_discard && self.forbidden_discards.contains(&tile.get()) {
             self.selected_tile = Some(idx);
             self.selected_drawn = false;
@@ -353,7 +352,6 @@ impl GameState {
 
         // Overlay clicks, as reported by draw_game.
         if let Some(click) = overlay_click {
-            // Every overlay control is outside the hand.
             self.clear_tile_selection();
 
             if self.nine_terminals_pending {
@@ -457,22 +455,19 @@ impl GameState {
             }
         }
 
-        // During our own riichi turn the drawn tile is handled only by
-        // tsumo/pei or automatic tsumogiri. Informational selection
-        // remains available during the other players' turns.
+        // Do not let inspection selection interfere with tsumo/pei or
+        // automatic tsumogiri during our own riichi turn.
         if self.is_my_turn && self.is_riichi {
             return None;
         }
 
-        // Hand selection is also available outside our turn. The click
-        // helpers below keep actual discards gated to our own turn.
         if !is_mouse_button_pressed(MouseButton::Left) {
             return None;
         }
 
-        // Nine terminals is an own-turn decision, so do not let a hand
-        // click accidentally become a discard. Call-response panels are
-        // outside our turn and still allow informational selection.
+        // Do not let a hand click become a discard while the own-turn
+        // nine terminals decision is unresolved. Call-response panels
+        // occur outside our turn, so inspection remains safe there.
         if self.nine_terminals_pending {
             self.clear_tile_selection();
             return None;

--- a/crates/mahjong-client/src/game/input.rs
+++ b/crates/mahjong-client/src/game/input.rs
@@ -41,8 +41,15 @@ impl GameState {
         self.riichi_selection_mode = false;
         self.riichi_selectable_tiles.clear();
         self.riichi_selectable_drawn = false;
+        self.clear_tile_selection();
+    }
+
+    /// Clears the currently selected hand tile and its related warnings.
+    pub(super) fn clear_tile_selection(&mut self) {
         self.selected_tile = None;
         self.selected_drawn = false;
+        self.selected_forbidden_swap = false;
+        self.selected_would_cause_furiten = false;
     }
 
     pub(super) fn can_discard_for_riichi(&self, tile: Option<Tile>) -> bool {
@@ -231,6 +238,79 @@ impl GameState {
         discarded_tile
     }
 
+    /// Handles a click on one of our concealed hand tiles.
+    ///
+    /// Selection is always available while playing. Only our turn, and
+    /// only before riichi, permits a second click to submit a discard.
+    pub(super) fn handle_hand_tile_click(&mut self, idx: usize) -> Option<ClientAction> {
+        let &tile = self.hand.get(idx)?;
+        let can_discard = self.is_my_turn && !self.is_riichi;
+
+        if can_discard && self.riichi_selection_mode && !self.riichi_selectable_tiles.contains(&idx)
+        {
+            return None;
+        }
+
+        // Swap-calling-forbidden tiles cannot be discarded: keep the
+        // selected (raised) look and show the warning, but do not emit a
+        // discard. Outside our turn they are ordinary reference
+        // selections, so no discard warning is needed.
+        if can_discard && self.forbidden_discards.contains(&tile.get()) {
+            self.selected_tile = Some(idx);
+            self.selected_drawn = false;
+            self.selected_would_cause_furiten = false;
+            self.selected_forbidden_swap = true;
+            return None;
+        }
+
+        if can_discard && self.selected_tile == Some(idx) {
+            let discarded_tile = self.apply_local_discard_from_hand(idx);
+            if self.riichi_selection_mode {
+                self.clear_riichi_selection();
+                return self.submit_turn_action(ClientAction::Riichi {
+                    tile: Some(discarded_tile),
+                });
+            }
+            return self.submit_turn_action(ClientAction::Discard {
+                tile: Some(discarded_tile),
+            });
+        }
+
+        self.selected_tile = Some(idx);
+        self.selected_drawn = false;
+        self.selected_forbidden_swap = false;
+        self.selected_would_cause_furiten =
+            can_discard && self.would_discard_cause_furiten(Some(tile));
+        None
+    }
+
+    /// Handles a click on our drawn tile, with the same informational
+    /// selection behavior outside our turn as concealed hand tiles.
+    pub(super) fn handle_drawn_tile_click(&mut self) -> Option<ClientAction> {
+        self.drawn?;
+        let can_discard = self.is_my_turn && !self.is_riichi;
+
+        if can_discard && self.riichi_selection_mode && !self.riichi_selectable_drawn {
+            return None;
+        }
+
+        if can_discard && self.selected_drawn {
+            self.selected_drawn = false;
+            self.drawn.take();
+            if self.riichi_selection_mode {
+                self.clear_riichi_selection();
+                return self.submit_turn_action(ClientAction::Riichi { tile: None });
+            }
+            return self.submit_turn_action(ClientAction::Discard { tile: None });
+        }
+
+        self.selected_drawn = true;
+        self.selected_tile = None;
+        self.selected_forbidden_swap = false;
+        self.selected_would_cause_furiten = can_discard && self.would_discard_cause_furiten(None);
+        None
+    }
+
     /// Input handling: turns overlay clicks and hand clicks into actions.
     pub fn handle_input(
         &mut self,
@@ -273,6 +353,9 @@ impl GameState {
 
         // Overlay clicks, as reported by draw_game.
         if let Some(click) = overlay_click {
+            // Every overlay control is outside the hand.
+            self.clear_tile_selection();
+
             if self.nine_terminals_pending {
                 match click {
                     OverlayClick::NineTerminalsDeclare => {
@@ -374,21 +457,24 @@ impl GameState {
             }
         }
 
-        // Hand clicks cannot discard while in riichi.
-        if self.is_riichi {
+        // During our own riichi turn the drawn tile is handled only by
+        // tsumo/pei or automatic tsumogiri. Informational selection
+        // remains available during the other players' turns.
+        if self.is_my_turn && self.is_riichi {
             return None;
         }
 
-        if !self.is_my_turn || !is_mouse_button_pressed(MouseButton::Left) {
+        // Hand selection is also available outside our turn. The click
+        // helpers below keep actual discards gated to our own turn.
+        if !is_mouse_button_pressed(MouseButton::Left) {
             return None;
         }
 
-        // Ignore hand clicks while a decision panel is open.
-        if self.nine_terminals_pending
-            || self.chi_option_selecting
-            || self.pon_option_selecting
-            || !self.available_calls.is_empty()
-        {
+        // Nine terminals is an own-turn decision, so do not let a hand
+        // click accidentally become a discard. Call-response panels are
+        // outside our turn and still allow informational selection.
+        if self.nine_terminals_pending {
+            self.clear_tile_selection();
             return None;
         }
 
@@ -400,72 +486,33 @@ impl GameState {
         let hand_y = crate::renderer::HAND_Y;
         let tile_w = 48.0;
         let tile_h = 68.0;
+        let selected_raise = 14.0;
 
         for i in 0..hand_len {
             let x = hand_start_x + i as f32 * tile_w;
-            if mx >= x && mx <= x + tile_w && my >= hand_y && my <= hand_y + tile_h {
-                if self.riichi_selection_mode && !self.riichi_selectable_tiles.contains(&i) {
-                    return None;
-                }
-
-                // Swap-calling-forbidden tiles cannot be discarded: keep
-                // the selected (raised) look and show the warning, but
-                // do not emit a discard.
-                if self.forbidden_discards.contains(&self.hand[i].get()) {
-                    self.selected_tile = Some(i);
-                    self.selected_drawn = false;
-                    self.selected_would_cause_furiten = false;
-                    self.selected_forbidden_swap = true;
-                    return None;
-                }
-
-                if self.selected_tile == Some(i) {
-                    let discarded_tile = self.apply_local_discard_from_hand(i);
-                    if self.riichi_selection_mode {
-                        self.clear_riichi_selection();
-                        return self.submit_turn_action(ClientAction::Riichi {
-                            tile: Some(discarded_tile),
-                        });
-                    }
-                    return self.submit_turn_action(ClientAction::Discard {
-                        tile: Some(discarded_tile),
-                    });
-                }
-
-                self.selected_tile = Some(i);
-                self.selected_drawn = false;
-                self.selected_forbidden_swap = false;
-                self.selected_would_cause_furiten =
-                    self.would_discard_cause_furiten(Some(self.hand[i]));
-                return None;
+            let y = if self.selected_tile == Some(i) {
+                hand_y - selected_raise
+            } else {
+                hand_y
+            };
+            if mx >= x && mx <= x + tile_w && my >= y && my <= y + tile_h {
+                return self.handle_hand_tile_click(i);
             }
         }
 
         if self.drawn.is_some() {
             let drawn_x = hand_start_x + hand_len as f32 * tile_w + crate::renderer::DRAWN_GAP;
-            if mx >= drawn_x && mx <= drawn_x + tile_w && my >= hand_y && my <= hand_y + tile_h {
-                if self.riichi_selection_mode && !self.riichi_selectable_drawn {
-                    return None;
-                }
-
-                if self.selected_drawn {
-                    self.selected_drawn = false;
-                    self.drawn.take();
-                    if self.riichi_selection_mode {
-                        self.clear_riichi_selection();
-                        return self.submit_turn_action(ClientAction::Riichi { tile: None });
-                    }
-                    return self.submit_turn_action(ClientAction::Discard { tile: None });
-                }
-
-                self.selected_drawn = true;
-                self.selected_tile = None;
-                self.selected_forbidden_swap = false;
-                self.selected_would_cause_furiten = self.would_discard_cause_furiten(None);
-                return None;
+            let drawn_y = if self.selected_drawn {
+                hand_y - selected_raise
+            } else {
+                hand_y
+            };
+            if mx >= drawn_x && mx <= drawn_x + tile_w && my >= drawn_y && my <= drawn_y + tile_h {
+                return self.handle_drawn_tile_click();
             }
         }
 
+        self.clear_tile_selection();
         None
     }
 }

--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -459,6 +459,20 @@ impl GameState {
         crate::i18n::Translator::new(self.lang)
     }
 
+    /// Tile kind currently selected in our hand.
+    ///
+    /// Red fives intentionally return the same kind as normal fives so
+    /// every publicly visible copy of that tile kind can be highlighted.
+    pub(crate) fn selected_tile_type(&self) -> Option<TileType> {
+        if self.selected_drawn {
+            self.drawn.map(|tile| tile.get())
+        } else {
+            self.selected_tile
+                .and_then(|idx| self.hand.get(idx))
+                .map(|tile| tile.get())
+        }
+    }
+
     /// Localized heading for a message-style hand result.
     pub fn message_result_heading(&self) -> &'static str {
         match self.message_result_kind {

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -356,7 +356,6 @@ fn test_hand_selection_is_informational_outside_our_turn() {
     assert_eq!(state.selected_tile_type(), Some(Tile::M5));
     assert_eq!(state.hand.len(), 2);
 
-    // A second click remains a reference selection and must not discard.
     assert!(state.handle_hand_tile_click(1).is_none());
     assert_eq!(state.selected_tile, Some(1));
     assert_eq!(state.hand.len(), 2);

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -345,6 +345,91 @@ fn test_self_turn_action_hides_stale_controls_until_server_event() {
 }
 
 #[test]
+fn test_hand_selection_is_informational_outside_our_turn() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    state.hand = vec![Tile::new(Tile::M1), Tile::new_red(Tile::M5)];
+    state.is_my_turn = false;
+
+    assert!(state.handle_hand_tile_click(1).is_none());
+    assert_eq!(state.selected_tile, Some(1));
+    assert_eq!(state.selected_tile_type(), Some(Tile::M5));
+    assert_eq!(state.hand.len(), 2);
+
+    // A second click remains a reference selection and must not discard.
+    assert!(state.handle_hand_tile_click(1).is_none());
+    assert_eq!(state.selected_tile, Some(1));
+    assert_eq!(state.hand.len(), 2);
+}
+
+#[test]
+fn test_hand_selection_still_discards_on_second_click_during_our_turn() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    state.hand = vec![Tile::new(Tile::M1), Tile::new(Tile::M2)];
+    state.drawn = Some(Tile::new(Tile::P9));
+    state.is_my_turn = true;
+
+    assert!(state.handle_hand_tile_click(1).is_none());
+    let action = state.handle_hand_tile_click(1);
+
+    assert!(matches!(
+        action,
+        Some(ClientAction::Discard {
+            tile: Some(tile)
+        }) if tile.get() == Tile::M2
+    ));
+    assert!(!state.is_my_turn);
+    assert_eq!(state.hand, vec![Tile::new(Tile::M1), Tile::new(Tile::P9)]);
+}
+
+#[test]
+fn test_selected_drawn_tile_type_is_available_outside_our_turn() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    state.drawn = Some(Tile::new_red(Tile::P5));
+    state.is_my_turn = false;
+
+    assert!(state.handle_drawn_tile_click().is_none());
+    assert!(state.selected_drawn);
+    assert_eq!(state.selected_tile_type(), Some(Tile::P5));
+    assert!(state.drawn.is_some());
+}
+
+#[test]
+fn test_clearing_tile_selection_also_clears_related_warnings() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    state.selected_tile = Some(0);
+    state.selected_drawn = true;
+    state.selected_forbidden_swap = true;
+    state.selected_would_cause_furiten = true;
+
+    state.clear_tile_selection();
+
+    assert_eq!(state.selected_tile, None);
+    assert!(!state.selected_drawn);
+    assert!(!state.selected_forbidden_swap);
+    assert!(!state.selected_would_cause_furiten);
+}
+
+#[test]
+fn test_overlay_click_clears_selected_tile() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    state.selected_tile = Some(0);
+    state.available_calls = vec![AvailableCall::Ron];
+
+    let action = state.handle_input(
+        Some(crate::renderer::OverlayClick::Action(ClientAction::Pass)),
+        100.0,
+    );
+
+    assert!(matches!(action, Some(ClientAction::Pass)));
+    assert_eq!(state.selected_tile, None);
+}
+
+#[test]
 fn test_sanma_relative_player_index_wraps_at_three() {
     let mut state = GameState::new();
     // With us as West, East sits to our right (relative 1).

--- a/crates/mahjong-client/src/renderer/board.rs
+++ b/crates/mahjong-client/src/renderer/board.rs
@@ -80,16 +80,18 @@ pub(super) fn draw_dora_panel(
     );
 
     let revealed = state.dora_indicators.len();
+    let selected_tile_type = state.selected_tile_type();
     for i in 0..5 {
         let x = tiles_x + i as f32 * (dora_w + 1.0);
         if i < revealed {
+            let tile = &state.dora_indicators[i];
             draw_tile_sprite(
-                tile_textures.for_tile(&state.dora_indicators[i]),
+                tile_textures.for_tile(tile),
                 x,
                 tiles_y,
                 dora_w,
                 dora_h,
-                WHITE,
+                public_tile_tint(tile, selected_tile_type),
             );
         } else {
             draw_tile_sprite(&tile_textures.back, x, tiles_y, dora_w, dora_h, WHITE);
@@ -384,6 +386,7 @@ pub(super) fn draw_discards(state: &GameState, tile_textures: &TileTextures) {
 
     let my_wind_idx = state.my_wind_index();
     let my_initial_wind_idx = state.my_initial_wind_index();
+    let selected_tile_type = state.selected_tile_type();
 
     for rel in 0..state.player_count {
         let discards = &state.discards[rel];
@@ -407,7 +410,7 @@ pub(super) fn draw_discards(state: &GameState, tile_textures: &TileTextures) {
                     start_y,
                     kw,
                     kh,
-                    WHITE,
+                    public_tile_tint(&north, selected_tile_type),
                 );
             }
         }
@@ -440,6 +443,7 @@ pub(super) fn draw_discards(state: &GameState, tile_textures: &TileTextures) {
             if discard.is_called {
                 tint.a = 0.28;
             }
+            tint = public_tile_tint_with_base(&discard.tile, selected_tile_type, tint);
 
             if row != current_row {
                 col_offset = 0.0;

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -28,7 +28,7 @@ use tiles::*;
 use macroquad::prelude::*;
 use mahjong_core::scoring::score::{DoraLabel, ScoreRank};
 use mahjong_core::settings::Lang;
-use mahjong_core::tile::Tile;
+use mahjong_core::tile::{Tile, TileType};
 use mahjong_server::cpu::client::CpuConfig;
 
 use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
@@ -37,6 +37,33 @@ use crate::game::{GamePhase, GameState, SetupState};
 use crate::i18n::Key;
 
 const RIICHI_DISABLED_TINT: Color = Color::new(0.45, 0.45, 0.42, 1.0);
+const PUBLIC_TILE_HIGHLIGHT_TINT: Color = Color::new(0.48, 0.70, 1.0, 1.0);
+
+/// Light complementary-blue tint for a publicly visible tile matching
+/// the selected hand tile. Matching is by tile kind, so red and normal
+/// fives correspond.
+fn public_tile_tint(tile: &Tile, selected_tile_type: Option<TileType>) -> Color {
+    public_tile_tint_with_base(tile, selected_tile_type, WHITE)
+}
+
+/// Applies the public-tile highlight while preserving an existing
+/// transparency such as a called discard's dimmed appearance.
+fn public_tile_tint_with_base(
+    tile: &Tile,
+    selected_tile_type: Option<TileType>,
+    base: Color,
+) -> Color {
+    if selected_tile_type == Some(tile.get()) {
+        Color::new(
+            PUBLIC_TILE_HIGHLIGHT_TINT.r,
+            PUBLIC_TILE_HIGHLIGHT_TINT.g,
+            PUBLIC_TILE_HIGHLIGHT_TINT.b,
+            base.a,
+        )
+    } else {
+        base
+    }
+}
 
 const TILE_W: f32 = 48.0;
 const TILE_H: f32 = 68.0;

--- a/crates/mahjong-client/src/renderer/overlay.rs
+++ b/crates/mahjong-client/src/renderer/overlay.rs
@@ -10,7 +10,7 @@ use mahjong_server::protocol::{AvailableCall, ClientAction};
 
 use super::{
     AGARI_FONT, DESIGN_W, FONT_SIZE, SMALL_FONT, TileTextures, draw_jp_text, draw_tile_sprite,
-    theme,
+    public_tile_tint, theme,
 };
 use crate::game::GameState;
 use crate::i18n::Key;
@@ -392,7 +392,7 @@ fn draw_call_overlay(
             tile_y,
             tile_w - 8.0,
             tile_h - 8.0,
-            WHITE,
+            public_tile_tint(&target, state.selected_tile_type()),
         );
     }
 

--- a/crates/mahjong-client/src/renderer/result.rs
+++ b/crates/mahjong-client/src/renderer/result.rs
@@ -147,7 +147,7 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
     }
     for meld in &state.win_melds {
         x += meld_gap;
-        draw_meld_group(meld, x, hand_y, tw, th, tile_textures);
+        draw_meld_group(meld, x, hand_y, tw, th, tile_textures, None);
         x += calc_meld_width(meld, tw, th);
     }
     y = hand_y + th + 20.0;

--- a/crates/mahjong-client/src/renderer/tests.rs
+++ b/crates/mahjong-client/src/renderer/tests.rs
@@ -1,7 +1,8 @@
 //! Unit tests for the rendering layout.
 
 use super::{
-    PLAYER_ROTATIONS, buffer_to_design, calc_meld_width, other_meld_x_positions, rotation_index,
+    PLAYER_ROTATIONS, PUBLIC_TILE_HIGHLIGHT_TINT, buffer_to_design, calc_meld_width,
+    other_meld_x_positions, public_tile_tint, public_tile_tint_with_base, rotation_index,
     seat_at_relative_position, self_meld_x_positions,
 };
 use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
@@ -22,6 +23,28 @@ fn buffer_to_design_scales_each_axis_independently() {
 #[test]
 fn buffer_to_design_handles_zero_sized_surface() {
     assert_eq!(buffer_to_design(10.0, 20.0, 0.0, 800.0), (0.0, 0.0));
+}
+
+#[test]
+fn public_tile_highlight_matches_red_and_normal_fives_by_kind() {
+    let red_five = Tile::new_red(Tile::M5);
+    assert_eq!(
+        public_tile_tint(&red_five, Some(Tile::M5)),
+        PUBLIC_TILE_HIGHLIGHT_TINT
+    );
+    assert_eq!(public_tile_tint(&red_five, Some(Tile::P5)), WHITE);
+}
+
+#[test]
+fn public_tile_highlight_preserves_called_discard_transparency() {
+    let tile = Tile::new(Tile::S3);
+    let base = Color::new(0.72, 0.72, 0.72, 0.28);
+    let tint = public_tile_tint_with_base(&tile, Some(Tile::S3), base);
+
+    assert_eq!(tint.a, 0.28);
+    assert_eq!(tint.r, PUBLIC_TILE_HIGHLIGHT_TINT.r);
+    assert_eq!(tint.g, PUBLIC_TILE_HIGHLIGHT_TINT.g);
+    assert_eq!(tint.b, PUBLIC_TILE_HIGHLIGHT_TINT.b);
 }
 
 /// Minimal pon meld for the ordering tests.

--- a/crates/mahjong-client/src/renderer/tiles.rs
+++ b/crates/mahjong-client/src/renderer/tiles.rs
@@ -145,8 +145,9 @@ pub(super) fn draw_melds(state: &GameState, tile_textures: &TileTextures) {
 
     // Earliest meld on the right, later melds further left.
     let xs = self_meld_x_positions(&state.melds, tw, th, meld_gap, right_edge);
+    let selected_tile_type = state.selected_tile_type();
     for (meld, &x) in state.melds.iter().zip(&xs) {
-        draw_meld_group(meld, x, meld_y, tw, th, tile_textures);
+        draw_meld_group(meld, x, meld_y, tw, th, tile_textures, selected_tile_type);
     }
 }
 
@@ -178,8 +179,16 @@ pub(super) fn draw_meld_tile(
     w: f32,
     h: f32,
     tile_textures: &TileTextures,
+    selected_tile_type: Option<TileType>,
 ) {
-    draw_tile_sprite(tile_textures.for_tile(tile), x, y, w - 2.0, h - 2.0, WHITE);
+    draw_tile_sprite(
+        tile_textures.for_tile(tile),
+        x,
+        y,
+        w - 2.0,
+        h - 2.0,
+        public_tile_tint(tile, selected_tile_type),
+    );
 }
 
 /// Draws a sideways (90-degree) meld tile.
@@ -190,6 +199,7 @@ pub(super) fn draw_meld_tile_sideways(
     tw: f32,
     th: f32,
     tile_textures: &TileTextures,
+    selected_tile_type: Option<TileType>,
 ) {
     // A sideways tile's bounding box is th wide and tw tall.
     draw_tile_sprite_rotated(
@@ -198,7 +208,7 @@ pub(super) fn draw_meld_tile_sideways(
         y,
         tw - 2.0,
         th - 2.0,
-        WHITE,
+        public_tile_tint(tile, selected_tile_type),
         -std::f32::consts::FRAC_PI_2,
     );
 }
@@ -249,6 +259,7 @@ pub(super) fn draw_meld_group(
     tw: f32,
     th: f32,
     tile_textures: &TileTextures,
+    selected_tile_type: Option<TileType>,
 ) {
     match meld.category {
         MeldType::Kan if meld.from == MeldFrom::Myself => {
@@ -258,7 +269,15 @@ pub(super) fn draw_meld_group(
                 if i == 0 || i == 3 {
                     draw_meld_tile_back(x, base_y, tw, th, tile_textures);
                 } else {
-                    draw_meld_tile(x, base_y, &meld.tiles[i], tw, th, tile_textures);
+                    draw_meld_tile(
+                        x,
+                        base_y,
+                        &meld.tiles[i],
+                        tw,
+                        th,
+                        tile_textures,
+                        selected_tile_type,
+                    );
                 }
             }
         }
@@ -270,7 +289,15 @@ pub(super) fn draw_meld_group(
 
             let mut x = base_x;
             if let Some(ct) = called {
-                draw_meld_tile_sideways(x, base_y + (th - tw), &ct, tw, th, tile_textures);
+                draw_meld_tile_sideways(
+                    x,
+                    base_y + (th - tw),
+                    &ct,
+                    tw,
+                    th,
+                    tile_textures,
+                    selected_tile_type,
+                );
                 x += th;
                 let mut skipped = false;
                 for tile in &sorted_tiles {
@@ -278,12 +305,12 @@ pub(super) fn draw_meld_group(
                         skipped = true;
                         continue;
                     }
-                    draw_meld_tile(x, base_y, tile, tw, th, tile_textures);
+                    draw_meld_tile(x, base_y, tile, tw, th, tile_textures, selected_tile_type);
                     x += tw;
                 }
             } else {
                 for tile in &sorted_tiles {
-                    draw_meld_tile(x, base_y, tile, tw, th, tile_textures);
+                    draw_meld_tile(x, base_y, tile, tw, th, tile_textures, selected_tile_type);
                     x += tw;
                 }
             }
@@ -301,10 +328,19 @@ pub(super) fn draw_meld_group(
                         tw,
                         th,
                         tile_textures,
+                        selected_tile_type,
                     );
                     x += th;
                 } else {
-                    draw_meld_tile(x, base_y, &meld.tiles[i], tw, th, tile_textures);
+                    draw_meld_tile(
+                        x,
+                        base_y,
+                        &meld.tiles[i],
+                        tw,
+                        th,
+                        tile_textures,
+                        selected_tile_type,
+                    );
                     x += tw;
                 }
             }
@@ -322,10 +358,19 @@ pub(super) fn draw_meld_group(
                         tw,
                         th,
                         tile_textures,
+                        selected_tile_type,
                     );
                     x += th;
                 } else {
-                    draw_meld_tile(x, base_y, &meld.tiles[i], tw, th, tile_textures);
+                    draw_meld_tile(
+                        x,
+                        base_y,
+                        &meld.tiles[i],
+                        tw,
+                        th,
+                        tile_textures,
+                        selected_tile_type,
+                    );
                     x += tw;
                 }
             }
@@ -343,6 +388,7 @@ pub(super) fn draw_meld_group(
                         tw,
                         th,
                         tile_textures,
+                        selected_tile_type,
                     );
                     if meld.tiles.len() > 3 {
                         draw_meld_tile_sideways(
@@ -352,11 +398,20 @@ pub(super) fn draw_meld_group(
                             tw,
                             th,
                             tile_textures,
+                            selected_tile_type,
                         );
                     }
                     x += th;
                 } else {
-                    draw_meld_tile(x, base_y, &meld.tiles[i], tw, th, tile_textures);
+                    draw_meld_tile(
+                        x,
+                        base_y,
+                        &meld.tiles[i],
+                        tw,
+                        th,
+                        tile_textures,
+                        selected_tile_type,
+                    );
                     x += tw;
                 }
             }
@@ -512,6 +567,7 @@ pub(super) fn draw_other_player_hands(state: &GameState, tile_textures: &TileTex
 
     let base_y = BOARD_CENTER_Y + hand_distance;
     let now = get_time();
+    let selected_tile_type = state.selected_tile_type();
 
     for other_idx in 0..(state.player_count - 1) {
         let relative_idx = other_idx + 1; // 1 right, 2 across, 3 left
@@ -555,7 +611,14 @@ pub(super) fn draw_other_player_hands(state: &GameState, tile_textures: &TileTex
         let mut x = start_x;
         if other.revealed {
             for tile in &other.hand {
-                draw_tile_sprite(tile_textures.for_tile(tile), x, base_y, tw, th, WHITE);
+                draw_tile_sprite(
+                    tile_textures.for_tile(tile),
+                    x,
+                    base_y,
+                    tw,
+                    th,
+                    public_tile_tint(tile, selected_tile_type),
+                );
                 x += tile_step;
             }
         } else {
@@ -598,7 +661,7 @@ pub(super) fn draw_other_player_hands(state: &GameState, tile_textures: &TileTex
         }
         let xs = other_meld_x_positions(&other.melds, tw, th, meld_gap, x + meld_offset);
         for (meld, &mx) in other.melds.iter().zip(&xs) {
-            draw_meld_group(meld, mx, base_y, tw, th, tile_textures);
+            draw_meld_group(meld, mx, base_y, tw, th, tile_textures, selected_tile_type);
         }
 
         set_design_camera();


### PR DESCRIPTION
## Summary

- allow the local hand and drawn tile to be selected while another player is acting
- highlight matching publicly visible tile kinds with a light complementary-blue tint
- clear the selection and related warnings when clicking outside the hand
- preserve the existing second-click discard behavior during the local player's turn
- treat red and normal fives as the same tile kind for highlighting

## Why

The client previously restricted hand selection to the local player's turn, making it difficult to inspect visible tile counts while waiting. The selection state was also tied directly to discard handling, and public tile rendering had no shared way to identify the selected tile kind.

This change separates informational selection from turn-authorized discards and adds one shared tint calculation across discards, dora indicators, melds, extracted North tiles, revealed opponent hands, and call-target displays.

## User impact

Players can inspect a tile during other players' turns and immediately see matching exposed copies. Clicking elsewhere dismisses the inspection state without affecting normal game actions.

## Validation

- `cargo test -p mahjong-client --bin mahjong-client` — 108 passed, 2 ignored
- `cargo clippy -p mahjong-client --bin mahjong-client -- -D warnings`
- `git diff --check`

Fixes #325
