### PR TITLE
Show rankings and score gaps in top bar

### DIFF
--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -532,11 +532,11 @@ impl GameState {
         self.player_labels = seats.clone();
     }
 
-    /// Final standings as (seat, score) from first to last.
+    /// Standings as (seat, score) from first to last.
     ///
     /// Ties go to the seat closer to the starting dealer; the dummy seat
     /// is excluded in three-player games.
-    pub fn final_rankings(&self) -> Vec<(usize, i32)> {
+    pub fn rankings(&self) -> Vec<(usize, i32)> {
         let n = self.player_count;
         let mut rankings: Vec<(usize, i32)> = self
             .scores

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -94,29 +94,29 @@ fn test_initial_dealer_seat_derived_from_game_started() {
 }
 
 #[test]
-fn test_final_rankings_tie_breaks_by_dealer_proximity() {
+fn test_rankings_tie_breaks_by_dealer_proximity() {
     // With equal scores the order runs counter-clockwise from the
     // starting dealer.
     let mut state = GameState::new();
     state.handle_event(game_started_4p(Wind::West, 0)); // starting dealer: seat 2
     state.scores = [25000; 4];
-    let order: Vec<usize> = state.final_rankings().iter().map(|r| r.0).collect();
+    let order: Vec<usize> = state.rankings().iter().map(|r| r.0).collect();
     assert_eq!(order, vec![2, 3, 0, 1]);
 
     // Differing scores outrank the seat order.
     state.scores = [30000, 20000, 25000, 25000];
-    let order: Vec<usize> = state.final_rankings().iter().map(|r| r.0).collect();
+    let order: Vec<usize> = state.rankings().iter().map(|r| r.0).collect();
     assert_eq!(order, vec![0, 2, 3, 1]);
 }
 
 #[test]
-fn test_final_rankings_sanma_excludes_dummy_seat() {
+fn test_rankings_sanma_excludes_dummy_seat() {
     // Three-player: starting dealer at seat 1 and equal scores give
     // 1, 2, 0, skipping the dummy.
     let mut state = GameState::new();
     state.handle_event(sanma_game_started(Wind::West)); // we as West puts the dealer at seat 1
     state.scores = [35000, 35000, 35000, 0];
-    let order: Vec<usize> = state.final_rankings().iter().map(|r| r.0).collect();
+    let order: Vec<usize> = state.rankings().iter().map(|r| r.0).collect();
     assert_eq!(order, vec![1, 2, 0]);
 }
 

--- a/crates/mahjong-client/src/renderer/board.rs
+++ b/crates/mahjong-client/src/renderer/board.rs
@@ -173,20 +173,68 @@ pub(super) fn draw_round_center(state: &GameState, font: Option<&Font>, bar_h: f
     }
 }
 
-/// Top-bar right: per-player score chips, ours highlighted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ScoreChip {
+    pub(super) seat: usize,
+    pub(super) relative_index: usize,
+    pub(super) rank: usize,
+    pub(super) score_delta: Option<i32>,
+}
+
+/// Builds the top-bar entries in standings order with scores relative to us.
+pub(super) fn score_chip_entries(state: &GameState) -> Vec<ScoreChip> {
+    let count = state.player_count;
+    let my_score = state.scores[state.my_seat];
+
+    state
+        .rankings()
+        .into_iter()
+        .enumerate()
+        .map(|(rank, (seat, score))| ScoreChip {
+            seat,
+            relative_index: (seat + count - state.my_seat) % count,
+            rank,
+            score_delta: (seat != state.my_seat).then_some(score - my_score),
+        })
+        .collect()
+}
+
+/// Score difference text with an explicit sign and digit grouping.
+pub(super) fn format_score_delta(delta: i32) -> String {
+    if delta > 0 {
+        format!("+{}", format_score(delta))
+    } else if delta < 0 {
+        format_score(delta)
+    } else {
+        "±0".to_string()
+    }
+}
+
+/// Color for an opponent's score difference relative to us.
+pub(super) fn score_delta_color(delta: i32) -> Color {
+    match delta.cmp(&0) {
+        std::cmp::Ordering::Greater => theme::BLUE_LT,
+        std::cmp::Ordering::Less => theme::RED_LT,
+        std::cmp::Ordering::Equal => theme::TEXT_DIM,
+    }
+}
+
+/// Top-bar right: standings and score differences, with ours highlighted.
 pub(super) fn draw_score_chips(state: &GameState, font: Option<&Font>, bar_h: f32) {
-    const CHIP_W: f32 = 70.0;
+    const CHIP_W: f32 = 84.0;
     const CHIP_H: f32 = 38.0;
     const GAP: f32 = 7.0;
-    let count = state.player_count;
+    const VALUE_GAP: f32 = 4.0;
+    const VALUE_SIZE: u16 = 11;
+    let chips = score_chip_entries(state);
+    let count = chips.len();
     let total = count as f32 * CHIP_W + (count as f32 - 1.0) * GAP;
     let start_x = DESIGN_W - 14.0 - total;
     let chip_y = (bar_h - CHIP_H) / 2.0;
 
-    for rel in 0..state.player_count {
-        let seat = seat_at_relative_position(state.my_seat, rel, state.player_count);
-        let is_me = seat == state.my_seat;
-        let x = start_x + rel as f32 * (CHIP_W + GAP);
+    for (index, chip) in chips.iter().enumerate() {
+        let is_me = chip.seat == state.my_seat;
+        let x = start_x + index as f32 * (CHIP_W + GAP);
 
         let (fill, border) = if is_me {
             (theme::rgba(0xc8a227, 0.10), theme::rgba(0xc8a227, 0.28))
@@ -199,7 +247,11 @@ pub(super) fn draw_score_chips(state: &GameState, font: Option<&Font>, bar_h: f3
         theme::draw_rounded_rect(x, chip_y, CHIP_W, CHIP_H, 4.0, fill);
         theme::draw_rounded_rect_lines(x, chip_y, CHIP_W, CHIP_H, 4.0, 1.0, border);
 
-        let name = short_player_name(&state.player_labels[seat], rel, state.lang);
+        let name = short_player_name(
+            &state.player_labels[chip.seat],
+            chip.relative_index,
+            state.lang,
+        );
         theme::draw_text_centered(
             font,
             &name,
@@ -208,9 +260,40 @@ pub(super) fn draw_score_chips(state: &GameState, font: Option<&Font>, bar_h: f3
             9,
             theme::TEXT_DIM,
         );
-        let val = format_score(state.scores[seat]);
-        let val_color = if is_me { theme::GOLD_LT } else { theme::TEXT };
-        theme::draw_text_centered(font, &val, x + CHIP_W / 2.0, chip_y + 30.0, 13, val_color);
+
+        let rank_text = format!("{}{}", chip.rank + 1, state.tr().place_suffix(chip.rank));
+        let rank_color = if is_me { theme::GOLD_LT } else { theme::TEXT };
+        if let Some(score_delta) = chip.score_delta {
+            let delta_text = format_score_delta(score_delta);
+            let rank_width = theme::measure_scaled(font, &rank_text, VALUE_SIZE).width;
+            let delta_width = theme::measure_scaled(font, &delta_text, VALUE_SIZE).width;
+            let value_x = x + (CHIP_W - rank_width - VALUE_GAP - delta_width) / 2.0;
+            draw_jp_text(
+                font,
+                &rank_text,
+                value_x,
+                chip_y + 30.0,
+                VALUE_SIZE,
+                rank_color,
+            );
+            draw_jp_text(
+                font,
+                &delta_text,
+                value_x + rank_width + VALUE_GAP,
+                chip_y + 30.0,
+                VALUE_SIZE,
+                score_delta_color(score_delta),
+            );
+        } else {
+            theme::draw_text_centered(
+                font,
+                &rank_text,
+                x + CHIP_W / 2.0,
+                chip_y + 30.0,
+                VALUE_SIZE,
+                rank_color,
+            );
+        }
     }
 }
 

--- a/crates/mahjong-client/src/renderer/result.rs
+++ b/crates/mahjong-client/src/renderer/result.rs
@@ -335,7 +335,7 @@ pub(super) fn draw_game_over(state: &GameState, font: Option<&Font>) {
 
     // Final standings; ties favor the seat nearer the starting dealer,
     // and three-player games skip the dummy seat.
-    let rankings = state.final_rankings();
+    let rankings = state.rankings();
 
     // Rank colors: gold, silver, bronze, rest.
     let rank_colors = [

--- a/crates/mahjong-client/src/renderer/tests.rs
+++ b/crates/mahjong-client/src/renderer/tests.rs
@@ -6,8 +6,10 @@ use super::{
     TILE_W, add_dora_tile_types, buffer_to_design, calc_meld_width, dora_tile_tint,
     dora_tile_tint_with_base, dora_tile_types, other_meld_x_positions, pei_tile_x,
     player_hand_start_x, player_hand_tile_x, public_tile_tint, public_tile_tint_with_base,
-    rotation_index, seat_at_relative_position, self_meld_x_positions, visible_tile_tint,
+    rotation_index, score_chip_entries, score_delta_color, seat_at_relative_position,
+    self_meld_x_positions, visible_tile_tint,
 };
+use super::{format_score_delta, theme};
 use crate::game::{GameState, SelfTedashiAnim, SelfTileOrigin};
 use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
 use mahjong_core::tile::{Tile, TileType};
@@ -197,6 +199,70 @@ fn sanma_seat_mapping_wraps_at_three() {
     assert_eq!(seat_at_relative_position(0, 2, 3), 2);
     assert_eq!(seat_at_relative_position(1, 2, 3), 0);
     assert_eq!(seat_at_relative_position(2, 1, 3), 0);
+}
+
+#[test]
+fn score_chips_follow_rankings_without_changing_player_identity() {
+    let mut state = GameState::new();
+    state.my_seat = 2;
+    state.initial_dealer_seat = 1;
+    state.scores = [24_000, 30_000, 25_000, 21_000];
+
+    let summary: Vec<_> = score_chip_entries(&state)
+        .iter()
+        .map(|chip| (chip.seat, chip.relative_index, chip.rank, chip.score_delta))
+        .collect();
+
+    assert_eq!(
+        summary,
+        vec![
+            (1, 3, 0, Some(5_000)),
+            (2, 0, 1, None),
+            (0, 2, 2, Some(-1_000)),
+            (3, 1, 3, Some(-4_000)),
+        ]
+    );
+}
+
+#[test]
+fn score_chips_keep_zero_delta_for_tied_opponents_only() {
+    let state = GameState::new();
+
+    let deltas: Vec<_> = score_chip_entries(&state)
+        .iter()
+        .map(|chip| chip.score_delta)
+        .collect();
+
+    assert_eq!(deltas, vec![None, Some(0), Some(0), Some(0)]);
+}
+
+#[test]
+fn score_chips_exclude_the_unused_sanma_seat() {
+    let mut state = GameState::new();
+    state.player_count = 3;
+    state.my_seat = 1;
+    state.scores = [35_000, 34_000, 36_000, 999_999];
+
+    let seats: Vec<_> = score_chip_entries(&state)
+        .iter()
+        .map(|chip| chip.seat)
+        .collect();
+
+    assert_eq!(seats, vec![2, 0, 1]);
+}
+
+#[test]
+fn score_deltas_have_explicit_signs_and_grouped_digits() {
+    assert_eq!(format_score_delta(12_300), "+12,300");
+    assert_eq!(format_score_delta(0), "±0");
+    assert_eq!(format_score_delta(-4_500), "-4,500");
+}
+
+#[test]
+fn score_delta_colors_distinguish_ahead_behind_and_tied() {
+    assert_eq!(score_delta_color(1), theme::BLUE_LT);
+    assert_eq!(score_delta_color(-1), theme::RED_LT);
+    assert_eq!(score_delta_color(0), theme::TEXT_DIM);
 }
 
 #[test]

--- a/crates/mahjong-client/src/renderer/theme.rs
+++ b/crates/mahjong-client/src/renderer/theme.rs
@@ -43,6 +43,7 @@ pub const TEXT_DIM: Color = rgb(0xa3bcab);
 pub const TEXT_BR: Color = rgb(0xf5f0e0);
 pub const RED: Color = rgb(0xcc3333);
 pub const RED_LT: Color = rgb(0xe84444);
+pub const BLUE_LT: Color = rgb(0x70b7ff);
 
 /// Background center color of the setup/end screens.
 pub const SETUP_BG_INNER: Color = rgb(0x102a1e);


### PR DESCRIPTION
## Summary

- sort the top player chips by the current standings
- replace duplicated absolute scores with ranks and signed score differences relative to the local player
- show only the rank on the local player's chip
- render positive differences in blue, negative differences in red, and ties in a neutral color
- preserve player identity and tie-breaking behavior in both four-player and three-player games

## Why

Absolute scores are already shown in the center panel. Using the top bar for standings and score gaps makes the duplicated area more useful, especially when evaluating placement changes late in a game.

## Testing

- `cargo fmt`
- `cargo build`
- `cargo test`
- `cargo clippy --all-targets --all-features`
- visually verified the WASM game screen at 1280x720

Fixes #360