### PR TITLE
Clarify the multiple-ron rule description

### DIFF
--- a/crates/mahjong-client/src/i18n/mod.rs
+++ b/crates/mahjong-client/src/i18n/mod.rs
@@ -679,8 +679,12 @@ impl Key {
                 Lang::En => "Ends the hand when three players ron the same discard.",
             },
             Key::RuleMultipleRonDescription => match lang {
-                Lang::Ja => "同じ捨て牌への複数人のロンをすべて認めます。",
-                Lang::En => "Allows every player who declares ron on the same discard to win.",
+                Lang::Ja => {
+                    "同じ捨て牌への複数人のロン（ダブロン・トリロン）をすべて認めます。\nオフの時は頭ハネ（放銃者からツモ順が最も早い和了者のみ）となります。\nオン・オフともに供託棒は頭ハネになります。"
+                }
+                Lang::En => {
+                    "Allows double and triple ron on the same discard.\nOff uses head bump: only the earliest winner after the discarder wins.\nRiichi deposits use head-bump priority in both modes."
+                }
             },
             Key::RuleYakumanPaoDescription => match lang {
                 Lang::Ja => "大三元・大四喜・四槓子を確定させた打牌に責任払いを適用します。",

--- a/crates/mahjong-client/src/renderer/menu.rs
+++ b/crates/mahjong-client/src/renderer/menu.rs
@@ -616,7 +616,7 @@ fn rule_description_rect() -> Rect2 {
         x: panel_x() + 32.0,
         y: 480.0,
         w: PANEL_W - 64.0,
-        h: 106.0,
+        h: 112.0,
     }
 }
 
@@ -970,6 +970,27 @@ mod tests {
             assert!(description.contains(name), "missing {name}");
         }
         assert_eq!(description.lines().count(), 2);
+    }
+
+    #[test]
+    fn multiple_ron_description_explains_head_bump_priority_and_fits_panel() {
+        let ja = Key::RuleMultipleRonDescription.text(Lang::Ja);
+        let en = Key::RuleMultipleRonDescription.text(Lang::En);
+
+        for phrase in ["ダブロン・トリロン", "オフの時は頭ハネ", "供託棒は頭ハネ"]
+        {
+            assert!(ja.contains(phrase), "missing {phrase}");
+        }
+        assert!(en.contains("double and triple ron"));
+        assert!(en.contains("Off uses head bump"));
+        assert!(en.contains("Riichi deposits use head-bump priority"));
+        assert_eq!(ja.lines().count(), 3);
+        assert_eq!(en.lines().count(), 3);
+
+        let description = rule_description_rect();
+        let last_baseline = description.y + 73.0 + 2.0 * 18.0;
+        assert!(last_baseline <= description.y + description.h);
+        assert!(description.y + description.h < rule_confirm_rect().y);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- explain that the enabled multiple-ron rule allows double and triple ron on the same discard
- explain that disabling the rule applies head-bump priority from the discarder
- clarify that riichi deposits use head-bump priority in both modes
- keep the Japanese and English descriptions aligned
- expand the description panel for three lines and add layout regression coverage

## Why

The previous description only explained the enabled behavior. It did not tell players how winners or riichi deposits are selected when several players declare ron.

## Impact

Players can understand the full effect of the multiple-ron toggle before starting a local or online match. Game logic is unchanged.

## Validation

- `cargo fmt`
- `cargo test -p mahjong-client --bin mahjong-client`
- `cargo clippy`
- `git diff --check`

Closes #351