### PR TITLE
Detect initial WASM language from browser preferences

### DIFF
--- a/crates/mahjong-client/js/storage.js
+++ b/crates/mahjong-client/js/storage.js
@@ -14,7 +14,26 @@ const MAHJONG_STORAGE_VERSION = 1;
 // 1 = English
 const MAHJONG_LANG_KEY = "mahjong.lang";
 
-// Returns the saved display language; -1 when unset or invalid.
+function mahjong_storage_browser_lang() {
+    let languages = [];
+    if (typeof navigator !== "undefined") {
+        if (Array.isArray(navigator.languages) && navigator.languages.length > 0) {
+            languages = navigator.languages;
+        } else if (typeof navigator.language === "string") {
+            languages = [navigator.language];
+        }
+    }
+
+    const hasJapanese = languages.some((language) => {
+        if (typeof language !== "string") {
+            return false;
+        }
+        const normalized = language.toLowerCase();
+        return normalized === "ja" || normalized.startsWith("ja-");
+    });
+    return hasJapanese ? 0 : 1;
+}
+
 function mahjong_storage_get_lang() {
     try {
         const v = window.localStorage.getItem(MAHJONG_LANG_KEY);
@@ -24,12 +43,10 @@ function mahjong_storage_get_lang() {
         if (v === "en") {
             return 1;
         }
-        return -1;
     } catch (_err) {
-        // Environments without localStorage (private mode etc.)
-        // read as unset.
-        return -1;
+        // Browser detection keeps first launch usable when storage is blocked.
     }
+    return mahjong_storage_browser_lang();
 }
 
 // Saves the display language (0 = Japanese, 1 = English; others ignored).

--- a/crates/mahjong-client/js/storage.test.js
+++ b/crates/mahjong-client/js/storage.test.js
@@ -1,0 +1,62 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const storagePluginSource = fs.readFileSync(
+    path.join(__dirname, "storage.js"),
+    "utf8",
+);
+
+function loadLanguage({ saved = null, languages, language, storageError = false }) {
+    let plugin;
+    const context = {
+        window: {
+            localStorage: {
+                getItem() {
+                    if (storageError) {
+                        throw new Error("localStorage unavailable");
+                    }
+                    return saved;
+                },
+                setItem() {},
+            },
+        },
+        navigator: { languages, language },
+        miniquad_add_plugin(registeredPlugin) {
+            plugin = registeredPlugin;
+        },
+    };
+    vm.runInNewContext(storagePluginSource, context);
+
+    const importObject = { env: {} };
+    plugin.register_plugin(importObject);
+    return importObject.env.mahjong_storage_get_lang();
+}
+
+test("a saved language takes precedence over browser preferences", () => {
+    assert.equal(loadLanguage({ saved: "ja", languages: ["en-US"] }), 0);
+    assert.equal(loadLanguage({ saved: "en", languages: ["ja-JP"] }), 1);
+});
+
+test("Japanese anywhere in the browser language list selects Japanese", () => {
+    assert.equal(loadLanguage({ languages: ["en-US", "ja-JP"] }), 0);
+    assert.equal(loadLanguage({ languages: ["JA"] }), 0);
+});
+
+test("browser preferences without Japanese select English", () => {
+    assert.equal(loadLanguage({ languages: ["en-US", "fr-FR"] }), 1);
+    assert.equal(loadLanguage({ languages: ["javanese"] }), 1);
+});
+
+test("navigator.language is used when navigator.languages is unavailable", () => {
+    assert.equal(loadLanguage({ language: "ja-JP" }), 0);
+    assert.equal(loadLanguage({ language: "en-US" }), 1);
+});
+
+test("browser preferences remain available when localStorage throws", () => {
+    assert.equal(loadLanguage({ languages: ["ja"], storageError: true }), 0);
+});

--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -471,8 +471,6 @@ impl GameState {
             event_hold_until: 0.0,
             head_announced: false,
             clock: 0.0,
-            // Load the saved display language (Japanese when unsaved) so
-            // the choice survives new() being rebuilt on "play again".
             lang: crate::persistence::load_lang().unwrap_or(Lang::Ja),
         }
     }

--- a/crates/mahjong-client/src/persistence.rs
+++ b/crates/mahjong-client/src/persistence.rs
@@ -26,7 +26,10 @@ fn code_to_lang(code: i32) -> Option<Lang> {
     }
 }
 
-/// Loads the saved display language; `None` when unsaved or invalid.
+/// Loads the display language selected by the platform backend.
+///
+/// WASM uses a saved choice first and otherwise detects the browser preference;
+/// native returns `None` when the setting is unsaved or invalid.
 pub fn load_lang() -> Option<Lang> {
     code_to_lang(load_lang_code())
 }


### PR DESCRIPTION
## Summary

- Preserve an explicitly saved display-language choice.
- Detect the initial WASM language from `navigator.languages`, with a `navigator.language` fallback.
- Select Japanese when any preference is `ja` or `ja-*`; otherwise select English.
- Keep the native client's Japanese default unchanged.
- Add JavaScript regression tests for detection, precedence, and unavailable storage.

## Root cause

The storage plugin returned an unset value when no language had been saved, so the shared Rust initialization always applied its Japanese fallback regardless of the browser language preferences.

## User impact

First-time WASM users now see the client in a language selected from their browser preferences, while returning users retain their explicit choice.

## Validation

- `node --test crates/mahjong-client/js/storage.test.js`
- `cargo fmt --check`
- `cargo build`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --locked --target wasm32-unknown-unknown -p mahjong-client`

Fixes #347