### PR TITLE
Animate the player hand after hand discards

### DIFF
--- a/crates/mahjong-client/src/game/events.rs
+++ b/crates/mahjong-client/src/game/events.rs
@@ -44,6 +44,7 @@ impl GameState {
                 self.hand = hand;
                 self.hand.sort();
                 self.drawn = None;
+                self.self_tedashi_anim = None;
                 self.scores = scores;
                 self.round_wind = Some(round_wind);
                 self.dora_indicators = dora_indicators;
@@ -96,6 +97,7 @@ impl GameState {
                 is_furiten,
             } => {
                 self.drawn = Some(tile);
+                self.self_tedashi_anim = None;
                 // Restart the auto-tsumogiri delay for the new draw.
                 self.riichi_auto_discard_at = None;
                 self.remaining_tiles = remaining_tiles;
@@ -405,6 +407,7 @@ impl GameState {
             ServerEvent::HandUpdated { hand } => {
                 self.hand = hand;
                 self.hand.sort();
+                self.self_tedashi_anim = None;
                 self.refresh_self_kan_options();
             }
 

--- a/crates/mahjong-client/src/game/input.rs
+++ b/crates/mahjong-client/src/game/input.rs
@@ -501,7 +501,7 @@ impl GameState {
 
         // Hand clicks use the same centering as the renderer.
         let hand_len = self.hand.len();
-        let hand_start_x = crate::renderer::player_hand_start_x(hand_len);
+        let hand_start_x = crate::renderer::player_hand_start_x(hand_len, &self.melds);
         let hand_y = crate::renderer::HAND_Y;
         let tile_w = 48.0;
         let tile_h = 68.0;

--- a/crates/mahjong-client/src/game/input.rs
+++ b/crates/mahjong-client/src/game/input.rs
@@ -226,15 +226,35 @@ impl GameState {
 
     pub(super) fn apply_local_discard_from_hand(&mut self, idx: usize) -> Tile {
         let discarded_tile = self.hand[idx];
+        let pre_hand_len = self.hand.len();
         self.selected_tile = None;
         self.selected_drawn = false;
+
+        // Sorting tiles together with their origins preserves the
+        // physical instance each final tile should animate from. Matching
+        // by tile value afterwards would be ambiguous for duplicates.
+        let mut tiles_with_origins: Vec<(Tile, SelfTileOrigin)> = self
+            .hand
+            .iter()
+            .copied()
+            .enumerate()
+            .filter(|(hand_idx, _)| *hand_idx != idx)
+            .map(|(hand_idx, tile)| (tile, SelfTileOrigin::Hand(hand_idx)))
+            .collect();
         if let Some(drawn_tile) = self.drawn.take() {
-            self.hand.remove(idx);
-            self.hand.push(drawn_tile);
-            self.hand.sort();
-        } else {
-            self.hand.remove(idx);
+            tiles_with_origins.push((drawn_tile, SelfTileOrigin::Drawn));
         }
+        tiles_with_origins.sort_by_key(|(tile, _)| *tile);
+
+        self.hand = tiles_with_origins.iter().map(|(tile, _)| *tile).collect();
+        self.self_tedashi_anim = Some(SelfTedashiAnim {
+            origins: tiles_with_origins
+                .into_iter()
+                .map(|(_, origin)| origin)
+                .collect(),
+            pre_hand_len,
+            started_at: self.clock,
+        });
         discarded_tile
     }
 
@@ -296,6 +316,7 @@ impl GameState {
         if can_discard && self.selected_drawn {
             self.selected_drawn = false;
             self.drawn.take();
+            self.self_tedashi_anim = None;
             if self.riichi_selection_mode {
                 self.clear_riichi_selection();
                 return self.submit_turn_action(ClientAction::Riichi { tile: None });
@@ -321,6 +342,7 @@ impl GameState {
         if self.phase != GamePhase::Playing {
             return None;
         }
+        self.clock = now;
 
         // Refuse input while unapplied server events remain (e.g. a
         // pending declaration banner): the screen still shows stale state,
@@ -347,6 +369,7 @@ impl GameState {
             }
             self.riichi_auto_discard_at = None;
             self.drawn.take();
+            self.self_tedashi_anim = None;
             return self.submit_turn_action(ClientAction::Discard { tile: None });
         }
 
@@ -439,6 +462,7 @@ impl GameState {
                     if self.is_riichi && self.drawn.is_some() {
                         self.can_pei = false;
                         self.drawn.take();
+                        self.self_tedashi_anim = None;
                         return self.submit_turn_action(ClientAction::Discard { tile: None });
                     }
                     return None;
@@ -484,7 +508,7 @@ impl GameState {
         let selected_raise = 14.0;
 
         for i in 0..hand_len {
-            let x = hand_start_x + i as f32 * tile_w;
+            let x = crate::renderer::player_hand_tile_x(self, i, now);
             let y = if self.selected_tile == Some(i) {
                 hand_y - selected_raise
             } else {

--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -146,6 +146,26 @@ pub struct TedashiAnim {
     pub started_at: f64,
 }
 
+/// A tile's visible position before our hand discard is applied locally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelfTileOrigin {
+    /// The tile was at this index in the concealed hand.
+    Hand(usize),
+    /// The tile was hanging to the right as the drawn tile.
+    Drawn,
+}
+
+/// Gap-closing animation state for our own hand discard.
+#[derive(Debug, Clone)]
+pub struct SelfTedashiAnim {
+    /// Pre-discard origins, aligned with the final sorted hand.
+    pub origins: Vec<SelfTileOrigin>,
+    /// Concealed-hand length before the discard.
+    pub pre_hand_len: usize,
+    /// Animation start time, on the input/process-events clock.
+    pub started_at: f64,
+}
+
 /// Display info for an opponent's hand, indexed relative to us.
 #[derive(Debug, Clone)]
 pub struct OtherPlayerHand {
@@ -195,6 +215,8 @@ pub struct GameState {
     pub hand: Vec<Tile>,
     /// The drawn tile
     pub drawn: Option<Tile>,
+    /// Gap-closing animation of our latest hand discard
+    pub self_tedashi_anim: Option<SelfTedashiAnim>,
     /// Discards per player (0 = self, 1 = right, 2 = across, 3 = left)
     pub discards: [Vec<DiscardInfo>; 4],
     /// Scores
@@ -319,8 +341,8 @@ pub struct GameState {
     event_hold_until: f64,
     /// Whether the front event's banner has been shown (pre-apply hold)
     head_announced: bool,
-    /// The time last passed to [`process_events`](Self::process_events);
-    /// used as the animation start time when applying events.
+    /// The time last passed to [`process_events`](Self::process_events)
+    /// or `handle_input`; used as the animation start time.
     clock: f64,
     /// Display language
     pub lang: Lang,
@@ -365,6 +387,7 @@ impl GameState {
             seat_wind: None,
             hand: Vec::new(),
             drawn: None,
+            self_tedashi_anim: None,
             discards: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             scores: [25000; 4],
             round_wind: None,

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -380,6 +380,84 @@ fn test_hand_selection_still_discards_on_second_click_during_our_turn() {
     ));
     assert!(!state.is_my_turn);
     assert_eq!(state.hand, vec![Tile::new(Tile::M1), Tile::new(Tile::P9)]);
+    assert_eq!(
+        state
+            .self_tedashi_anim
+            .as_ref()
+            .expect("手出しアニメーションが開始されていない")
+            .origins,
+        vec![SelfTileOrigin::Hand(0), SelfTileOrigin::Drawn]
+    );
+}
+
+#[test]
+fn test_local_hand_discard_tracks_origins_through_sorting() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    state.hand = vec![
+        Tile::new(Tile::M2),
+        Tile::new(Tile::M3),
+        Tile::new(Tile::M4),
+    ];
+    state.drawn = Some(Tile::new(Tile::M1));
+    state.process_events(100.0);
+
+    let discarded = state.apply_local_discard_from_hand(1);
+
+    assert_eq!(discarded, Tile::new(Tile::M3));
+    assert_eq!(
+        state.hand,
+        vec![
+            Tile::new(Tile::M1),
+            Tile::new(Tile::M2),
+            Tile::new(Tile::M4),
+        ]
+    );
+    let anim = state
+        .self_tedashi_anim
+        .as_ref()
+        .expect("手出しアニメーションが開始されていない");
+    assert_eq!(anim.pre_hand_len, 3);
+    assert_eq!(anim.started_at, 100.0);
+    assert_eq!(
+        anim.origins,
+        vec![
+            SelfTileOrigin::Drawn,
+            SelfTileOrigin::Hand(0),
+            SelfTileOrigin::Hand(2),
+        ]
+    );
+}
+
+#[test]
+fn test_local_tsumogiri_does_not_start_hand_animation() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    state.drawn = Some(Tile::new(Tile::P9));
+    state.is_my_turn = true;
+    state.selected_drawn = true;
+
+    let action = state.handle_drawn_tile_click();
+
+    assert!(matches!(action, Some(ClientAction::Discard { tile: None })));
+    assert!(state.drawn.is_none());
+    assert!(state.self_tedashi_anim.is_none());
+}
+
+#[test]
+fn test_authoritative_hand_update_clears_local_hand_animation() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+    state.hand = vec![Tile::new(Tile::M1), Tile::new(Tile::M2)];
+    state.drawn = Some(Tile::new(Tile::P9));
+    state.apply_local_discard_from_hand(0);
+    assert!(state.self_tedashi_anim.is_some());
+
+    state.handle_event(ServerEvent::HandUpdated {
+        hand: vec![Tile::new(Tile::S1), Tile::new(Tile::S2)],
+    });
+
+    assert!(state.self_tedashi_anim.is_none());
 }
 
 #[test]

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -139,6 +139,12 @@ impl<'a> TileTintContext<'a> {
 
 const TILE_W: f32 = 48.0;
 const TILE_H: f32 = 68.0;
+const SELF_MELD_TILE_W: f32 = 40.0;
+const SELF_MELD_TILE_H: f32 = 56.0;
+const SELF_MELD_GAP: f32 = 12.0;
+const SELF_MELD_RIGHT_EDGE: f32 = 1220.0;
+const SELF_HAND_MELD_GAP: f32 = 20.0;
+const SELF_HAND_LEFT_MARGIN: f32 = 40.0;
 const FONT_SIZE: u16 = 20;
 const SMALL_FONT: u16 = 16;
 const AGARI_FONT: u16 = 32;
@@ -170,18 +176,34 @@ pub const HAND_Y: f32 = 680.0;
 /// Gap between the hand and the drawn tile to its right.
 pub const DRAWN_GAP: f32 = 20.0;
 
-/// Left X that centers our stable concealed hand on screen.
+/// Left X that centers our stable concealed hand when space permits.
 ///
 /// The drawn tile is excluded from centering and hangs to the right, as
 /// is conventional. Shared by rendering ([`draw_hand`]) and hit testing
-/// (`GameState::handle_input`).
-pub fn player_hand_start_x(hand_len: usize) -> f32 {
+/// (`GameState::handle_input`). Space for the drawn tile is always
+/// reserved when checking the called-meld boundary, so drawing and
+/// discarding do not shift the whole hand.
+pub fn player_hand_start_x(hand_len: usize, melds: &[Meld]) -> f32 {
     // A pon/chii temporarily leaves one extra tile before the caller's
     // discard. Centering on the post-discard length prevents that discard
     // from shifting tiles that were left of the gap (#339).
     let layout_len = hand_len - usize::from(hand_len % 3 == 2);
     let hand_w = layout_len as f32 * TILE_W;
-    (DESIGN_W - hand_w) / 2.0
+    let centered_x = (DESIGN_W - hand_w) / 2.0;
+    if melds.is_empty() {
+        return centered_x;
+    }
+
+    let meld_widths: f32 = melds
+        .iter()
+        .map(|meld| calc_meld_width(meld, SELF_MELD_TILE_W, SELF_MELD_TILE_H))
+        .sum();
+    let meld_gaps = melds.len().saturating_sub(1) as f32 * SELF_MELD_GAP;
+    let meld_left_x = SELF_MELD_RIGHT_EDGE - meld_widths - meld_gaps;
+    let reserved_hand_width = hand_w + DRAWN_GAP + TILE_W;
+    let non_overlapping_x = meld_left_x - SELF_HAND_MELD_GAP - reserved_hand_width;
+
+    centered_x.min(non_overlapping_x).max(SELF_HAND_LEFT_MARGIN)
 }
 
 /// Current X of one tile in our final sorted hand.
@@ -189,7 +211,7 @@ pub fn player_hand_start_x(hand_len: usize) -> f32 {
 /// Rendering and hit testing share this function so animated tiles stay
 /// interactive at the position where they are visible.
 pub(crate) fn player_hand_tile_x(state: &GameState, index: usize, now: f64) -> f32 {
-    let final_x = player_hand_start_x(state.hand.len()) + index as f32 * TILE_W;
+    let final_x = player_hand_start_x(state.hand.len(), &state.melds) + index as f32 * TILE_W;
     let Some(anim) = &state.self_tedashi_anim else {
         return final_x;
     };
@@ -197,7 +219,7 @@ pub(crate) fn player_hand_tile_x(state: &GameState, index: usize, now: f64) -> f
         return final_x;
     };
 
-    let pre_start_x = player_hand_start_x(anim.pre_hand_len);
+    let pre_start_x = player_hand_start_x(anim.pre_hand_len, &state.melds);
     let from_x = match origin {
         SelfTileOrigin::Hand(pre_index) => pre_start_x + *pre_index as f32 * TILE_W,
         SelfTileOrigin::Drawn => pre_start_x + anim.pre_hand_len as f32 * TILE_W + DRAWN_GAP,

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -33,7 +33,7 @@ use mahjong_server::cpu::client::CpuConfig;
 
 use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
 
-use crate::game::{GamePhase, GameState, SetupState};
+use crate::game::{GamePhase, GameState, SelfTileOrigin, SetupState};
 use crate::i18n::Key;
 
 const RIICHI_DISABLED_TINT: Color = Color::new(0.45, 0.45, 0.42, 1.0);
@@ -170,14 +170,40 @@ pub const HAND_Y: f32 = 680.0;
 /// Gap between the hand and the drawn tile to its right.
 pub const DRAWN_GAP: f32 = 20.0;
 
-/// Left X that centers our `hand_len`-tile hand on screen.
+/// Left X that centers our stable concealed hand on screen.
 ///
 /// The drawn tile is excluded from centering and hangs to the right, as
 /// is conventional. Shared by rendering ([`draw_hand`]) and hit testing
 /// (`GameState::handle_input`).
 pub fn player_hand_start_x(hand_len: usize) -> f32 {
-    let hand_w = hand_len as f32 * TILE_W;
+    // A pon/chii temporarily leaves one extra tile before the caller's
+    // discard. Centering on the post-discard length prevents that discard
+    // from shifting tiles that were left of the gap (#339).
+    let layout_len = hand_len - usize::from(hand_len % 3 == 2);
+    let hand_w = layout_len as f32 * TILE_W;
     (DESIGN_W - hand_w) / 2.0
+}
+
+/// Current X of one tile in our final sorted hand.
+///
+/// Rendering and hit testing share this function so animated tiles stay
+/// interactive at the position where they are visible.
+pub(crate) fn player_hand_tile_x(state: &GameState, index: usize, now: f64) -> f32 {
+    let final_x = player_hand_start_x(state.hand.len()) + index as f32 * TILE_W;
+    let Some(anim) = &state.self_tedashi_anim else {
+        return final_x;
+    };
+    let Some(origin) = anim.origins.get(index) else {
+        return final_x;
+    };
+
+    let pre_start_x = player_hand_start_x(anim.pre_hand_len);
+    let from_x = match origin {
+        SelfTileOrigin::Hand(pre_index) => pre_start_x + *pre_index as f32 * TILE_W,
+        SelfTileOrigin::Drawn => pre_start_x + anim.pre_hand_len as f32 * TILE_W + DRAWN_GAP,
+    };
+    let progress = tedashi_progress(now - anim.started_at);
+    final_x + (from_x - final_x) * (1.0 - progress)
 }
 
 /// Camera2D rotations in degrees: self 0, right -90, across 180, left 90.

--- a/crates/mahjong-client/src/renderer/tests.rs
+++ b/crates/mahjong-client/src/renderer/tests.rs
@@ -1,8 +1,9 @@
 //! Unit tests for the rendering layout.
 
 use super::{
-    DORA_TILE_TINT, DRAWN_GAP, PLAYER_ROTATIONS, PUBLIC_TILE_HIGHLIGHT_TINT, TILE_W,
-    add_dora_tile_types, buffer_to_design, calc_meld_width, dora_tile_tint,
+    DORA_TILE_TINT, DRAWN_GAP, PLAYER_ROTATIONS, PUBLIC_TILE_HIGHLIGHT_TINT, SELF_HAND_LEFT_MARGIN,
+    SELF_HAND_MELD_GAP, SELF_MELD_GAP, SELF_MELD_RIGHT_EDGE, SELF_MELD_TILE_H, SELF_MELD_TILE_W,
+    TILE_W, add_dora_tile_types, buffer_to_design, calc_meld_width, dora_tile_tint,
     dora_tile_tint_with_base, dora_tile_types, other_meld_x_positions, player_hand_start_x,
     player_hand_tile_x, public_tile_tint, public_tile_tint_with_base, rotation_index,
     seat_at_relative_position, self_meld_x_positions, visible_tile_tint,
@@ -105,6 +106,17 @@ fn pon(tile_type: TileType) -> Meld {
     Meld {
         tiles: vec![tile, tile, tile],
         category: MeldType::Pon,
+        from: MeldFrom::Previous,
+        called_tile: Some(tile),
+    }
+}
+
+/// Minimal called quad for the layout tests.
+fn called_kan(tile_type: TileType) -> Meld {
+    let tile = Tile::new(tile_type);
+    Meld {
+        tiles: vec![tile; 4],
+        category: MeldType::Kan,
         from: MeldFrom::Previous,
         called_tile: Some(tile),
     }
@@ -455,11 +467,71 @@ fn post_call_discard_keeps_hand_edges_and_melds_fixed() {
 
 #[test]
 fn own_post_call_discard_keeps_the_hand_left_edge_fixed() {
+    let melds = vec![pon(Tile::M1)];
     assert_eq!(
-        player_hand_start_x(11),
-        player_hand_start_x(10),
+        player_hand_start_x(11, &melds),
+        player_hand_start_x(10, &melds),
         "鳴き直後の打牌で手牌の左端を動かさない"
     );
+}
+
+#[test]
+fn own_hand_stays_centered_while_melds_leave_enough_room() {
+    let melds = vec![pon(Tile::M1), pon(Tile::P2)];
+    let hand_len = 7;
+    let centered_x = (super::DESIGN_W - hand_len as f32 * TILE_W) / 2.0;
+
+    assert_eq!(player_hand_start_x(hand_len, &melds), centered_x);
+}
+
+#[test]
+fn own_hand_shifts_left_to_clear_three_melds() {
+    let melds = vec![pon(Tile::M1), pon(Tile::P2), pon(Tile::S3)];
+    let hand_len = 4;
+    let centered_x = (super::DESIGN_W - hand_len as f32 * TILE_W) / 2.0;
+    let hand_start_x = player_hand_start_x(hand_len, &melds);
+    let reserved_hand_right_x = hand_start_x + hand_len as f32 * TILE_W + DRAWN_GAP + TILE_W;
+    let meld_left_x = self_meld_x_positions(
+        &melds,
+        SELF_MELD_TILE_W,
+        SELF_MELD_TILE_H,
+        SELF_MELD_GAP,
+        SELF_MELD_RIGHT_EDGE,
+    )
+    .into_iter()
+    .fold(f32::INFINITY, f32::min);
+
+    assert!(hand_start_x < centered_x, "重なる場合だけ手牌を左へ寄せる");
+    assert_eq!(
+        meld_left_x - reserved_hand_right_x,
+        SELF_HAND_MELD_GAP,
+        "予約ツモ牌枠と副露の間に一定の余白を空ける"
+    );
+}
+
+#[test]
+fn own_hand_and_four_called_quads_fit_without_overlap() {
+    let melds = vec![
+        called_kan(Tile::M1),
+        called_kan(Tile::P2),
+        called_kan(Tile::S3),
+        called_kan(Tile::Z1),
+    ];
+    let hand_len = 1;
+    let hand_start_x = player_hand_start_x(hand_len, &melds);
+    let reserved_hand_right_x = hand_start_x + hand_len as f32 * TILE_W + DRAWN_GAP + TILE_W;
+    let meld_left_x = self_meld_x_positions(
+        &melds,
+        SELF_MELD_TILE_W,
+        SELF_MELD_TILE_H,
+        SELF_MELD_GAP,
+        SELF_MELD_RIGHT_EDGE,
+    )
+    .into_iter()
+    .fold(f32::INFINITY, f32::min);
+
+    assert!(hand_start_x >= SELF_HAND_LEFT_MARGIN);
+    assert!(reserved_hand_right_x + SELF_HAND_MELD_GAP <= meld_left_x);
 }
 
 #[test]
@@ -479,7 +551,7 @@ fn own_tedashi_tiles_move_from_pre_discard_origins() {
         pre_hand_len: 3,
         started_at: 100.0,
     });
-    let start_x = player_hand_start_x(3);
+    let start_x = player_hand_start_x(3, &state.melds);
 
     assert_eq!(player_hand_tile_x(&state, 0, 100.0), start_x);
     assert_eq!(

--- a/crates/mahjong-client/src/renderer/tests.rs
+++ b/crates/mahjong-client/src/renderer/tests.rs
@@ -1,11 +1,13 @@
 //! Unit tests for the rendering layout.
 
 use super::{
-    DORA_TILE_TINT, PLAYER_ROTATIONS, PUBLIC_TILE_HIGHLIGHT_TINT, add_dora_tile_types,
-    buffer_to_design, calc_meld_width, dora_tile_tint, dora_tile_tint_with_base, dora_tile_types,
-    other_meld_x_positions, public_tile_tint, public_tile_tint_with_base, rotation_index,
+    DORA_TILE_TINT, DRAWN_GAP, PLAYER_ROTATIONS, PUBLIC_TILE_HIGHLIGHT_TINT, TILE_W,
+    add_dora_tile_types, buffer_to_design, calc_meld_width, dora_tile_tint,
+    dora_tile_tint_with_base, dora_tile_types, other_meld_x_positions, player_hand_start_x,
+    player_hand_tile_x, public_tile_tint, public_tile_tint_with_base, rotation_index,
     seat_at_relative_position, self_meld_x_positions, visible_tile_tint,
 };
+use crate::game::{GameState, SelfTedashiAnim, SelfTileOrigin};
 use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
 use mahjong_core::tile::{Tile, TileType};
 
@@ -449,4 +451,53 @@ fn post_call_discard_keeps_hand_edges_and_melds_fixed() {
         after_count as f32 * step + after_slot,
         "打牌の前後で手牌領域の両端と後続する副露位置を固定する"
     );
+}
+
+#[test]
+fn own_post_call_discard_keeps_the_hand_left_edge_fixed() {
+    assert_eq!(
+        player_hand_start_x(11),
+        player_hand_start_x(10),
+        "鳴き直後の打牌で手牌の左端を動かさない"
+    );
+}
+
+#[test]
+fn own_tedashi_tiles_move_from_pre_discard_origins() {
+    let mut state = GameState::new();
+    state.hand = vec![
+        Tile::new(Tile::M1),
+        Tile::new(Tile::M3),
+        Tile::new(Tile::P9),
+    ];
+    state.self_tedashi_anim = Some(SelfTedashiAnim {
+        origins: vec![
+            SelfTileOrigin::Hand(0),
+            SelfTileOrigin::Hand(2),
+            SelfTileOrigin::Drawn,
+        ],
+        pre_hand_len: 3,
+        started_at: 100.0,
+    });
+    let start_x = player_hand_start_x(3);
+
+    assert_eq!(player_hand_tile_x(&state, 0, 100.0), start_x);
+    assert_eq!(
+        player_hand_tile_x(&state, 1, 100.0),
+        start_x + 2.0 * TILE_W,
+        "打牌位置の空きを保持する"
+    );
+    assert_eq!(
+        player_hand_tile_x(&state, 2, 100.0),
+        start_x + 3.0 * TILE_W + DRAWN_GAP,
+        "ツモ牌はツモ牌位置から移動を始める"
+    );
+
+    let finished_at = 100.0 + TEDASHI_GAP_HOLD_SECS + TEDASHI_SLIDE_SECS;
+    for i in 0..state.hand.len() {
+        assert_eq!(
+            player_hand_tile_x(&state, i, finished_at),
+            start_x + i as f32 * TILE_W
+        );
+    }
 }

--- a/crates/mahjong-client/src/renderer/tiles.rs
+++ b/crates/mahjong-client/src/renderer/tiles.rs
@@ -5,12 +5,13 @@ use super::*;
 pub(super) fn draw_hand(state: &GameState, font: Option<&Font>, tile_textures: &TileTextures) {
     let hand_start_x = player_hand_start_x(state.hand.len());
     let hand_y = HAND_Y;
+    let now = get_time();
     let tr = state.tr();
     let dora_tile_types = dora_tile_types(&state.dora_indicators, state.is_three_player());
 
     // Hand first; badges draw later so tiles cannot cover them.
     for (i, tile) in state.hand.iter().enumerate() {
-        let x = hand_start_x + i as f32 * TILE_W;
+        let x = player_hand_tile_x(state, i, now);
         let selected = state.selected_tile == Some(i);
         let riichi_selectable =
             state.riichi_selection_mode && state.riichi_selectable_tiles.contains(&i);

--- a/crates/mahjong-client/src/renderer/tiles.rs
+++ b/crates/mahjong-client/src/renderer/tiles.rs
@@ -3,7 +3,7 @@
 use super::*;
 
 pub(super) fn draw_hand(state: &GameState, font: Option<&Font>, tile_textures: &TileTextures) {
-    let hand_start_x = player_hand_start_x(state.hand.len());
+    let hand_start_x = player_hand_start_x(state.hand.len(), &state.melds);
     let hand_y = HAND_Y;
     let now = get_time();
     let tr = state.tr();
@@ -141,11 +141,11 @@ pub(super) fn draw_melds(state: &GameState, tile_textures: &TileTextures) {
         return;
     }
 
-    let tw: f32 = 40.0;
-    let th: f32 = 56.0;
+    let tw = SELF_MELD_TILE_W;
+    let th = SELF_MELD_TILE_H;
     let meld_y: f32 = 692.0;
-    let meld_gap: f32 = 12.0;
-    let right_edge: f32 = 1220.0;
+    let meld_gap = SELF_MELD_GAP;
+    let right_edge = SELF_MELD_RIGHT_EDGE;
 
     // Earliest meld on the right, later melds further left.
     let xs = self_meld_x_positions(&state.melds, tw, th, meld_gap, right_edge);


### PR DESCRIPTION
## Summary

- Animate the local player's concealed hand after a non-tsumogiri discard.
- Preserve each tile's pre-discard origin while sorting the final hand, including the drawn tile and duplicate tile kinds.
- Keep the hand's left edge stable for the discard immediately following a pon or chii.
- Share animated tile coordinates between rendering and hit testing.
- Clear stale animation state on tsumogiri, a new draw, a new hand, or an authoritative hand update.

## Why

Opponent hand discards already show a brief gap before affected tiles slide into place, but the local player's hand changed immediately. The local hand also sorts as soon as the discard is applied optimistically, so an index-only animation cannot identify where each final tile came from.

The new state sorts tiles together with their physical origins, then interpolates every final tile from that origin. This keeps unaffected tiles stationary while allowing the drawn tile and any tiles affected by sorting to move smoothly.

## User impact

The local player's non-tsumogiri discards now use the same gap-and-slide timing as opponents. Tsumogiri remains unchanged, and called melds stay fixed.

## Stacked PR

This PR is based on `fix/#337-keep-opponent-melds-fixed` and depends on PR #338. After #338 is merged, this PR can be retargeted to `main`.

## Validation

- `cargo fmt -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

Fixes #339