### PR TITLE
Prevent the player hand from overlapping melds

### DIFF
--- a/crates/mahjong-client/src/game/input.rs
+++ b/crates/mahjong-client/src/game/input.rs
@@ -501,7 +501,7 @@ impl GameState {
 
         // Hand clicks use the same centering as the renderer.
         let hand_len = self.hand.len();
-        let hand_start_x = crate::renderer::player_hand_start_x(hand_len);
+        let hand_start_x = crate::renderer::player_hand_start_x(hand_len, &self.melds);
         let hand_y = crate::renderer::HAND_Y;
         let tile_w = 48.0;
         let tile_h = 68.0;

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -139,6 +139,12 @@ impl<'a> TileTintContext<'a> {
 
 const TILE_W: f32 = 48.0;
 const TILE_H: f32 = 68.0;
+const SELF_MELD_TILE_W: f32 = 40.0;
+const SELF_MELD_TILE_H: f32 = 56.0;
+const SELF_MELD_GAP: f32 = 12.0;
+const SELF_MELD_RIGHT_EDGE: f32 = 1220.0;
+const SELF_HAND_MELD_GAP: f32 = 20.0;
+const SELF_HAND_LEFT_MARGIN: f32 = 40.0;
 const FONT_SIZE: u16 = 20;
 const SMALL_FONT: u16 = 16;
 const AGARI_FONT: u16 = 32;
@@ -170,18 +176,34 @@ pub const HAND_Y: f32 = 680.0;
 /// Gap between the hand and the drawn tile to its right.
 pub const DRAWN_GAP: f32 = 20.0;
 
-/// Left X that centers our stable concealed hand on screen.
+/// Left X that centers our stable concealed hand when space permits.
 ///
 /// The drawn tile is excluded from centering and hangs to the right, as
 /// is conventional. Shared by rendering ([`draw_hand`]) and hit testing
-/// (`GameState::handle_input`).
-pub fn player_hand_start_x(hand_len: usize) -> f32 {
+/// (`GameState::handle_input`). Space for the drawn tile is always
+/// reserved when checking the called-meld boundary, so drawing and
+/// discarding do not shift the whole hand.
+pub fn player_hand_start_x(hand_len: usize, melds: &[Meld]) -> f32 {
     // A pon/chii temporarily leaves one extra tile before the caller's
     // discard. Centering on the post-discard length prevents that discard
     // from shifting tiles that were left of the gap (#339).
     let layout_len = hand_len - usize::from(hand_len % 3 == 2);
     let hand_w = layout_len as f32 * TILE_W;
-    (DESIGN_W - hand_w) / 2.0
+    let centered_x = (DESIGN_W - hand_w) / 2.0;
+    if melds.is_empty() {
+        return centered_x;
+    }
+
+    let meld_widths: f32 = melds
+        .iter()
+        .map(|meld| calc_meld_width(meld, SELF_MELD_TILE_W, SELF_MELD_TILE_H))
+        .sum();
+    let meld_gaps = melds.len().saturating_sub(1) as f32 * SELF_MELD_GAP;
+    let meld_left_x = SELF_MELD_RIGHT_EDGE - meld_widths - meld_gaps;
+    let reserved_hand_width = hand_w + DRAWN_GAP + TILE_W;
+    let non_overlapping_x = meld_left_x - SELF_HAND_MELD_GAP - reserved_hand_width;
+
+    centered_x.min(non_overlapping_x).max(SELF_HAND_LEFT_MARGIN)
 }
 
 /// Current X of one tile in our final sorted hand.
@@ -189,7 +211,7 @@ pub fn player_hand_start_x(hand_len: usize) -> f32 {
 /// Rendering and hit testing share this function so animated tiles stay
 /// interactive at the position where they are visible.
 pub(crate) fn player_hand_tile_x(state: &GameState, index: usize, now: f64) -> f32 {
-    let final_x = player_hand_start_x(state.hand.len()) + index as f32 * TILE_W;
+    let final_x = player_hand_start_x(state.hand.len(), &state.melds) + index as f32 * TILE_W;
     let Some(anim) = &state.self_tedashi_anim else {
         return final_x;
     };
@@ -197,7 +219,7 @@ pub(crate) fn player_hand_tile_x(state: &GameState, index: usize, now: f64) -> f
         return final_x;
     };
 
-    let pre_start_x = player_hand_start_x(anim.pre_hand_len);
+    let pre_start_x = player_hand_start_x(anim.pre_hand_len, &state.melds);
     let from_x = match origin {
         SelfTileOrigin::Hand(pre_index) => pre_start_x + *pre_index as f32 * TILE_W,
         SelfTileOrigin::Drawn => pre_start_x + anim.pre_hand_len as f32 * TILE_W + DRAWN_GAP,

--- a/crates/mahjong-client/src/renderer/tests.rs
+++ b/crates/mahjong-client/src/renderer/tests.rs
@@ -1,8 +1,9 @@
 //! Unit tests for the rendering layout.
 
 use super::{
-    DORA_TILE_TINT, DRAWN_GAP, PLAYER_ROTATIONS, PUBLIC_TILE_HIGHLIGHT_TINT, TILE_W,
-    add_dora_tile_types, buffer_to_design, calc_meld_width, dora_tile_tint,
+    DORA_TILE_TINT, DRAWN_GAP, PLAYER_ROTATIONS, PUBLIC_TILE_HIGHLIGHT_TINT, SELF_HAND_LEFT_MARGIN,
+    SELF_HAND_MELD_GAP, SELF_MELD_GAP, SELF_MELD_RIGHT_EDGE, SELF_MELD_TILE_H, SELF_MELD_TILE_W,
+    TILE_W, add_dora_tile_types, buffer_to_design, calc_meld_width, dora_tile_tint,
     dora_tile_tint_with_base, dora_tile_types, other_meld_x_positions, player_hand_start_x,
     player_hand_tile_x, public_tile_tint, public_tile_tint_with_base, rotation_index,
     seat_at_relative_position, self_meld_x_positions, visible_tile_tint,
@@ -105,6 +106,17 @@ fn pon(tile_type: TileType) -> Meld {
     Meld {
         tiles: vec![tile, tile, tile],
         category: MeldType::Pon,
+        from: MeldFrom::Previous,
+        called_tile: Some(tile),
+    }
+}
+
+/// Minimal called quad for the layout tests.
+fn called_kan(tile_type: TileType) -> Meld {
+    let tile = Tile::new(tile_type);
+    Meld {
+        tiles: vec![tile; 4],
+        category: MeldType::Kan,
         from: MeldFrom::Previous,
         called_tile: Some(tile),
     }
@@ -455,11 +467,71 @@ fn post_call_discard_keeps_hand_edges_and_melds_fixed() {
 
 #[test]
 fn own_post_call_discard_keeps_the_hand_left_edge_fixed() {
+    let melds = vec![pon(Tile::M1)];
     assert_eq!(
-        player_hand_start_x(11),
-        player_hand_start_x(10),
+        player_hand_start_x(11, &melds),
+        player_hand_start_x(10, &melds),
         "鳴き直後の打牌で手牌の左端を動かさない"
     );
+}
+
+#[test]
+fn own_hand_stays_centered_while_melds_leave_enough_room() {
+    let melds = vec![pon(Tile::M1), pon(Tile::P2)];
+    let hand_len = 7;
+    let centered_x = (super::DESIGN_W - hand_len as f32 * TILE_W) / 2.0;
+
+    assert_eq!(player_hand_start_x(hand_len, &melds), centered_x);
+}
+
+#[test]
+fn own_hand_shifts_left_to_clear_three_melds() {
+    let melds = vec![pon(Tile::M1), pon(Tile::P2), pon(Tile::S3)];
+    let hand_len = 4;
+    let centered_x = (super::DESIGN_W - hand_len as f32 * TILE_W) / 2.0;
+    let hand_start_x = player_hand_start_x(hand_len, &melds);
+    let reserved_hand_right_x = hand_start_x + hand_len as f32 * TILE_W + DRAWN_GAP + TILE_W;
+    let meld_left_x = self_meld_x_positions(
+        &melds,
+        SELF_MELD_TILE_W,
+        SELF_MELD_TILE_H,
+        SELF_MELD_GAP,
+        SELF_MELD_RIGHT_EDGE,
+    )
+    .into_iter()
+    .fold(f32::INFINITY, f32::min);
+
+    assert!(hand_start_x < centered_x, "重なる場合だけ手牌を左へ寄せる");
+    assert_eq!(
+        meld_left_x - reserved_hand_right_x,
+        SELF_HAND_MELD_GAP,
+        "予約ツモ牌枠と副露の間に一定の余白を空ける"
+    );
+}
+
+#[test]
+fn own_hand_and_four_called_quads_fit_without_overlap() {
+    let melds = vec![
+        called_kan(Tile::M1),
+        called_kan(Tile::P2),
+        called_kan(Tile::S3),
+        called_kan(Tile::Z1),
+    ];
+    let hand_len = 1;
+    let hand_start_x = player_hand_start_x(hand_len, &melds);
+    let reserved_hand_right_x = hand_start_x + hand_len as f32 * TILE_W + DRAWN_GAP + TILE_W;
+    let meld_left_x = self_meld_x_positions(
+        &melds,
+        SELF_MELD_TILE_W,
+        SELF_MELD_TILE_H,
+        SELF_MELD_GAP,
+        SELF_MELD_RIGHT_EDGE,
+    )
+    .into_iter()
+    .fold(f32::INFINITY, f32::min);
+
+    assert!(hand_start_x >= SELF_HAND_LEFT_MARGIN);
+    assert!(reserved_hand_right_x + SELF_HAND_MELD_GAP <= meld_left_x);
 }
 
 #[test]
@@ -479,7 +551,7 @@ fn own_tedashi_tiles_move_from_pre_discard_origins() {
         pre_hand_len: 3,
         started_at: 100.0,
     });
-    let start_x = player_hand_start_x(3);
+    let start_x = player_hand_start_x(3, &state.melds);
 
     assert_eq!(player_hand_tile_x(&state, 0, 100.0), start_x);
     assert_eq!(

--- a/crates/mahjong-client/src/renderer/tiles.rs
+++ b/crates/mahjong-client/src/renderer/tiles.rs
@@ -3,7 +3,7 @@
 use super::*;
 
 pub(super) fn draw_hand(state: &GameState, font: Option<&Font>, tile_textures: &TileTextures) {
-    let hand_start_x = player_hand_start_x(state.hand.len());
+    let hand_start_x = player_hand_start_x(state.hand.len(), &state.melds);
     let hand_y = HAND_Y;
     let now = get_time();
     let tr = state.tr();
@@ -141,11 +141,11 @@ pub(super) fn draw_melds(state: &GameState, tile_textures: &TileTextures) {
         return;
     }
 
-    let tw: f32 = 40.0;
-    let th: f32 = 56.0;
+    let tw = SELF_MELD_TILE_W;
+    let th = SELF_MELD_TILE_H;
     let meld_y: f32 = 692.0;
-    let meld_gap: f32 = 12.0;
-    let right_edge: f32 = 1220.0;
+    let meld_gap = SELF_MELD_GAP;
+    let right_edge = SELF_MELD_RIGHT_EDGE;
 
     // Earliest meld on the right, later melds further left.
     let xs = self_meld_x_positions(&state.melds, tw, th, meld_gap, right_edge);


### PR DESCRIPTION
## Summary
- keep the player's called melds anchored at their existing right edge
- shift the concealed hand left only when its reserved drawn-tile slot would overlap the meld area
- share the computed hand origin across rendering, tedashi animation, and hit testing
- cover two-pon, three-meld, and four-called-quad layouts with regression tests

## Root cause
The concealed hand was always centered independently from the right-aligned melds. With three or more calls, especially quads, the two independently positioned areas could overlap.

## User impact
The player's hand now remains centered while space is available and moves left only as much as necessary to preserve a 20 px gap from called melds. The legal worst case of four called quads also fits within the play area.

## Stack
This PR is based on `feat/#339-animate-player-hand-discard` (PR #340) and therefore also depends on PR #338. Retarget it after the parent PRs are merged.

## Validation
- `cargo build`
- `cargo test -p mahjong-client --bin mahjong-client`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`

Fixes #341