### PR TITLE
Highlight dora tiles with a light yellow tint

### DIFF
--- a/crates/mahjong-client/src/renderer/board.rs
+++ b/crates/mahjong-client/src/renderer/board.rs
@@ -387,6 +387,7 @@ pub(super) fn draw_discards(state: &GameState, tile_textures: &TileTextures) {
     let my_wind_idx = state.my_wind_index();
     let my_initial_wind_idx = state.my_initial_wind_index();
     let selected_tile_type = state.selected_tile_type();
+    let dora_tile_types = dora_tile_types(&state.dora_indicators, state.is_three_player());
 
     for rel in 0..state.player_count {
         let discards = &state.discards[rel];
@@ -410,7 +411,7 @@ pub(super) fn draw_discards(state: &GameState, tile_textures: &TileTextures) {
                     start_y,
                     kw,
                     kh,
-                    public_tile_tint(&north, selected_tile_type),
+                    public_tile_tint_with_base(&north, selected_tile_type, DORA_TILE_TINT),
                 );
             }
         }
@@ -443,7 +444,12 @@ pub(super) fn draw_discards(state: &GameState, tile_textures: &TileTextures) {
             if discard.is_called {
                 tint.a = 0.28;
             }
-            tint = public_tile_tint_with_base(&discard.tile, selected_tile_type, tint);
+            tint = visible_tile_tint_with_base(
+                &discard.tile,
+                selected_tile_type,
+                &dora_tile_types,
+                tint,
+            );
 
             if row != current_row {
                 col_offset = 0.0;

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -28,7 +28,7 @@ use tiles::*;
 use macroquad::prelude::*;
 use mahjong_core::scoring::score::{DoraLabel, ScoreRank};
 use mahjong_core::settings::Lang;
-use mahjong_core::tile::{Tile, TileType};
+use mahjong_core::tile::{Tile, TileType, dora_indicator_to_dora_in};
 use mahjong_server::cpu::client::CpuConfig;
 
 use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
@@ -38,6 +38,38 @@ use crate::i18n::Key;
 
 const RIICHI_DISABLED_TINT: Color = Color::new(0.45, 0.45, 0.42, 1.0);
 const PUBLIC_TILE_HIGHLIGHT_TINT: Color = Color::new(0.48, 0.70, 1.0, 1.0);
+const DORA_TILE_TINT: Color = Color::new(1.0, 0.96, 0.72, 1.0);
+
+type DoraTileTypes = [bool; Tile::LEN];
+
+fn add_dora_tile_types(
+    dora_tile_types: &mut DoraTileTypes,
+    indicators: &[Tile],
+    three_player: bool,
+) {
+    for indicator in indicators {
+        let tile_type = dora_indicator_to_dora_in(indicator.get(), three_player);
+        dora_tile_types[tile_type as usize] = true;
+    }
+}
+
+fn dora_tile_types(indicators: &[Tile], three_player: bool) -> DoraTileTypes {
+    let mut result = [false; Tile::LEN];
+    add_dora_tile_types(&mut result, indicators, three_player);
+    result
+}
+
+fn dora_tile_tint(tile: &Tile, dora_tile_types: &DoraTileTypes) -> Color {
+    dora_tile_tint_with_base(tile, dora_tile_types, WHITE)
+}
+
+fn dora_tile_tint_with_base(tile: &Tile, dora_tile_types: &DoraTileTypes, base: Color) -> Color {
+    if tile.is_red_dora() || dora_tile_types[tile.get() as usize] {
+        Color::new(DORA_TILE_TINT.r, DORA_TILE_TINT.g, DORA_TILE_TINT.b, base.a)
+    } else {
+        base
+    }
+}
 
 /// Light complementary-blue tint for a publicly visible tile matching
 /// the selected hand tile. Matching is by tile kind, so red and normal
@@ -62,6 +94,46 @@ fn public_tile_tint_with_base(
         )
     } else {
         base
+    }
+}
+
+fn visible_tile_tint(
+    tile: &Tile,
+    selected_tile_type: Option<TileType>,
+    dora_tile_types: &DoraTileTypes,
+) -> Color {
+    visible_tile_tint_with_base(tile, selected_tile_type, dora_tile_types, WHITE)
+}
+
+fn visible_tile_tint_with_base(
+    tile: &Tile,
+    selected_tile_type: Option<TileType>,
+    dora_tile_types: &DoraTileTypes,
+    base: Color,
+) -> Color {
+    if selected_tile_type == Some(tile.get()) {
+        public_tile_tint_with_base(tile, selected_tile_type, base)
+    } else {
+        dora_tile_tint_with_base(tile, dora_tile_types, base)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct TileTintContext<'a> {
+    selected_tile_type: Option<TileType>,
+    dora_tile_types: &'a DoraTileTypes,
+}
+
+impl<'a> TileTintContext<'a> {
+    fn new(selected_tile_type: Option<TileType>, dora_tile_types: &'a DoraTileTypes) -> Self {
+        Self {
+            selected_tile_type,
+            dora_tile_types,
+        }
+    }
+
+    fn tint(self, tile: &Tile) -> Color {
+        visible_tile_tint(tile, self.selected_tile_type, self.dora_tile_types)
     }
 }
 

--- a/crates/mahjong-client/src/renderer/overlay.rs
+++ b/crates/mahjong-client/src/renderer/overlay.rs
@@ -9,8 +9,8 @@ use mahjong_core::tile::Tile;
 use mahjong_server::protocol::{AvailableCall, ClientAction};
 
 use super::{
-    AGARI_FONT, DESIGN_W, FONT_SIZE, SMALL_FONT, TileTextures, draw_jp_text, draw_tile_sprite,
-    public_tile_tint, theme,
+    AGARI_FONT, DESIGN_W, DORA_TILE_TINT, DoraTileTypes, FONT_SIZE, SMALL_FONT, TileTextures,
+    dora_tile_tint, dora_tile_types, draw_jp_text, draw_tile_sprite, theme, visible_tile_tint,
 };
 use crate::game::GameState;
 use crate::i18n::Key;
@@ -344,6 +344,7 @@ fn draw_call_overlay(
     let tile_w = CALL_PANEL_TILE_W;
     let tile_h = CALL_PANEL_TILE_H;
     let tile_gap = 12.0_f32;
+    let dora_tile_types = dora_tile_types(&state.dora_indicators, state.is_three_player());
 
     let non_ron_call_count = state
         .available_calls
@@ -392,7 +393,7 @@ fn draw_call_overlay(
             tile_y,
             tile_w - 8.0,
             tile_h - 8.0,
-            public_tile_tint(&target, state.selected_tile_type()),
+            visible_tile_tint(&target, state.selected_tile_type(), &dora_tile_types),
         );
     }
 
@@ -509,7 +510,7 @@ fn draw_self_call_overlay(
 ) -> Option<OverlayClick> {
     let tr = state.tr();
 
-    let mut units: Vec<(Tile, &'static str, CallBtnKind, ClientAction)> = Vec::new();
+    let mut units: Vec<(Tile, &'static str, CallBtnKind, ClientAction, bool)> = Vec::new();
     for tile in &state.self_kan_options {
         units.push((
             *tile,
@@ -518,6 +519,7 @@ fn draw_self_call_overlay(
             ClientAction::Kan {
                 tile_index: tile.get() as usize,
             },
+            false,
         ));
     }
     if state.can_pei {
@@ -526,6 +528,7 @@ fn draw_self_call_overlay(
             tr.get(Key::Pei),
             CallBtnKind::Pei,
             ClientAction::Pei,
+            true,
         ));
     }
     if units.is_empty() {
@@ -537,6 +540,7 @@ fn draw_self_call_overlay(
     let tile_w = CALL_PANEL_TILE_W;
     let tile_h = CALL_PANEL_TILE_H;
     let pad = CALL_PANEL_PAD;
+    let dora_tile_types = dora_tile_types(&state.dora_indicators, state.is_three_player());
 
     // One unit = sprite + gap + button.
     let unit_w = tile_w + SELF_CALL_TILE_GAP + btn_w;
@@ -575,17 +579,22 @@ fn draw_self_call_overlay(
     );
 
     let mut result = None;
-    for (idx, (tile, label, kind, action)) in units.into_iter().enumerate() {
+    for (idx, (tile, label, kind, action, is_pei_dora)) in units.into_iter().enumerate() {
         let unit_x = base_x + idx as f32 * (unit_w + SELF_CALL_UNIT_SPACING);
         // Sprite vertically centered against the button.
         let tile_y = base_y + (btn_h - tile_h) / 2.0;
+        let tint = if is_pei_dora {
+            DORA_TILE_TINT
+        } else {
+            dora_tile_tint(&tile, &dora_tile_types)
+        };
         draw_tile_sprite(
             tile_textures.for_tile(&tile),
             unit_x,
             tile_y,
             tile_w - 8.0,
             tile_h - 8.0,
-            WHITE,
+            tint,
         );
         let btn_x = unit_x + tile_w + SELF_CALL_TILE_GAP;
         draw_call_button(font, btn_x, base_y, btn_w, btn_h, label, kind);
@@ -633,6 +642,7 @@ fn draw_chi_selection_overlay(
             cancel_label: tr.get(Key::Cancel),
             called_tile,
             options: &state.chi_pending_options,
+            dora_tile_types: dora_tile_types(&state.dora_indicators, state.is_three_player()),
             click: ClickState { clicked, mx, my },
         },
         |opt| ClientAction::Chi { tiles: opt },
@@ -657,6 +667,7 @@ fn draw_pon_selection_overlay(
             cancel_label: tr.get(Key::Cancel),
             called_tile,
             options: &state.pon_pending_options,
+            dora_tile_types: dora_tile_types(&state.dora_indicators, state.is_three_player()),
             click: ClickState { clicked, mx, my },
         },
         |opt| ClientAction::Pon { tiles: opt },
@@ -677,6 +688,7 @@ struct MeldSelectionOverlay<'a> {
     cancel_label: &'a str,
     called_tile: Tile,
     options: &'a [[Tile; 2]],
+    dora_tile_types: DoraTileTypes,
     click: ClickState,
 }
 
@@ -691,6 +703,7 @@ fn draw_meld_selection_overlay(
         cancel_label,
         called_tile,
         options,
+        dora_tile_types,
         click,
     } = overlay;
     let ClickState { clicked, mx, my } = click;
@@ -767,7 +780,7 @@ fn draw_meld_selection_overlay(
             let tint = if *tile == called_tile {
                 Color::new(1.0, 1.0, 0.6, 1.0)
             } else {
-                WHITE
+                dora_tile_tint(tile, &dora_tile_types)
             };
             draw_tile_sprite(
                 tile_textures.for_tile(tile),

--- a/crates/mahjong-client/src/renderer/result.rs
+++ b/crates/mahjong-client/src/renderer/result.rs
@@ -80,6 +80,13 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
         Some(w) => w,
         None => return,
     };
+    let mut dora_tile_types = dora_tile_types(&state.dora_indicators, state.is_three_player());
+    add_dora_tile_types(
+        &mut dora_tile_types,
+        &state.uradora_indicators,
+        state.is_three_player(),
+    );
+    let tile_tint = TileTintContext::new(None, &dora_tile_types);
     let tr = state.tr();
     let yaku_count = wr.yaku.len().max(1);
     let kyoutaku_points = wr.riichi_points();
@@ -128,7 +135,14 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
     let mut x = cx - row_w / 2.0;
     let hand_y = y;
     for tile in &state.win_hand {
-        draw_tile_sprite(tile_textures.for_tile(tile), x, hand_y, tw, th, WHITE);
+        draw_tile_sprite(
+            tile_textures.for_tile(tile),
+            x,
+            hand_y,
+            tw,
+            th,
+            dora_tile_tint(tile, &dora_tile_types),
+        );
         x += tw;
     }
     if let Some(win_tile) = &state.win_tile {
@@ -142,12 +156,19 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
             2.0,
             theme::GOLD_LT,
         );
-        draw_tile_sprite(tile_textures.for_tile(win_tile), x, hand_y, tw, th, WHITE);
+        draw_tile_sprite(
+            tile_textures.for_tile(win_tile),
+            x,
+            hand_y,
+            tw,
+            th,
+            dora_tile_tint(win_tile, &dora_tile_types),
+        );
         x += tw;
     }
     for meld in &state.win_melds {
         x += meld_gap;
-        draw_meld_group(meld, x, hand_y, tw, th, tile_textures, None);
+        draw_meld_group(meld, x, hand_y, tw, th, tile_textures, tile_tint);
         x += calc_meld_width(meld, tw, th);
     }
     y = hand_y + th + 20.0;

--- a/crates/mahjong-client/src/renderer/tests.rs
+++ b/crates/mahjong-client/src/renderer/tests.rs
@@ -1,9 +1,10 @@
 //! Unit tests for the rendering layout.
 
 use super::{
-    PLAYER_ROTATIONS, PUBLIC_TILE_HIGHLIGHT_TINT, buffer_to_design, calc_meld_width,
+    DORA_TILE_TINT, PLAYER_ROTATIONS, PUBLIC_TILE_HIGHLIGHT_TINT, add_dora_tile_types,
+    buffer_to_design, calc_meld_width, dora_tile_tint, dora_tile_tint_with_base, dora_tile_types,
     other_meld_x_positions, public_tile_tint, public_tile_tint_with_base, rotation_index,
-    seat_at_relative_position, self_meld_x_positions,
+    seat_at_relative_position, self_meld_x_positions, visible_tile_tint,
 };
 use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
 use mahjong_core::tile::{Tile, TileType};
@@ -45,6 +46,55 @@ fn public_tile_highlight_preserves_called_discard_transparency() {
     assert_eq!(tint.r, PUBLIC_TILE_HIGHLIGHT_TINT.r);
     assert_eq!(tint.g, PUBLIC_TILE_HIGHLIGHT_TINT.g);
     assert_eq!(tint.b, PUBLIC_TILE_HIGHLIGHT_TINT.b);
+}
+
+#[test]
+fn dora_tiles_use_a_light_yellow_tint() {
+    let dora_types = dora_tile_types(&[Tile::new(Tile::M4)], false);
+
+    assert_eq!(
+        dora_tile_tint(&Tile::new(Tile::M5), &dora_types),
+        DORA_TILE_TINT
+    );
+    assert_eq!(
+        dora_tile_tint(&Tile::new_red(Tile::P5), &dora_types),
+        DORA_TILE_TINT
+    );
+    assert_eq!(dora_tile_tint(&Tile::new(Tile::P5), &dora_types), WHITE);
+}
+
+#[test]
+fn dora_tint_preserves_transparency() {
+    let tile = Tile::new(Tile::S3);
+    let dora_types = dora_tile_types(&[Tile::new(Tile::S2)], false);
+    let base = Color::new(0.72, 0.72, 0.72, 0.28);
+    let tint = dora_tile_tint_with_base(&tile, &dora_types, base);
+
+    assert_eq!(tint.a, 0.28);
+    assert_eq!(tint.r, DORA_TILE_TINT.r);
+    assert_eq!(tint.g, DORA_TILE_TINT.g);
+    assert_eq!(tint.b, DORA_TILE_TINT.b);
+}
+
+#[test]
+fn selected_public_tile_tint_takes_priority_over_dora_tint() {
+    let tile = Tile::new(Tile::Z1);
+    let dora_types = dora_tile_types(&[Tile::new(Tile::Z4)], false);
+
+    assert_eq!(
+        visible_tile_tint(&tile, Some(Tile::Z1), &dora_types),
+        PUBLIC_TILE_HIGHLIGHT_TINT
+    );
+}
+
+#[test]
+fn dora_types_include_three_player_and_uradora_indicators() {
+    let mut dora_types = dora_tile_types(&[Tile::new(Tile::M1)], true);
+    add_dora_tile_types(&mut dora_types, &[Tile::new(Tile::P4)], true);
+
+    assert!(dora_types[Tile::M9 as usize]);
+    assert!(!dora_types[Tile::M2 as usize]);
+    assert!(dora_types[Tile::P5 as usize]);
 }
 
 /// Minimal pon meld for the ordering tests.

--- a/crates/mahjong-client/src/renderer/tiles.rs
+++ b/crates/mahjong-client/src/renderer/tiles.rs
@@ -6,6 +6,7 @@ pub(super) fn draw_hand(state: &GameState, font: Option<&Font>, tile_textures: &
     let hand_start_x = player_hand_start_x(state.hand.len());
     let hand_y = HAND_Y;
     let tr = state.tr();
+    let dora_tile_types = dora_tile_types(&state.dora_indicators, state.is_three_player());
 
     // Hand first; badges draw later so tiles cannot cover them.
     for (i, tile) in state.hand.iter().enumerate() {
@@ -26,6 +27,7 @@ pub(super) fn draw_hand(state: &GameState, font: Option<&Font>, tile_textures: &
             tile,
             riichi_disabled || swap_forbidden,
             tile_textures,
+            &dora_tile_types,
         );
     }
 
@@ -54,6 +56,7 @@ pub(super) fn draw_hand(state: &GameState, font: Option<&Font>, tile_textures: &
             drawn,
             riichi_disabled,
             tile_textures,
+            &dora_tile_types,
         );
     }
 
@@ -146,8 +149,10 @@ pub(super) fn draw_melds(state: &GameState, tile_textures: &TileTextures) {
     // Earliest meld on the right, later melds further left.
     let xs = self_meld_x_positions(&state.melds, tw, th, meld_gap, right_edge);
     let selected_tile_type = state.selected_tile_type();
+    let dora_tile_types = dora_tile_types(&state.dora_indicators, state.is_three_player());
+    let tile_tint = TileTintContext::new(selected_tile_type, &dora_tile_types);
     for (meld, &x) in state.melds.iter().zip(&xs) {
-        draw_meld_group(meld, x, meld_y, tw, th, tile_textures, selected_tile_type);
+        draw_meld_group(meld, x, meld_y, tw, th, tile_textures, tile_tint);
     }
 }
 
@@ -179,7 +184,7 @@ pub(super) fn draw_meld_tile(
     w: f32,
     h: f32,
     tile_textures: &TileTextures,
-    selected_tile_type: Option<TileType>,
+    tile_tint: TileTintContext<'_>,
 ) {
     draw_tile_sprite(
         tile_textures.for_tile(tile),
@@ -187,7 +192,7 @@ pub(super) fn draw_meld_tile(
         y,
         w - 2.0,
         h - 2.0,
-        public_tile_tint(tile, selected_tile_type),
+        tile_tint.tint(tile),
     );
 }
 
@@ -199,7 +204,7 @@ pub(super) fn draw_meld_tile_sideways(
     tw: f32,
     th: f32,
     tile_textures: &TileTextures,
-    selected_tile_type: Option<TileType>,
+    tile_tint: TileTintContext<'_>,
 ) {
     // A sideways tile's bounding box is th wide and tw tall.
     draw_tile_sprite_rotated(
@@ -208,7 +213,7 @@ pub(super) fn draw_meld_tile_sideways(
         y,
         tw - 2.0,
         th - 2.0,
-        public_tile_tint(tile, selected_tile_type),
+        tile_tint.tint(tile),
         -std::f32::consts::FRAC_PI_2,
     );
 }
@@ -259,7 +264,7 @@ pub(super) fn draw_meld_group(
     tw: f32,
     th: f32,
     tile_textures: &TileTextures,
-    selected_tile_type: Option<TileType>,
+    tile_tint: TileTintContext<'_>,
 ) {
     match meld.category {
         MeldType::Kan if meld.from == MeldFrom::Myself => {
@@ -269,15 +274,7 @@ pub(super) fn draw_meld_group(
                 if i == 0 || i == 3 {
                     draw_meld_tile_back(x, base_y, tw, th, tile_textures);
                 } else {
-                    draw_meld_tile(
-                        x,
-                        base_y,
-                        &meld.tiles[i],
-                        tw,
-                        th,
-                        tile_textures,
-                        selected_tile_type,
-                    );
+                    draw_meld_tile(x, base_y, &meld.tiles[i], tw, th, tile_textures, tile_tint);
                 }
             }
         }
@@ -296,7 +293,7 @@ pub(super) fn draw_meld_group(
                     tw,
                     th,
                     tile_textures,
-                    selected_tile_type,
+                    tile_tint,
                 );
                 x += th;
                 let mut skipped = false;
@@ -305,12 +302,12 @@ pub(super) fn draw_meld_group(
                         skipped = true;
                         continue;
                     }
-                    draw_meld_tile(x, base_y, tile, tw, th, tile_textures, selected_tile_type);
+                    draw_meld_tile(x, base_y, tile, tw, th, tile_textures, tile_tint);
                     x += tw;
                 }
             } else {
                 for tile in &sorted_tiles {
-                    draw_meld_tile(x, base_y, tile, tw, th, tile_textures, selected_tile_type);
+                    draw_meld_tile(x, base_y, tile, tw, th, tile_textures, tile_tint);
                     x += tw;
                 }
             }
@@ -328,19 +325,11 @@ pub(super) fn draw_meld_group(
                         tw,
                         th,
                         tile_textures,
-                        selected_tile_type,
+                        tile_tint,
                     );
                     x += th;
                 } else {
-                    draw_meld_tile(
-                        x,
-                        base_y,
-                        &meld.tiles[i],
-                        tw,
-                        th,
-                        tile_textures,
-                        selected_tile_type,
-                    );
+                    draw_meld_tile(x, base_y, &meld.tiles[i], tw, th, tile_textures, tile_tint);
                     x += tw;
                 }
             }
@@ -358,19 +347,11 @@ pub(super) fn draw_meld_group(
                         tw,
                         th,
                         tile_textures,
-                        selected_tile_type,
+                        tile_tint,
                     );
                     x += th;
                 } else {
-                    draw_meld_tile(
-                        x,
-                        base_y,
-                        &meld.tiles[i],
-                        tw,
-                        th,
-                        tile_textures,
-                        selected_tile_type,
-                    );
+                    draw_meld_tile(x, base_y, &meld.tiles[i], tw, th, tile_textures, tile_tint);
                     x += tw;
                 }
             }
@@ -388,7 +369,7 @@ pub(super) fn draw_meld_group(
                         tw,
                         th,
                         tile_textures,
-                        selected_tile_type,
+                        tile_tint,
                     );
                     if meld.tiles.len() > 3 {
                         draw_meld_tile_sideways(
@@ -398,20 +379,12 @@ pub(super) fn draw_meld_group(
                             tw,
                             th,
                             tile_textures,
-                            selected_tile_type,
+                            tile_tint,
                         );
                     }
                     x += th;
                 } else {
-                    draw_meld_tile(
-                        x,
-                        base_y,
-                        &meld.tiles[i],
-                        tw,
-                        th,
-                        tile_textures,
-                        selected_tile_type,
-                    );
+                    draw_meld_tile(x, base_y, &meld.tiles[i], tw, th, tile_textures, tile_tint);
                     x += tw;
                 }
             }
@@ -425,11 +398,12 @@ pub(super) fn draw_tile(
     tile: &mahjong_core::tile::Tile,
     riichi_disabled: bool,
     tile_textures: &TileTextures,
+    dora_tile_types: &DoraTileTypes,
 ) {
     let tint = if riichi_disabled {
         RIICHI_DISABLED_TINT
     } else {
-        WHITE
+        dora_tile_tint(tile, dora_tile_types)
     };
     draw_tile_sprite(
         tile_textures.for_tile(tile),
@@ -568,6 +542,8 @@ pub(super) fn draw_other_player_hands(state: &GameState, tile_textures: &TileTex
     let base_y = BOARD_CENTER_Y + hand_distance;
     let now = get_time();
     let selected_tile_type = state.selected_tile_type();
+    let dora_tile_types = dora_tile_types(&state.dora_indicators, state.is_three_player());
+    let tile_tint = TileTintContext::new(selected_tile_type, &dora_tile_types);
 
     for other_idx in 0..(state.player_count - 1) {
         let relative_idx = other_idx + 1; // 1 right, 2 across, 3 left
@@ -617,7 +593,7 @@ pub(super) fn draw_other_player_hands(state: &GameState, tile_textures: &TileTex
                     base_y,
                     tw,
                     th,
-                    public_tile_tint(tile, selected_tile_type),
+                    visible_tile_tint(tile, selected_tile_type, &dora_tile_types),
                 );
                 x += tile_step;
             }
@@ -661,7 +637,7 @@ pub(super) fn draw_other_player_hands(state: &GameState, tile_textures: &TileTex
         }
         let xs = other_meld_x_positions(&other.melds, tw, th, meld_gap, x + meld_offset);
         for (meld, &mx) in other.melds.iter().zip(&xs) {
-            draw_meld_group(meld, mx, base_y, tw, th, tile_textures, selected_tile_type);
+            draw_meld_group(meld, mx, base_y, tw, th, tile_textures, tile_tint);
         }
 
         set_design_camera();


### PR DESCRIPTION
## What changed

- Tint indicator-derived dora with a light yellow color in hands, melds, discard pools, call-selection UI, and win results.
- Highlight red dora and extracted North tiles.
- Include ura dora when highlighting the winning hand.
- Preserve called-discard transparency and prioritize existing selected/disabled tile states.
- Keep dora indicator tiles unchanged to distinguish indicators from actual dora.
- Apply the three-player characters-suit dora wrap rule.
- Add rendering regression tests for dora detection and tint precedence.

## Why

Dora are strategically important but were not visually distinguishable from ordinary tiles. A consistent, subtle tint makes them easier to recognize without obscuring tile artwork or interaction feedback.

## User impact

Players can identify dora at a glance across the board and result UI, including red dora, pei dora, and revealed ura dora.

## Validation

- `cargo fmt`
- `cargo build`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

Closes #333