### PR TITLE
Add animated startup loading progress

### DIFF
--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -11,7 +11,7 @@
             width: 100%;
             height: 100%;
             overflow: hidden;
-            background: #000;
+            background: #060e09;
         }
         /* Letterbox the canvas at the window center. */
         body {
@@ -22,9 +22,72 @@
         canvas {
             display: block;
         }
+        #loading {
+            position: fixed;
+            inset: 0;
+            z-index: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-direction: column;
+            gap: 20px;
+            color: #ece4d2;
+            font: 28px/1.2 system-ui, sans-serif;
+        }
+        .loading-label {
+            display: flex;
+            align-items: center;
+            gap: 18px;
+        }
+        .loading-spinner {
+            box-sizing: border-box;
+            width: 28px;
+            height: 28px;
+            border: 3px solid rgba(232, 200, 74, 0.3);
+            border-top-color: #e8c84a;
+            border-radius: 50%;
+            animation: loading-spin 0.8s linear infinite;
+        }
+        .loading-progress {
+            position: relative;
+            width: min(320px, 60vw);
+            height: 10px;
+            overflow: hidden;
+            border: 1px solid rgba(232, 200, 74, 0.6);
+            background: #050e08;
+        }
+        .loading-progress::after {
+            position: absolute;
+            inset-block: 0;
+            width: 35%;
+            content: "";
+            background: #c9a227;
+            animation: loading-sweep 1.1s ease-in-out infinite alternate;
+        }
+        #loading[hidden] {
+            display: none;
+        }
+        @keyframes loading-spin {
+            to { transform: rotate(360deg); }
+        }
+        @keyframes loading-sweep {
+            from { left: -35%; }
+            to { left: 100%; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .loading-spinner, .loading-progress::after { animation: none; }
+            .loading-progress::after { left: 32.5%; }
+        }
     </style>
 </head>
 <body>
+    <div id="loading" role="status" aria-live="polite">
+        <div class="loading-label">
+            <span class="loading-spinner" aria-hidden="true"></span>
+            <span>Loading...</span>
+        </div>
+        <div class="loading-progress" aria-hidden="true"></div>
+    </div>
     <canvas id="glcanvas" tabindex='1' width="1280" height="800"></canvas>
     <script>
         // Online server URL. When unset, ws://127.0.0.1:8080/ws (local
@@ -57,6 +120,7 @@
     <script src="mq_js_bundle.js"></script>
     <script src="ws.js"></script>
     <script src="storage.js"></script>
+    <script src="loading.js"></script>
     <script>
         if (typeof load === "function") {
             load("mahjong-client.wasm");

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -31,6 +31,8 @@
             justify-content: center;
             flex-direction: column;
             gap: 20px;
+            /* Keep the canvas loader hidden until this overlay is removed. */
+            background: #060e09;
             color: #ece4d2;
             font: 28px/1.2 system-ui, sans-serif;
         }

--- a/crates/mahjong-client/js/loading.js
+++ b/crates/mahjong-client/js/loading.js
@@ -1,0 +1,23 @@
+// Startup loading-overlay plugin.
+//
+// The HTML overlay is visible before WASM exists. Rust hides it only after
+// Macroquad has presented its own loading frame, avoiding a black gap between
+// browser startup and synchronous asset initialization.
+"use strict";
+
+const MAHJONG_LOADING_VERSION = 1;
+
+function mahjong_loading_hide() {
+    const overlay = document.getElementById("loading");
+    if (overlay) {
+        overlay.hidden = true;
+    }
+}
+
+miniquad_add_plugin({
+    name: "mahjong_loading",
+    version: MAHJONG_LOADING_VERSION,
+    register_plugin(importObject) {
+        importObject.env.mahjong_loading_hide = mahjong_loading_hide;
+    },
+});

--- a/crates/mahjong-client/js/loading.test.js
+++ b/crates/mahjong-client/js/loading.test.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const loadingPluginSource = fs.readFileSync(
+    path.join(__dirname, "loading.js"),
+    "utf8",
+);
+
+function loadPlugin(overlay) {
+    let plugin;
+    const context = {
+        document: {
+            getElementById(id) {
+                return id === "loading" ? overlay : null;
+            },
+        },
+        miniquad_add_plugin(registeredPlugin) {
+            plugin = registeredPlugin;
+        },
+    };
+    vm.runInNewContext(loadingPluginSource, context);
+
+    const importObject = { env: {} };
+    plugin.register_plugin(importObject);
+    return importObject.env.mahjong_loading_hide;
+}
+
+test("the WASM callback hides the startup overlay", () => {
+    const overlay = { hidden: false };
+    loadPlugin(overlay)();
+    assert.equal(overlay.hidden, true);
+});
+
+test("the WASM callback tolerates a missing startup overlay", () => {
+    assert.doesNotThrow(() => loadPlugin(null)());
+});

--- a/crates/mahjong-client/js/loading.test.js
+++ b/crates/mahjong-client/js/loading.test.js
@@ -10,6 +10,10 @@ const loadingPluginSource = fs.readFileSync(
     path.join(__dirname, "loading.js"),
     "utf8",
 );
+const startupPageSource = fs.readFileSync(
+    path.join(__dirname, "../../../assets/web/index.html"),
+    "utf8",
+);
 
 function loadPlugin(overlay) {
     let plugin;
@@ -38,4 +42,11 @@ test("the WASM callback hides the startup overlay", () => {
 
 test("the WASM callback tolerates a missing startup overlay", () => {
     assert.doesNotThrow(() => loadPlugin(null)());
+});
+
+test("the startup overlay obscures the canvas until WASM hides it", () => {
+    assert.match(
+        startupPageSource,
+        /#loading\s*\{[^}]*background:\s*#060e09\s*;/s,
+    );
 });

--- a/crates/mahjong-client/src/loading.rs
+++ b/crates/mahjong-client/src/loading.rs
@@ -1,0 +1,175 @@
+//! Startup loading screen shared by the native and WASM clients.
+
+use macroquad::prelude::*;
+
+const SPINNER_DOTS: usize = 8;
+const SPINNER_STEP_SECONDS: f64 = 0.1;
+
+/// Animated loading screen used while startup work proceeds cooperatively.
+pub struct LoadingScreen {
+    completed_steps: usize,
+    total_steps: usize,
+    web_overlay_hidden: bool,
+}
+
+impl LoadingScreen {
+    pub fn new(total_steps: usize) -> Self {
+        assert!(total_steps > 0);
+        Self {
+            completed_steps: 0,
+            total_steps,
+            web_overlay_hidden: false,
+        }
+    }
+
+    /// Presents the current animation frame and yields to the platform event loop.
+    pub async fn next_frame(&mut self) {
+        draw(
+            get_time(),
+            progress_ratio(self.completed_steps, self.total_steps),
+        );
+        next_frame().await;
+
+        if !self.web_overlay_hidden {
+            hide_web_overlay();
+            self.web_overlay_hidden = true;
+        }
+    }
+
+    /// Records one completed startup unit before presenting the next frame.
+    pub async fn complete_step(&mut self) {
+        debug_assert!(self.completed_steps < self.total_steps);
+        self.completed_steps = (self.completed_steps + 1).min(self.total_steps);
+        self.next_frame().await;
+    }
+}
+
+fn draw(now: f64, progress: f32) {
+    clear_background(Color::from_rgba(6, 14, 9, 255));
+    crate::renderer::set_design_camera();
+
+    let label = "Loading...";
+    let font_size = 28;
+    let dimensions = measure_text(label, None, font_size, 1.0);
+    let spinner_diameter = 28.0;
+    let gap = 18.0;
+    let group_width = spinner_diameter + gap + dimensions.width;
+    let group_x = (crate::renderer::DESIGN_W - group_width) / 2.0;
+    let center_y = crate::renderer::DESIGN_H / 2.0;
+    let spinner_center = vec2(group_x + spinner_diameter / 2.0, center_y);
+    let head = spinner_head(now);
+
+    for index in 0..SPINNER_DOTS {
+        let angle = index as f32 * std::f32::consts::TAU / SPINNER_DOTS as f32;
+        let distance_from_head = (head + SPINNER_DOTS - index) % SPINNER_DOTS;
+        let alpha = 1.0 - distance_from_head as f32 * 0.1;
+        draw_circle(
+            spinner_center.x + angle.cos() * 11.0,
+            spinner_center.y + angle.sin() * 11.0,
+            3.0,
+            Color::new(0.91, 0.78, 0.29, alpha),
+        );
+    }
+
+    draw_text_ex(
+        label,
+        group_x + spinner_diameter + gap,
+        center_y + dimensions.height / 2.0,
+        TextParams {
+            font_size,
+            color: Color::from_rgba(236, 228, 210, 255),
+            ..Default::default()
+        },
+    );
+
+    let bar_width = 320.0;
+    let bar_height = 10.0;
+    let bar_x = (crate::renderer::DESIGN_W - bar_width) / 2.0;
+    let bar_y = center_y + 42.0;
+    draw_rectangle(
+        bar_x,
+        bar_y,
+        bar_width,
+        bar_height,
+        Color::from_rgba(5, 14, 8, 255),
+    );
+    draw_rectangle(
+        bar_x,
+        bar_y,
+        bar_width * progress,
+        bar_height,
+        Color::from_rgba(201, 162, 39, 255),
+    );
+    draw_rectangle_lines(
+        bar_x,
+        bar_y,
+        bar_width,
+        bar_height,
+        1.0,
+        Color::from_rgba(232, 200, 74, 150),
+    );
+
+    let percentage = format!("{:.0}%", progress * 100.0);
+    let percentage_size = 18;
+    let percentage_dimensions = measure_text(&percentage, None, percentage_size, 1.0);
+    draw_text_ex(
+        &percentage,
+        (crate::renderer::DESIGN_W - percentage_dimensions.width) / 2.0,
+        bar_y + bar_height + percentage_dimensions.height + 10.0,
+        TextParams {
+            font_size: percentage_size,
+            color: Color::from_rgba(163, 188, 171, 255),
+            ..Default::default()
+        },
+    );
+}
+
+fn spinner_head(now: f64) -> usize {
+    ((now / SPINNER_STEP_SECONDS) as usize) % SPINNER_DOTS
+}
+
+fn progress_ratio(completed_steps: usize, total_steps: usize) -> f32 {
+    debug_assert!(total_steps > 0);
+    completed_steps.min(total_steps) as f32 / total_steps as f32
+}
+
+#[cfg(target_arch = "wasm32")]
+fn hide_web_overlay() {
+    // loading.js registers this import before the WASM module is instantiated.
+    unsafe { mahjong_loading_hide() };
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn hide_web_overlay() {}
+
+#[cfg(target_arch = "wasm32")]
+unsafe extern "C" {
+    fn mahjong_loading_hide();
+}
+
+/// Version handshake for the JavaScript loading-overlay plugin.
+#[cfg(target_arch = "wasm32")]
+#[unsafe(no_mangle)]
+pub extern "C" fn mahjong_loading_crate_version() -> u32 {
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spinner_advances_and_wraps() {
+        assert_eq!(spinner_head(0.0), 0);
+        assert_eq!(spinner_head(SPINNER_STEP_SECONDS), 1);
+        assert_eq!(spinner_head(SPINNER_STEP_SECONDS * SPINNER_DOTS as f64), 0);
+    }
+
+    #[test]
+    fn progress_ratio_tracks_steps_and_stays_bounded() {
+        assert_eq!(progress_ratio(0, 42), 0.0);
+        assert_eq!(progress_ratio(21, 42), 0.5);
+        assert_eq!(progress_ratio(42, 42), 1.0);
+        assert_eq!(progress_ratio(43, 42), 1.0);
+    }
+}

--- a/crates/mahjong-client/src/main.rs
+++ b/crates/mahjong-client/src/main.rs
@@ -10,6 +10,7 @@ use macroquad::prelude::*;
 mod adapter;
 mod game;
 mod i18n;
+mod loading;
 mod persistence;
 mod renderer;
 #[cfg(not(target_arch = "wasm32"))]
@@ -196,9 +197,17 @@ fn sync_online_ui(remote: &mut RemoteAdapter, state: &mut GameState) {
 
 #[macroquad::main(window_conf)]
 async fn main() {
+    #[cfg(target_arch = "wasm32")]
+    let loading_steps = 1 + renderer::TEXTURE_LOAD_STEPS;
+    #[cfg(not(target_arch = "wasm32"))]
+    let loading_steps = 1 + renderer::TEXTURE_LOAD_STEPS + renderer::FONT_PREWARM_STEPS;
+    let mut loading_screen = loading::LoadingScreen::new(loading_steps);
+    loading_screen.next_frame().await;
+
     let font_bytes: &[u8] = include_bytes!("../../../assets/fonts/ShipporiMincho-Regular.ttf");
     let font = load_ttf_font_from_bytes(font_bytes).ok();
-    let tile_textures = TileTextures::load(font_bytes);
+    loading_screen.complete_step().await;
+    let tile_textures = TileTextures::load(font_bytes, &mut loading_screen).await;
 
     if font.is_none() {
         eprintln!("警告: 日本語フォントを読み込めませんでした。デフォルトフォントで表示します。");
@@ -216,7 +225,7 @@ async fn main() {
     // Skipping the prewarm lets glyphs cache one at a time as they
     // appear, avoiding the mass repacking.
     #[cfg(not(target_arch = "wasm32"))]
-    renderer::prewarm_fonts(font.as_ref());
+    renderer::prewarm_fonts(font.as_ref(), &mut loading_screen).await;
 
     // The in-game adapter (local or remote).
     let mut adapter: Option<Box<dyn GameAdapter>> = None;

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -163,6 +163,13 @@ const USED_FONT_SIZES: [u16; 16] = [
     9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 21, 24, 26, 28, 32,
 ];
 
+/// Startup units used to prepare the label font and all tile-related textures.
+pub const TEXTURE_LOAD_STEPS: usize = 1 + Tile::LEN + 3 + 4;
+
+/// Startup units used to prewarm each native font size.
+#[cfg(not(target_arch = "wasm32"))]
+pub const FONT_PREWARM_STEPS: usize = USED_FONT_SIZES.len();
+
 /// Design resolution. All UI coordinates live on this virtual canvas and
 /// scale to the real window. The HTML keeps this aspect ratio; native
 /// windows may be resized to a different one.
@@ -362,11 +369,17 @@ pub struct TileTextures {
 }
 
 impl TileTextures {
-    /// Loads every texture. `font_bytes` is the TTF used to bake labels;
-    /// when unavailable the unlabeled set stands in.
-    pub fn load(font_bytes: &[u8]) -> Self {
+    /// Loads every texture while yielding between tiles for startup animation.
+    ///
+    /// `font_bytes` is the TTF used to bake labels; when unavailable the
+    /// unlabeled set stands in.
+    pub async fn load(
+        font_bytes: &[u8],
+        loading_screen: &mut crate::loading::LoadingScreen,
+    ) -> Self {
         let label_font =
             fontdue::Font::from_bytes(font_bytes, fontdue::FontSettings::default()).ok();
+        loading_screen.complete_step().await;
 
         let mut standard_tiles = Vec::with_capacity(Tile::LEN);
         let mut labeled_tiles = Vec::with_capacity(Tile::LEN);
@@ -378,31 +391,52 @@ impl TileTextures {
                 tile_type as mahjong_core::tile::TileType,
                 label_font.as_ref(),
             ));
+            loading_screen.complete_step().await;
         }
 
         let red_5m_img = image_from_png(include_bytes!("../../../../assets/images/tiles/r5m.png"));
+        let red_5m = texture_from_image(&red_5m_img);
+        let labeled_red_5m = labeled_texture(red_5m_img, Tile::M5, label_font.as_ref());
+        loading_screen.complete_step().await;
+
         let red_5p_img = image_from_png(include_bytes!("../../../../assets/images/tiles/r5p.png"));
+        let red_5p = texture_from_image(&red_5p_img);
+        let labeled_red_5p = labeled_texture(red_5p_img, Tile::P5, label_font.as_ref());
+        loading_screen.complete_step().await;
+
         let red_5s_img = image_from_png(include_bytes!("../../../../assets/images/tiles/r5s.png"));
+        let red_5s = texture_from_image(&red_5s_img);
+        let labeled_red_5s = labeled_texture(red_5s_img, Tile::S5, label_font.as_ref());
+        loading_screen.complete_step().await;
+
+        let back =
+            load_texture_from_png(include_bytes!("../../../../assets/images/tiles/back.png"));
+        loading_screen.complete_step().await;
+        let stick1000 = load_texture_from_png(include_bytes!(
+            "../../../../assets/images/sticks/stick1000.png"
+        ));
+        loading_screen.complete_step().await;
+        let stick100 = load_texture_from_png(include_bytes!(
+            "../../../../assets/images/sticks/stick100.png"
+        ));
+        loading_screen.complete_step().await;
+        let logo =
+            load_texture_from_png(include_bytes!("../../../../assets/images/others/logo.png"));
+        loading_screen.complete_step().await;
 
         Self {
             standard_tiles,
             labeled_tiles,
-            red_5m: texture_from_image(&red_5m_img),
-            red_5p: texture_from_image(&red_5p_img),
-            red_5s: texture_from_image(&red_5s_img),
-            labeled_red_5m: labeled_texture(red_5m_img, Tile::M5, label_font.as_ref()),
-            labeled_red_5p: labeled_texture(red_5p_img, Tile::P5, label_font.as_ref()),
-            labeled_red_5s: labeled_texture(red_5s_img, Tile::S5, label_font.as_ref()),
-            back: load_texture_from_png(include_bytes!("../../../../assets/images/tiles/back.png")),
-            stick1000: load_texture_from_png(include_bytes!(
-                "../../../../assets/images/sticks/stick1000.png"
-            )),
-            stick100: load_texture_from_png(include_bytes!(
-                "../../../../assets/images/sticks/stick100.png"
-            )),
-            logo: load_texture_from_png(include_bytes!(
-                "../../../../assets/images/others/logo.png"
-            )),
+            red_5m,
+            red_5p,
+            red_5s,
+            labeled_red_5m,
+            labeled_red_5p,
+            labeled_red_5s,
+            back,
+            stick1000,
+            stick100,
+            logo,
             labels_enabled: std::cell::Cell::new(false),
         }
     }
@@ -496,7 +530,10 @@ fn draw_jp_text(font: Option<&Font>, text: &str, x: f32, y: f32, font_size: u16,
 /// entirely (the black-square issue is native-only; verified absent on
 /// WASM without the prewarm).
 #[cfg(not(target_arch = "wasm32"))]
-pub fn prewarm_fonts(font: Option<&Font>) {
+pub async fn prewarm_fonts(
+    font: Option<&Font>,
+    loading_screen: &mut crate::loading::LoadingScreen,
+) {
     // Every glyph the UI shows (generated by scripts/extract_glyphs.py).
     let mut glyphs: String = include_str!("../../glyphs.txt").to_string();
     // ASCII too: digits, punctuation, Latin text like "CPU".
@@ -505,6 +542,7 @@ pub fn prewarm_fonts(font: Option<&Font>) {
     }
     for &base in &USED_FONT_SIZES {
         let _ = theme::measure_scaled(font, &glyphs, base);
+        loading_screen.complete_step().await;
     }
 }
 

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -29,6 +29,7 @@ cargo build --locked --release --target wasm32-unknown-unknown -p mahjong-client
 cp target/wasm32-unknown-unknown/release/mahjong-client.wasm public/mahjong-client.wasm
 cp crates/mahjong-client/js/ws.js public/ws.js
 cp crates/mahjong-client/js/storage.js public/storage.js
+cp crates/mahjong-client/js/loading.js public/loading.js
 cp assets/web/favicon.png public/favicon.png
 cp assets/web/index.html public/index.html
 
@@ -39,15 +40,18 @@ wasm_hash=$(sha1sum public/mahjong-client.wasm | cut -c1-8)
 js_hash=$(sha1sum public/mq_js_bundle.js | cut -c1-8)
 ws_hash=$(sha1sum public/ws.js | cut -c1-8)
 storage_hash=$(sha1sum public/storage.js | cut -c1-8)
+loading_hash=$(sha1sum public/loading.js | cut -c1-8)
 mv public/mahjong-client.wasm "public/mahjong-client.${wasm_hash}.wasm"
 mv public/mq_js_bundle.js "public/mq_js_bundle.${js_hash}.js"
 mv public/ws.js "public/ws.${ws_hash}.js"
 mv public/storage.js "public/storage.${storage_hash}.js"
+mv public/loading.js "public/loading.${loading_hash}.js"
 
 sed -i "s|load(\"mahjong-client.wasm\")|load(\"mahjong-client.${wasm_hash}.wasm\")|" public/index.html
 sed -i "s|src=\"mq_js_bundle.js\"|src=\"mq_js_bundle.${js_hash}.js\"|" public/index.html
 sed -i "s|src=\"ws.js\"|src=\"ws.${ws_hash}.js\"|" public/index.html
 sed -i "s|src=\"storage.js\"|src=\"storage.${storage_hash}.js\"|" public/index.html
+sed -i "s|src=\"loading.js\"|src=\"loading.${loading_hash}.js\"|" public/index.html
 
 # The online game server URL for the deployed client. Set the
 # MAHJONG_SERVER_URL environment variable in the Vercel project to


### PR DESCRIPTION
## Summary

- show an immediate animated loading state for native and WASM startup
- yield between texture and font initialization steps so the UI remains responsive
- show determinate Rust-side progress and an indeterminate pre-WASM progress bar
- package the loading bridge in hashed web assets without wasm-bindgen

## Why

Startup previously showed a black screen for several seconds, which made the client appear frozen.

## User impact

Players now receive visible, animated feedback throughout startup and a percentage once Rust-side initialization begins.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --locked`
- `node --test crates/mahjong-client/js/loading.test.js crates/mahjong-client/js/storage.test.js`
- `bash scripts/vercel-build.sh`
- Visual WASM verification in browser (animated spinner progressed and menu loaded)

Fixes #358