### PR TITLE
Keep opponent melds fixed during discard animation

### DIFF
--- a/crates/mahjong-client/src/game/events.rs
+++ b/crates/mahjong-client/src/game/events.rs
@@ -44,6 +44,7 @@ impl GameState {
                 self.hand = hand;
                 self.hand.sort();
                 self.drawn = None;
+                self.self_tedashi_anim = None;
                 self.scores = scores;
                 self.round_wind = Some(round_wind);
                 self.dora_indicators = dora_indicators;
@@ -96,6 +97,7 @@ impl GameState {
                 is_furiten,
             } => {
                 self.drawn = Some(tile);
+                self.self_tedashi_anim = None;
                 // Restart the auto-tsumogiri delay for the new draw.
                 self.riichi_auto_discard_at = None;
                 self.remaining_tiles = remaining_tiles;
@@ -405,6 +407,7 @@ impl GameState {
             ServerEvent::HandUpdated { hand } => {
                 self.hand = hand;
                 self.hand.sort();
+                self.self_tedashi_anim = None;
                 self.refresh_self_kan_options();
             }
 

--- a/crates/mahjong-client/src/game/input.rs
+++ b/crates/mahjong-client/src/game/input.rs
@@ -501,7 +501,7 @@ impl GameState {
 
         // Hand clicks use the same centering as the renderer.
         let hand_len = self.hand.len();
-        let hand_start_x = crate::renderer::player_hand_start_x(hand_len);
+        let hand_start_x = crate::renderer::player_hand_start_x(hand_len, &self.melds);
         let hand_y = crate::renderer::HAND_Y;
         let tile_w = 48.0;
         let tile_h = 68.0;

--- a/crates/mahjong-client/src/game/input.rs
+++ b/crates/mahjong-client/src/game/input.rs
@@ -226,15 +226,35 @@ impl GameState {
 
     pub(super) fn apply_local_discard_from_hand(&mut self, idx: usize) -> Tile {
         let discarded_tile = self.hand[idx];
+        let pre_hand_len = self.hand.len();
         self.selected_tile = None;
         self.selected_drawn = false;
+
+        // Sorting tiles together with their origins preserves the
+        // physical instance each final tile should animate from. Matching
+        // by tile value afterwards would be ambiguous for duplicates.
+        let mut tiles_with_origins: Vec<(Tile, SelfTileOrigin)> = self
+            .hand
+            .iter()
+            .copied()
+            .enumerate()
+            .filter(|(hand_idx, _)| *hand_idx != idx)
+            .map(|(hand_idx, tile)| (tile, SelfTileOrigin::Hand(hand_idx)))
+            .collect();
         if let Some(drawn_tile) = self.drawn.take() {
-            self.hand.remove(idx);
-            self.hand.push(drawn_tile);
-            self.hand.sort();
-        } else {
-            self.hand.remove(idx);
+            tiles_with_origins.push((drawn_tile, SelfTileOrigin::Drawn));
         }
+        tiles_with_origins.sort_by_key(|(tile, _)| *tile);
+
+        self.hand = tiles_with_origins.iter().map(|(tile, _)| *tile).collect();
+        self.self_tedashi_anim = Some(SelfTedashiAnim {
+            origins: tiles_with_origins
+                .into_iter()
+                .map(|(_, origin)| origin)
+                .collect(),
+            pre_hand_len,
+            started_at: self.clock,
+        });
         discarded_tile
     }
 
@@ -296,6 +316,7 @@ impl GameState {
         if can_discard && self.selected_drawn {
             self.selected_drawn = false;
             self.drawn.take();
+            self.self_tedashi_anim = None;
             if self.riichi_selection_mode {
                 self.clear_riichi_selection();
                 return self.submit_turn_action(ClientAction::Riichi { tile: None });
@@ -321,6 +342,7 @@ impl GameState {
         if self.phase != GamePhase::Playing {
             return None;
         }
+        self.clock = now;
 
         // Refuse input while unapplied server events remain (e.g. a
         // pending declaration banner): the screen still shows stale state,
@@ -347,6 +369,7 @@ impl GameState {
             }
             self.riichi_auto_discard_at = None;
             self.drawn.take();
+            self.self_tedashi_anim = None;
             return self.submit_turn_action(ClientAction::Discard { tile: None });
         }
 
@@ -439,6 +462,7 @@ impl GameState {
                     if self.is_riichi && self.drawn.is_some() {
                         self.can_pei = false;
                         self.drawn.take();
+                        self.self_tedashi_anim = None;
                         return self.submit_turn_action(ClientAction::Discard { tile: None });
                     }
                     return None;
@@ -484,7 +508,7 @@ impl GameState {
         let selected_raise = 14.0;
 
         for i in 0..hand_len {
-            let x = hand_start_x + i as f32 * tile_w;
+            let x = crate::renderer::player_hand_tile_x(self, i, now);
             let y = if self.selected_tile == Some(i) {
                 hand_y - selected_raise
             } else {

--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -146,6 +146,26 @@ pub struct TedashiAnim {
     pub started_at: f64,
 }
 
+/// A tile's visible position before our hand discard is applied locally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelfTileOrigin {
+    /// The tile was at this index in the concealed hand.
+    Hand(usize),
+    /// The tile was hanging to the right as the drawn tile.
+    Drawn,
+}
+
+/// Gap-closing animation state for our own hand discard.
+#[derive(Debug, Clone)]
+pub struct SelfTedashiAnim {
+    /// Pre-discard origins, aligned with the final sorted hand.
+    pub origins: Vec<SelfTileOrigin>,
+    /// Concealed-hand length before the discard.
+    pub pre_hand_len: usize,
+    /// Animation start time, on the input/process-events clock.
+    pub started_at: f64,
+}
+
 /// Display info for an opponent's hand, indexed relative to us.
 #[derive(Debug, Clone)]
 pub struct OtherPlayerHand {
@@ -195,6 +215,8 @@ pub struct GameState {
     pub hand: Vec<Tile>,
     /// The drawn tile
     pub drawn: Option<Tile>,
+    /// Gap-closing animation of our latest hand discard
+    pub self_tedashi_anim: Option<SelfTedashiAnim>,
     /// Discards per player (0 = self, 1 = right, 2 = across, 3 = left)
     pub discards: [Vec<DiscardInfo>; 4],
     /// Scores
@@ -319,8 +341,8 @@ pub struct GameState {
     event_hold_until: f64,
     /// Whether the front event's banner has been shown (pre-apply hold)
     head_announced: bool,
-    /// The time last passed to [`process_events`](Self::process_events);
-    /// used as the animation start time when applying events.
+    /// The time last passed to [`process_events`](Self::process_events)
+    /// or `handle_input`; used as the animation start time.
     clock: f64,
     /// Display language
     pub lang: Lang,
@@ -365,6 +387,7 @@ impl GameState {
             seat_wind: None,
             hand: Vec::new(),
             drawn: None,
+            self_tedashi_anim: None,
             discards: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             scores: [25000; 4],
             round_wind: None,

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -380,6 +380,84 @@ fn test_hand_selection_still_discards_on_second_click_during_our_turn() {
     ));
     assert!(!state.is_my_turn);
     assert_eq!(state.hand, vec![Tile::new(Tile::M1), Tile::new(Tile::P9)]);
+    assert_eq!(
+        state
+            .self_tedashi_anim
+            .as_ref()
+            .expect("手出しアニメーションが開始されていない")
+            .origins,
+        vec![SelfTileOrigin::Hand(0), SelfTileOrigin::Drawn]
+    );
+}
+
+#[test]
+fn test_local_hand_discard_tracks_origins_through_sorting() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    state.hand = vec![
+        Tile::new(Tile::M2),
+        Tile::new(Tile::M3),
+        Tile::new(Tile::M4),
+    ];
+    state.drawn = Some(Tile::new(Tile::M1));
+    state.process_events(100.0);
+
+    let discarded = state.apply_local_discard_from_hand(1);
+
+    assert_eq!(discarded, Tile::new(Tile::M3));
+    assert_eq!(
+        state.hand,
+        vec![
+            Tile::new(Tile::M1),
+            Tile::new(Tile::M2),
+            Tile::new(Tile::M4),
+        ]
+    );
+    let anim = state
+        .self_tedashi_anim
+        .as_ref()
+        .expect("手出しアニメーションが開始されていない");
+    assert_eq!(anim.pre_hand_len, 3);
+    assert_eq!(anim.started_at, 100.0);
+    assert_eq!(
+        anim.origins,
+        vec![
+            SelfTileOrigin::Drawn,
+            SelfTileOrigin::Hand(0),
+            SelfTileOrigin::Hand(2),
+        ]
+    );
+}
+
+#[test]
+fn test_local_tsumogiri_does_not_start_hand_animation() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    state.drawn = Some(Tile::new(Tile::P9));
+    state.is_my_turn = true;
+    state.selected_drawn = true;
+
+    let action = state.handle_drawn_tile_click();
+
+    assert!(matches!(action, Some(ClientAction::Discard { tile: None })));
+    assert!(state.drawn.is_none());
+    assert!(state.self_tedashi_anim.is_none());
+}
+
+#[test]
+fn test_authoritative_hand_update_clears_local_hand_animation() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    state.hand = vec![Tile::new(Tile::M1), Tile::new(Tile::M2)];
+    state.drawn = Some(Tile::new(Tile::P9));
+    state.apply_local_discard_from_hand(0);
+    assert!(state.self_tedashi_anim.is_some());
+
+    state.handle_event(ServerEvent::HandUpdated {
+        hand: vec![Tile::new(Tile::S1), Tile::new(Tile::S2)],
+    });
+
+    assert!(state.self_tedashi_anim.is_none());
 }
 
 #[test]

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -139,6 +139,12 @@ impl<'a> TileTintContext<'a> {
 
 const TILE_W: f32 = 48.0;
 const TILE_H: f32 = 68.0;
+const SELF_MELD_TILE_W: f32 = 40.0;
+const SELF_MELD_TILE_H: f32 = 56.0;
+const SELF_MELD_GAP: f32 = 12.0;
+const SELF_MELD_RIGHT_EDGE: f32 = 1220.0;
+const SELF_HAND_MELD_GAP: f32 = 20.0;
+const SELF_HAND_LEFT_MARGIN: f32 = 40.0;
 const FONT_SIZE: u16 = 20;
 const SMALL_FONT: u16 = 16;
 const AGARI_FONT: u16 = 32;
@@ -170,18 +176,34 @@ pub const HAND_Y: f32 = 680.0;
 /// Gap between the hand and the drawn tile to its right.
 pub const DRAWN_GAP: f32 = 20.0;
 
-/// Left X that centers our stable concealed hand on screen.
+/// Left X that centers our stable concealed hand when space permits.
 ///
 /// The drawn tile is excluded from centering and hangs to the right, as
 /// is conventional. Shared by rendering ([`draw_hand`]) and hit testing
-/// (`GameState::handle_input`).
-pub fn player_hand_start_x(hand_len: usize) -> f32 {
+/// (`GameState::handle_input`). Space for the drawn tile is always
+/// reserved when checking the called-meld boundary, so drawing and
+/// discarding do not shift the whole hand.
+pub fn player_hand_start_x(hand_len: usize, melds: &[Meld]) -> f32 {
     // A pon/chii temporarily leaves one extra tile before the caller's
     // discard. Centering on the post-discard length prevents that discard
     // from shifting tiles that were left of the gap (#339).
     let layout_len = hand_len - usize::from(hand_len % 3 == 2);
     let hand_w = layout_len as f32 * TILE_W;
-    (DESIGN_W - hand_w) / 2.0
+    let centered_x = (DESIGN_W - hand_w) / 2.0;
+    if melds.is_empty() {
+        return centered_x;
+    }
+
+    let meld_widths: f32 = melds
+        .iter()
+        .map(|meld| calc_meld_width(meld, SELF_MELD_TILE_W, SELF_MELD_TILE_H))
+        .sum();
+    let meld_gaps = melds.len().saturating_sub(1) as f32 * SELF_MELD_GAP;
+    let meld_left_x = SELF_MELD_RIGHT_EDGE - meld_widths - meld_gaps;
+    let reserved_hand_width = hand_w + DRAWN_GAP + TILE_W;
+    let non_overlapping_x = meld_left_x - SELF_HAND_MELD_GAP - reserved_hand_width;
+
+    centered_x.min(non_overlapping_x).max(SELF_HAND_LEFT_MARGIN)
 }
 
 /// Current X of one tile in our final sorted hand.
@@ -189,7 +211,7 @@ pub fn player_hand_start_x(hand_len: usize) -> f32 {
 /// Rendering and hit testing share this function so animated tiles stay
 /// interactive at the position where they are visible.
 pub(crate) fn player_hand_tile_x(state: &GameState, index: usize, now: f64) -> f32 {
-    let final_x = player_hand_start_x(state.hand.len()) + index as f32 * TILE_W;
+    let final_x = player_hand_start_x(state.hand.len(), &state.melds) + index as f32 * TILE_W;
     let Some(anim) = &state.self_tedashi_anim else {
         return final_x;
     };
@@ -197,7 +219,7 @@ pub(crate) fn player_hand_tile_x(state: &GameState, index: usize, now: f64) -> f
         return final_x;
     };
 
-    let pre_start_x = player_hand_start_x(anim.pre_hand_len);
+    let pre_start_x = player_hand_start_x(anim.pre_hand_len, &state.melds);
     let from_x = match origin {
         SelfTileOrigin::Hand(pre_index) => pre_start_x + *pre_index as f32 * TILE_W,
         SelfTileOrigin::Drawn => pre_start_x + anim.pre_hand_len as f32 * TILE_W + DRAWN_GAP,

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -33,7 +33,7 @@ use mahjong_server::cpu::client::CpuConfig;
 
 use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
 
-use crate::game::{GamePhase, GameState, SetupState};
+use crate::game::{GamePhase, GameState, SelfTileOrigin, SetupState};
 use crate::i18n::Key;
 
 const RIICHI_DISABLED_TINT: Color = Color::new(0.45, 0.45, 0.42, 1.0);
@@ -170,14 +170,40 @@ pub const HAND_Y: f32 = 680.0;
 /// Gap between the hand and the drawn tile to its right.
 pub const DRAWN_GAP: f32 = 20.0;
 
-/// Left X that centers our `hand_len`-tile hand on screen.
+/// Left X that centers our stable concealed hand on screen.
 ///
 /// The drawn tile is excluded from centering and hangs to the right, as
 /// is conventional. Shared by rendering ([`draw_hand`]) and hit testing
 /// (`GameState::handle_input`).
 pub fn player_hand_start_x(hand_len: usize) -> f32 {
-    let hand_w = hand_len as f32 * TILE_W;
+    // A pon/chii temporarily leaves one extra tile before the caller's
+    // discard. Centering on the post-discard length prevents that discard
+    // from shifting tiles that were left of the gap (#339).
+    let layout_len = hand_len - usize::from(hand_len % 3 == 2);
+    let hand_w = layout_len as f32 * TILE_W;
     (DESIGN_W - hand_w) / 2.0
+}
+
+/// Current X of one tile in our final sorted hand.
+///
+/// Rendering and hit testing share this function so animated tiles stay
+/// interactive at the position where they are visible.
+pub(crate) fn player_hand_tile_x(state: &GameState, index: usize, now: f64) -> f32 {
+    let final_x = player_hand_start_x(state.hand.len()) + index as f32 * TILE_W;
+    let Some(anim) = &state.self_tedashi_anim else {
+        return final_x;
+    };
+    let Some(origin) = anim.origins.get(index) else {
+        return final_x;
+    };
+
+    let pre_start_x = player_hand_start_x(anim.pre_hand_len);
+    let from_x = match origin {
+        SelfTileOrigin::Hand(pre_index) => pre_start_x + *pre_index as f32 * TILE_W,
+        SelfTileOrigin::Drawn => pre_start_x + anim.pre_hand_len as f32 * TILE_W + DRAWN_GAP,
+    };
+    let progress = tedashi_progress(now - anim.started_at);
+    final_x + (from_x - final_x) * (1.0 - progress)
 }
 
 /// Camera2D rotations in degrees: self 0, right -90, across 180, left 90.

--- a/crates/mahjong-client/src/renderer/tests.rs
+++ b/crates/mahjong-client/src/renderer/tests.rs
@@ -1,8 +1,9 @@
 //! Unit tests for the rendering layout.
 
 use super::{
-    DORA_TILE_TINT, DRAWN_GAP, PLAYER_ROTATIONS, PUBLIC_TILE_HIGHLIGHT_TINT, TILE_W,
-    add_dora_tile_types, buffer_to_design, calc_meld_width, dora_tile_tint,
+    DORA_TILE_TINT, DRAWN_GAP, PLAYER_ROTATIONS, PUBLIC_TILE_HIGHLIGHT_TINT, SELF_HAND_LEFT_MARGIN,
+    SELF_HAND_MELD_GAP, SELF_MELD_GAP, SELF_MELD_RIGHT_EDGE, SELF_MELD_TILE_H, SELF_MELD_TILE_W,
+    TILE_W, add_dora_tile_types, buffer_to_design, calc_meld_width, dora_tile_tint,
     dora_tile_tint_with_base, dora_tile_types, other_meld_x_positions, player_hand_start_x,
     player_hand_tile_x, public_tile_tint, public_tile_tint_with_base, rotation_index,
     seat_at_relative_position, self_meld_x_positions, visible_tile_tint,
@@ -105,6 +106,17 @@ fn pon(tile_type: TileType) -> Meld {
     Meld {
         tiles: vec![tile, tile, tile],
         category: MeldType::Pon,
+        from: MeldFrom::Previous,
+        called_tile: Some(tile),
+    }
+}
+
+/// Minimal called quad for the layout tests.
+fn called_kan(tile_type: TileType) -> Meld {
+    let tile = Tile::new(tile_type);
+    Meld {
+        tiles: vec![tile; 4],
+        category: MeldType::Kan,
         from: MeldFrom::Previous,
         called_tile: Some(tile),
     }
@@ -455,11 +467,71 @@ fn post_call_discard_keeps_hand_edges_and_melds_fixed() {
 
 #[test]
 fn own_post_call_discard_keeps_the_hand_left_edge_fixed() {
+    let melds = vec![pon(Tile::M1)];
     assert_eq!(
-        player_hand_start_x(11),
-        player_hand_start_x(10),
+        player_hand_start_x(11, &melds),
+        player_hand_start_x(10, &melds),
         "鳴き直後の打牌で手牌の左端を動かさない"
     );
+}
+
+#[test]
+fn own_hand_stays_centered_while_melds_leave_enough_room() {
+    let melds = vec![pon(Tile::M1), pon(Tile::P2)];
+    let hand_len = 7;
+    let centered_x = (super::DESIGN_W - hand_len as f32 * TILE_W) / 2.0;
+
+    assert_eq!(player_hand_start_x(hand_len, &melds), centered_x);
+}
+
+#[test]
+fn own_hand_shifts_left_to_clear_three_melds() {
+    let melds = vec![pon(Tile::M1), pon(Tile::P2), pon(Tile::S3)];
+    let hand_len = 4;
+    let centered_x = (super::DESIGN_W - hand_len as f32 * TILE_W) / 2.0;
+    let hand_start_x = player_hand_start_x(hand_len, &melds);
+    let reserved_hand_right_x = hand_start_x + hand_len as f32 * TILE_W + DRAWN_GAP + TILE_W;
+    let meld_left_x = self_meld_x_positions(
+        &melds,
+        SELF_MELD_TILE_W,
+        SELF_MELD_TILE_H,
+        SELF_MELD_GAP,
+        SELF_MELD_RIGHT_EDGE,
+    )
+    .into_iter()
+    .fold(f32::INFINITY, f32::min);
+
+    assert!(hand_start_x < centered_x, "重なる場合だけ手牌を左へ寄せる");
+    assert_eq!(
+        meld_left_x - reserved_hand_right_x,
+        SELF_HAND_MELD_GAP,
+        "予約ツモ牌枠と副露の間に一定の余白を空ける"
+    );
+}
+
+#[test]
+fn own_hand_and_four_called_quads_fit_without_overlap() {
+    let melds = vec![
+        called_kan(Tile::M1),
+        called_kan(Tile::P2),
+        called_kan(Tile::S3),
+        called_kan(Tile::Z1),
+    ];
+    let hand_len = 1;
+    let hand_start_x = player_hand_start_x(hand_len, &melds);
+    let reserved_hand_right_x = hand_start_x + hand_len as f32 * TILE_W + DRAWN_GAP + TILE_W;
+    let meld_left_x = self_meld_x_positions(
+        &melds,
+        SELF_MELD_TILE_W,
+        SELF_MELD_TILE_H,
+        SELF_MELD_GAP,
+        SELF_MELD_RIGHT_EDGE,
+    )
+    .into_iter()
+    .fold(f32::INFINITY, f32::min);
+
+    assert!(hand_start_x >= SELF_HAND_LEFT_MARGIN);
+    assert!(reserved_hand_right_x + SELF_HAND_MELD_GAP <= meld_left_x);
 }
 
 #[test]
@@ -479,7 +551,7 @@ fn own_tedashi_tiles_move_from_pre_discard_origins() {
         pre_hand_len: 3,
         started_at: 100.0,
     });
-    let start_x = player_hand_start_x(3);
+    let start_x = player_hand_start_x(3, &state.melds);
 
     assert_eq!(player_hand_tile_x(&state, 0, 100.0), start_x);
     assert_eq!(

--- a/crates/mahjong-client/src/renderer/tests.rs
+++ b/crates/mahjong-client/src/renderer/tests.rs
@@ -1,11 +1,13 @@
 //! Unit tests for the rendering layout.
 
 use super::{
-    DORA_TILE_TINT, PLAYER_ROTATIONS, PUBLIC_TILE_HIGHLIGHT_TINT, add_dora_tile_types,
-    buffer_to_design, calc_meld_width, dora_tile_tint, dora_tile_tint_with_base, dora_tile_types,
-    other_meld_x_positions, public_tile_tint, public_tile_tint_with_base, rotation_index,
+    DORA_TILE_TINT, DRAWN_GAP, PLAYER_ROTATIONS, PUBLIC_TILE_HIGHLIGHT_TINT, TILE_W,
+    add_dora_tile_types, buffer_to_design, calc_meld_width, dora_tile_tint,
+    dora_tile_tint_with_base, dora_tile_types, other_meld_x_positions, player_hand_start_x,
+    player_hand_tile_x, public_tile_tint, public_tile_tint_with_base, rotation_index,
     seat_at_relative_position, self_meld_x_positions, visible_tile_tint,
 };
+use crate::game::{GameState, SelfTedashiAnim, SelfTileOrigin};
 use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
 use mahjong_core::tile::{Tile, TileType};
 
@@ -449,4 +451,53 @@ fn post_call_discard_keeps_hand_edges_and_melds_fixed() {
         after_count as f32 * step + after_slot,
         "打牌の前後で手牌領域の両端と後続する副露位置を固定する"
     );
+}
+
+#[test]
+fn own_post_call_discard_keeps_the_hand_left_edge_fixed() {
+    assert_eq!(
+        player_hand_start_x(11),
+        player_hand_start_x(10),
+        "鳴き直後の打牌で手牌の左端を動かさない"
+    );
+}
+
+#[test]
+fn own_tedashi_tiles_move_from_pre_discard_origins() {
+    let mut state = GameState::new();
+    state.hand = vec![
+        Tile::new(Tile::M1),
+        Tile::new(Tile::M3),
+        Tile::new(Tile::P9),
+    ];
+    state.self_tedashi_anim = Some(SelfTedashiAnim {
+        origins: vec![
+            SelfTileOrigin::Hand(0),
+            SelfTileOrigin::Hand(2),
+            SelfTileOrigin::Drawn,
+        ],
+        pre_hand_len: 3,
+        started_at: 100.0,
+    });
+    let start_x = player_hand_start_x(3);
+
+    assert_eq!(player_hand_tile_x(&state, 0, 100.0), start_x);
+    assert_eq!(
+        player_hand_tile_x(&state, 1, 100.0),
+        start_x + 2.0 * TILE_W,
+        "打牌位置の空きを保持する"
+    );
+    assert_eq!(
+        player_hand_tile_x(&state, 2, 100.0),
+        start_x + 3.0 * TILE_W + DRAWN_GAP,
+        "ツモ牌はツモ牌位置から移動を始める"
+    );
+
+    let finished_at = 100.0 + TEDASHI_GAP_HOLD_SECS + TEDASHI_SLIDE_SECS;
+    for i in 0..state.hand.len() {
+        assert_eq!(
+            player_hand_tile_x(&state, i, finished_at),
+            start_x + i as f32 * TILE_W
+        );
+    }
 }

--- a/crates/mahjong-client/src/renderer/tests.rs
+++ b/crates/mahjong-client/src/renderer/tests.rs
@@ -383,7 +383,8 @@ fn export_labeled_tiles_for_visual_check() {
 // --- Opponent hand-discard animation ---
 
 use super::tiles::{
-    TEDASHI_GAP_HOLD_SECS, TEDASHI_SLIDE_SECS, tedashi_progress, tedashi_tile_offset,
+    TEDASHI_GAP_HOLD_SECS, TEDASHI_SLIDE_SECS, opponent_drawn_slot_width, tedashi_progress,
+    tedashi_tile_offset,
 };
 
 #[test]
@@ -423,18 +424,29 @@ fn tedashi_offsets_show_gap_at_discarded_position() {
 }
 
 #[test]
-fn tedashi_offsets_without_drawn_include_recentering_shift() {
+fn tedashi_offsets_without_drawn_only_move_tiles_right_of_gap() {
     let (step, gap) = (28.0, 8.0);
-    // A post-call discard (no drawn tile) shrinks the hand by one, so
-    // centering shifts half a tile and tiles left of the gap slide too.
-    assert_eq!(
-        tedashi_tile_offset(0, 10, 2, false, step, gap, 0.0),
-        -step / 2.0
-    );
-    assert_eq!(
-        tedashi_tile_offset(5, 10, 2, false, step, gap, 0.0),
-        step / 2.0
-    );
+    // A post-call discard must leave tiles left of the discarded tile
+    // fixed while tiles to its right close the gap.
+    assert_eq!(tedashi_tile_offset(0, 10, 2, false, step, gap, 0.0), 0.0);
+    assert_eq!(tedashi_tile_offset(5, 10, 2, false, step, gap, 0.0), step);
     // No offsets at the final position.
     assert_eq!(tedashi_tile_offset(0, 10, 2, false, step, gap, 1.0), 0.0);
+}
+
+#[test]
+fn post_call_discard_keeps_hand_edges_and_melds_fixed() {
+    let (step, gap) = (28.0, 8.0);
+    let before_count = 11;
+    let after_count = 10;
+    let before_slot = opponent_drawn_slot_width(before_count, false, step, gap);
+    let after_slot = opponent_drawn_slot_width(after_count, false, step, gap);
+
+    assert_eq!(before_slot, gap, "鳴き直後は余分な手牌がツモ牌枠を占める");
+    assert_eq!(after_slot, step + gap, "打牌後は通常のツモ牌枠を戻す");
+    assert_eq!(
+        before_count as f32 * step + before_slot,
+        after_count as f32 * step + after_slot,
+        "打牌の前後で手牌領域の両端と後続する副露位置を固定する"
+    );
 }

--- a/crates/mahjong-client/src/renderer/tiles.rs
+++ b/crates/mahjong-client/src/renderer/tiles.rs
@@ -5,12 +5,13 @@ use super::*;
 pub(super) fn draw_hand(state: &GameState, font: Option<&Font>, tile_textures: &TileTextures) {
     let hand_start_x = player_hand_start_x(state.hand.len());
     let hand_y = HAND_Y;
+    let now = get_time();
     let tr = state.tr();
     let dora_tile_types = dora_tile_types(&state.dora_indicators, state.is_three_player());
 
     // Hand first; badges draw later so tiles cannot cover them.
     for (i, tile) in state.hand.iter().enumerate() {
-        let x = hand_start_x + i as f32 * TILE_W;
+        let x = player_hand_tile_x(state, i, now);
         let selected = state.selected_tile == Some(i);
         let riichi_selectable =
             state.riichi_selection_mode && state.riichi_selectable_tiles.contains(&i);

--- a/crates/mahjong-client/src/renderer/tiles.rs
+++ b/crates/mahjong-client/src/renderer/tiles.rs
@@ -486,20 +486,10 @@ pub(super) fn tedashi_progress(elapsed: f64) -> f32 {
     1.0 - (1.0 - t) * (1.0 - t)
 }
 
-/// How far the centering anchor (hand left edge) moved across a hand
-/// discard (pre-discard X minus post-discard X).
-///
-/// With a drawn tile the count is unchanged and there is no shift;
-/// without one (a post-call discard) the hand shrinks by one and the
-/// centering shifts half a tile.
-fn tedashi_start_shift(had_drawn: bool, tile_step: f32) -> f32 {
-    if had_drawn { 0.0 } else { -tile_step / 2.0 }
-}
-
 /// Per-tile X offsets (added to post-discard positions) during the
 /// hand-discard animation.
 ///
-/// - Tiles left of the gap stay put (centering shift only).
+/// - Tiles left of the gap stay put.
 /// - Tiles right of the gap start one tile right (their pre-discard
 ///   spot) and slide left.
 /// - A drawn tile that was hanging out slides from its slot into the
@@ -513,15 +503,33 @@ pub(super) fn tedashi_tile_offset(
     drawn_gap: f32,
     progress: f32,
 ) -> f32 {
-    let shift = tedashi_start_shift(had_drawn, tile_step);
     let from = if final_index < gap_index {
-        shift
+        0.0
     } else if had_drawn && final_index + 1 == hand_count {
-        shift + tile_step + drawn_gap
+        tile_step + drawn_gap
     } else {
-        shift + tile_step
+        tile_step
     };
     from * (1.0 - progress)
+}
+
+/// Width reserved after an opponent's concealed hand for the drawn tile.
+///
+/// A pon/chii temporarily leaves one extra concealed tile until the
+/// caller discards. That tile occupies the drawn-tile slot itself, while
+/// the usual gap remains reserved. Restoring the full slot after the
+/// discard keeps both layout edges fixed while the hand closes its gap.
+pub(super) fn opponent_drawn_slot_width(
+    hand_count: usize,
+    has_drawn: bool,
+    tile_step: f32,
+    drawn_gap: f32,
+) -> f32 {
+    if !has_drawn && hand_count % 3 == 2 {
+        drawn_gap
+    } else {
+        drawn_gap + tile_step
+    }
 }
 
 /// Draws the other players' hands.
@@ -559,7 +567,7 @@ pub(super) fn draw_other_player_hands(state: &GameState, tile_textures: &TileTex
         let drawn_slot = if other.revealed {
             0.0
         } else {
-            OTHER_DRAWN_GAP + tile_step
+            opponent_drawn_slot_width(hand_count, other.has_drawn, tile_step, OTHER_DRAWN_GAP)
         };
         let meld_widths: f32 = other.melds.iter().map(|m| calc_meld_width(m, tw, th)).sum();
         let meld_gaps = if other.melds.is_empty() {
@@ -627,15 +635,12 @@ pub(super) fn draw_other_player_hands(state: &GameState, tile_textures: &TileTex
             x += drawn_slot;
         }
 
-        // Melds continue past the drawn-tile slot; on a post-call discard
-        // they slide together with the hand by the centering shift.
-        let meld_offset = anim.map_or(0.0, |(a, p)| {
-            tedashi_start_shift(a.had_drawn, tile_step) * (1.0 - p)
-        });
+        // Melds continue past the drawn-tile slot. The slot absorbs the
+        // width lost by a post-call discard, so melds remain stationary.
         if !other.melds.is_empty() {
             x += meld_gap;
         }
-        let xs = other_meld_x_positions(&other.melds, tw, th, meld_gap, x + meld_offset);
+        let xs = other_meld_x_positions(&other.melds, tw, th, meld_gap, x);
         for (meld, &mx) in other.melds.iter().zip(&xs) {
             draw_meld_group(meld, mx, base_y, tw, th, tile_textures, tile_tint);
         }

--- a/crates/mahjong-client/src/renderer/tiles.rs
+++ b/crates/mahjong-client/src/renderer/tiles.rs
@@ -3,7 +3,7 @@
 use super::*;
 
 pub(super) fn draw_hand(state: &GameState, font: Option<&Font>, tile_textures: &TileTextures) {
-    let hand_start_x = player_hand_start_x(state.hand.len());
+    let hand_start_x = player_hand_start_x(state.hand.len(), &state.melds);
     let hand_y = HAND_Y;
     let now = get_time();
     let tr = state.tr();
@@ -141,11 +141,11 @@ pub(super) fn draw_melds(state: &GameState, tile_textures: &TileTextures) {
         return;
     }
 
-    let tw: f32 = 40.0;
-    let th: f32 = 56.0;
+    let tw = SELF_MELD_TILE_W;
+    let th = SELF_MELD_TILE_H;
     let meld_y: f32 = 692.0;
-    let meld_gap: f32 = 12.0;
-    let right_edge: f32 = 1220.0;
+    let meld_gap = SELF_MELD_GAP;
+    let right_edge = SELF_MELD_RIGHT_EDGE;
 
     // Earliest meld on the right, later melds further left.
     let xs = self_meld_x_positions(&state.melds, tw, th, meld_gap, right_edge);

--- a/crates/mahjong-server/src/driver.rs
+++ b/crates/mahjong-server/src/driver.rs
@@ -1247,6 +1247,11 @@ mod tests {
         {
             let round = driver.table_mut().current_round_mut().unwrap();
 
+            // Seat 1 is not part of this scenario; leaving its dealt hand intact
+            // can add an unrelated call response and make the manual chain stall.
+            let seat1_wind = round.players[1].seat_wind;
+            round.players[1] = Player::new(seat1_wind, Vec::new(), 25000);
+
             // Seat 0: 13 tiles that can pon a 9s.
             let seat0_wind = round.players[0].seat_wind;
             let seat0_tiles = vec![


### PR DESCRIPTION
## Summary

- Keep concealed tiles to the left of an opponent's hand discard stationary.
- Keep called melds stationary during the post-call discard animation.
- Add regression coverage for both the tile offsets and the stable hand/meld layout width.

## Root cause

After a pon or chii, the caller temporarily has one extra concealed tile until their following discard. Removing that tile reduced the combined hand and meld width, so the renderer recentered the whole layout. The animation compensation therefore moved tiles left of the discard and could also move the called melds.

The layout now lets the temporary extra concealed tile occupy the reserved drawn-tile slot. Restoring the full slot after the discard preserves both layout edges, allowing only tiles to the right of the discarded tile to slide into the gap.

## User impact

Opponent hand-discard animations no longer move unrelated concealed tiles or called melds.

## Validation

- `cargo fmt -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

Fixes #337