### PR TITLE
Improve UI text and tile readability

### DIFF
--- a/crates/mahjong-client/src/renderer/banners.rs
+++ b/crates/mahjong-client/src/renderer/banners.rs
@@ -10,8 +10,8 @@ use macroquad::prelude::*;
 use super::{BOARD_CENTER_Y, DESIGN_W, rotation_index, theme};
 use crate::game::{CALL_BANNER_SECS, GameState};
 
-/// Banner font size; must be one of `USED_FONT_SIZES`.
-const BANNER_FONT: u16 = 26;
+/// Banner font size from the shared typography scale.
+const BANNER_FONT: u16 = theme::font_size::TITLE;
 /// Fade-out duration in seconds.
 const FADE_SECS: f64 = 0.35;
 /// Bubble height.
@@ -97,7 +97,7 @@ pub(super) fn draw_call_banners(state: &GameState, font: Option<&Font>) {
 fn draw_banner_bubble(font: Option<&Font>, slot: usize, text: &str, alpha: f32) {
     let (cx, cy, tail) = banner_anchor(slot);
 
-    let dims = theme::measure_scaled(font, text, BANNER_FONT);
+    let dims = theme::measure_text_size(font, text, BANNER_FONT);
     let w = dims.width + 44.0;
     let h = BUBBLE_H;
     let x = cx - w / 2.0;

--- a/crates/mahjong-client/src/renderer/board.rs
+++ b/crates/mahjong-client/src/renderer/board.rs
@@ -3,6 +3,16 @@
 
 use super::*;
 
+pub(super) const TOP_BAR_HEIGHT: f32 = 50.0;
+pub(super) const DORA_PANEL_Y: f32 = 5.0;
+pub(super) const DORA_PANEL_HEIGHT: f32 = 40.0;
+pub(super) const TABLE_DORA_INDICATOR_TILE_W: f32 = 26.0;
+pub(super) const TABLE_DORA_INDICATOR_TILE_H: f32 = 37.0;
+pub(super) const DISCARD_TILE_W: f32 = 32.0;
+pub(super) const DISCARD_TILE_H: f32 = 44.0;
+/// Center-to-row distance that leaves the riichi stick unobstructed.
+pub(super) const DISCARD_FIRST_ROW_OFFSET: f32 = 130.0;
+
 /// Game background: radial felt, brighter at the center.
 pub(super) fn draw_felt_background() {
     theme::draw_radial_bg(
@@ -34,14 +44,18 @@ pub(super) fn draw_setup_background() {
 /// Draws the top bar: dora display, hand/remaining counters, and
 /// per-player score chips.
 pub(super) fn draw_top_bar(state: &GameState, font: Option<&Font>, tile_textures: &TileTextures) {
-    const BAR_H: f32 = 50.0;
-
-    draw_rectangle(0.0, 0.0, DESIGN_W, BAR_H, Color::new(0.0, 0.0, 0.0, 0.48));
-    draw_rectangle(0.0, BAR_H - 1.0, DESIGN_W, 1.0, theme::BORDER);
+    draw_rectangle(
+        0.0,
+        0.0,
+        DESIGN_W,
+        TOP_BAR_HEIGHT,
+        Color::new(0.0, 0.0, 0.0, 0.48),
+    );
+    draw_rectangle(0.0, TOP_BAR_HEIGHT - 1.0, DESIGN_W, 1.0, theme::BORDER);
 
     draw_dora_panel(state, font, tile_textures);
-    draw_round_center(state, font, BAR_H);
-    draw_score_chips(state, font, BAR_H);
+    draw_round_center(state, font, TOP_BAR_HEIGHT);
+    draw_score_chips(state, font, TOP_BAR_HEIGHT);
 }
 
 /// Top-bar left: dora indicators, riichi deposits, honba.
@@ -51,12 +65,12 @@ pub(super) fn draw_dora_panel(
     tile_textures: &TileTextures,
 ) {
     let panel_x = 12.0;
-    let panel_y = 8.0;
-    let panel_h = 34.0;
-    let dora_w = 20.0;
-    let dora_h = 28.0;
+    let panel_y = DORA_PANEL_Y;
+    let panel_h = DORA_PANEL_HEIGHT;
+    let dora_w = TABLE_DORA_INDICATOR_TILE_W;
+    let dora_h = TABLE_DORA_INDICATOR_TILE_H;
     let tiles_x = panel_x + 44.0;
-    let tiles_y = panel_y + 3.0;
+    let tiles_y = panel_y + (panel_h - dora_h) / 2.0;
     let sticks_x = tiles_x + 5.0 * (dora_w + 1.0) + 12.0;
     let panel_w = sticks_x + 64.0 - panel_x;
 
@@ -75,7 +89,7 @@ pub(super) fn draw_dora_panel(
         DoraLabel::Dora.name(state.lang),
         panel_x + 10.0,
         panel_y + 21.0,
-        11,
+        theme::font_size::CAPTION,
         theme::TEXT_DIM,
     );
 
@@ -112,7 +126,7 @@ pub(super) fn draw_dora_panel(
         &format!("×{}", state.riichi_sticks),
         sticks_x + 38.0,
         panel_y + 14.0,
-        11,
+        theme::font_size::CAPTION,
         theme::TEXT_DIM,
     );
     draw_tile_sprite(
@@ -128,7 +142,7 @@ pub(super) fn draw_dora_panel(
         &format!("×{}", state.honba),
         sticks_x + 38.0,
         panel_y + 28.0,
-        11,
+        theme::font_size::CAPTION,
         theme::TEXT_DIM,
     );
 }
@@ -146,11 +160,11 @@ pub(super) fn draw_round_center(state: &GameState, font: Option<&Font>, bar_h: f
 
     let baseline = bar_h / 2.0 + 6.0;
     let gap = 12.0;
-    let gdims = theme::measure_scaled(font, &rule_text, 16);
-    let rdims = theme::measure_scaled(font, &round_text, 16);
+    let gdims = theme::measure_text_size(font, &rule_text, theme::font_size::BODY_LARGE);
+    let rdims = theme::measure_text_size(font, &round_text, theme::font_size::BODY_LARGE);
     let hdims = honba_text
         .as_ref()
-        .map(|t| theme::measure_scaled(font, t, 14));
+        .map(|t| theme::measure_text_size(font, t, theme::font_size::LABEL));
 
     let mut total_w = gdims.width + gap + rdims.width;
     if let Some(hd) = &hdims {
@@ -158,16 +172,30 @@ pub(super) fn draw_round_center(state: &GameState, font: Option<&Font>, bar_h: f
     }
     let start_x = DESIGN_W / 2.0 - total_w / 2.0;
 
-    draw_jp_text(font, &rule_text, start_x, baseline, 16, theme::GOLD_LT);
+    draw_jp_text(
+        font,
+        &rule_text,
+        start_x,
+        baseline,
+        theme::font_size::BODY_LARGE,
+        theme::GOLD_LT,
+    );
     let round_x = start_x + gdims.width + gap;
-    draw_jp_text(font, &round_text, round_x, baseline, 16, theme::GOLD_LT);
+    draw_jp_text(
+        font,
+        &round_text,
+        round_x,
+        baseline,
+        theme::font_size::BODY_LARGE,
+        theme::GOLD_LT,
+    );
     if let Some(honba_text) = &honba_text {
         draw_jp_text(
             font,
             honba_text,
             round_x + rdims.width + gap,
             baseline,
-            14,
+            theme::font_size::LABEL,
             theme::TEXT_DIM,
         );
     }
@@ -221,11 +249,11 @@ pub(super) fn score_delta_color(delta: i32) -> Color {
 
 /// Top-bar right: standings and score differences, with ours highlighted.
 pub(super) fn draw_score_chips(state: &GameState, font: Option<&Font>, bar_h: f32) {
-    const CHIP_W: f32 = 84.0;
-    const CHIP_H: f32 = 38.0;
+    const CHIP_W: f32 = 90.0;
+    const CHIP_H: f32 = 40.0;
     const GAP: f32 = 7.0;
     const VALUE_GAP: f32 = 4.0;
-    const VALUE_SIZE: u16 = 11;
+    const VALUE_FONT_SIZE: u16 = theme::font_size::CAPTION;
     let chips = score_chip_entries(state);
     let count = chips.len();
     let total = count as f32 * CHIP_W + (count as f32 - 1.0) * GAP;
@@ -256,8 +284,8 @@ pub(super) fn draw_score_chips(state: &GameState, font: Option<&Font>, bar_h: f3
             font,
             &name,
             x + CHIP_W / 2.0,
-            chip_y + 14.0,
-            9,
+            chip_y + 15.0,
+            theme::font_size::MICRO,
             theme::TEXT_DIM,
         );
 
@@ -265,23 +293,23 @@ pub(super) fn draw_score_chips(state: &GameState, font: Option<&Font>, bar_h: f3
         let rank_color = if is_me { theme::GOLD_LT } else { theme::TEXT };
         if let Some(score_delta) = chip.score_delta {
             let delta_text = format_score_delta(score_delta);
-            let rank_width = theme::measure_scaled(font, &rank_text, VALUE_SIZE).width;
-            let delta_width = theme::measure_scaled(font, &delta_text, VALUE_SIZE).width;
+            let rank_width = theme::measure_text_size(font, &rank_text, VALUE_FONT_SIZE).width;
+            let delta_width = theme::measure_text_size(font, &delta_text, VALUE_FONT_SIZE).width;
             let value_x = x + (CHIP_W - rank_width - VALUE_GAP - delta_width) / 2.0;
             draw_jp_text(
                 font,
                 &rank_text,
                 value_x,
-                chip_y + 30.0,
-                VALUE_SIZE,
+                chip_y + 32.0,
+                VALUE_FONT_SIZE,
                 rank_color,
             );
             draw_jp_text(
                 font,
                 &delta_text,
                 value_x + rank_width + VALUE_GAP,
-                chip_y + 30.0,
-                VALUE_SIZE,
+                chip_y + 32.0,
+                VALUE_FONT_SIZE,
                 score_delta_color(score_delta),
             );
         } else {
@@ -289,8 +317,8 @@ pub(super) fn draw_score_chips(state: &GameState, font: Option<&Font>, bar_h: f3
                 font,
                 &rank_text,
                 x + CHIP_W / 2.0,
-                chip_y + 30.0,
-                VALUE_SIZE,
+                chip_y + 32.0,
+                VALUE_FONT_SIZE,
                 rank_color,
             );
         }
@@ -345,7 +373,8 @@ pub(super) fn draw_center_panel(state: &GameState, font: Option<&Font>) {
 
     let my_wind_idx = state.my_wind_index();
     let my_initial_wind_idx = state.my_initial_wind_index();
-    let label_dist: f32 = 64.0;
+    let label_dist: f32 = 62.0;
+    let detail_line_step: f32 = 16.0;
 
     for rel in 0..state.player_count {
         // rel is the position relative to us. scores/player_labels are
@@ -371,7 +400,7 @@ pub(super) fn draw_center_panel(state: &GameState, font: Option<&Font>) {
             display_wind.name(state.lang),
             BOARD_CENTER_X,
             BOARD_CENTER_Y + label_dist,
-            14,
+            theme::font_size::LABEL,
             theme::GOLD_LT,
         );
         let score_label = format_score(score);
@@ -379,8 +408,8 @@ pub(super) fn draw_center_panel(state: &GameState, font: Option<&Font>) {
             font,
             &score_label,
             BOARD_CENTER_X,
-            BOARD_CENTER_Y + label_dist + 14.0,
-            11,
+            BOARD_CENTER_Y + label_dist + detail_line_step,
+            theme::font_size::CAPTION,
             theme::TEXT_DIM,
         );
 
@@ -391,8 +420,8 @@ pub(super) fn draw_center_panel(state: &GameState, font: Option<&Font>) {
                 font,
                 &detail,
                 BOARD_CENTER_X,
-                BOARD_CENTER_Y + label_dist + 28.0,
-                11,
+                BOARD_CENTER_Y + label_dist + detail_line_step * 2.0,
+                theme::font_size::CAPTION,
                 theme::rgba(0x7a9880, 0.85),
             );
         }
@@ -412,7 +441,7 @@ pub(super) fn draw_center_panel(state: &GameState, font: Option<&Font>) {
         &round_text,
         BOARD_CENTER_X,
         BOARD_CENTER_Y - 8.0,
-        13,
+        theme::font_size::LABEL,
         theme::TEXT_DIM,
     );
     theme::draw_text_centered(
@@ -420,7 +449,7 @@ pub(super) fn draw_center_panel(state: &GameState, font: Option<&Font>) {
         &remaining_text,
         BOARD_CENTER_X,
         BOARD_CENTER_Y + 18.0,
-        21,
+        theme::font_size::HEADING_LARGE,
         theme::TEXT_BR,
     );
 }
@@ -456,23 +485,21 @@ pub(super) fn pei_tile_x(start_x: f32, tile_width: f32, index: usize) -> f32 {
 }
 
 pub(super) fn draw_discards(state: &GameState, tile_textures: &TileTextures) {
-    let dtw: f32 = 32.0; // natural tile width
-    let dth: f32 = 44.0; // natural tile height
+    let dtw = DISCARD_TILE_W;
+    let dth = DISCARD_TILE_H;
     let col_step: f32 = dtw; // columns touch
     let row_step: f32 = dth; // rows touch
 
     // Normalized layout in our own view: left-to-right, rows downward.
     let half_width = 3.0 * col_step; // half of six tiles = 108px
     let stick_offset: f32 = 108.0; // center to the riichi stick
-    let discard_offset: f32 = 130.0; // center to the first discard row
-    // (leaves room for the stick)
 
     // Riichi stick draw size (source ~800x117px, shrunk horizontal).
     let stick_w: f32 = 100.0;
     let stick_h: f32 = 14.0;
 
     let start_x = BOARD_CENTER_X - half_width;
-    let start_y = BOARD_CENTER_Y + discard_offset;
+    let start_y = BOARD_CENTER_Y + DISCARD_FIRST_ROW_OFFSET;
 
     let my_wind_idx = state.my_wind_index();
     let my_initial_wind_idx = state.my_initial_wind_index();
@@ -584,12 +611,19 @@ pub(super) fn draw_badge(
     border: Color,
     text_color: Color,
 ) -> f32 {
-    let dims = theme::measure_scaled(font, text, 11);
+    let dims = theme::measure_text_size(font, text, theme::font_size::CAPTION);
     let pad = 8.0;
     let w = dims.width + pad * 2.0;
-    let h = 18.0;
+    let h = 20.0;
     theme::draw_rounded_rect(x, y, w, h, 3.0, fill);
     theme::draw_rounded_rect_lines(x, y, w, h, 3.0, 1.0, border);
-    draw_jp_text(font, text, x + pad, y + 13.0, 11, text_color);
+    draw_jp_text(
+        font,
+        text,
+        x + pad,
+        y + 15.0,
+        theme::font_size::CAPTION,
+        text_color,
+    );
     x + w + 6.0
 }

--- a/crates/mahjong-client/src/renderer/menu.rs
+++ b/crates/mahjong-client/src/renderer/menu.rs
@@ -154,7 +154,7 @@ fn draw_menu_button(font: Option<&Font>, rect: &Rect2, label: &str, accent: bool
             label,
             rect.center_x(),
             rect.center_y() + 7.0,
-            18,
+            theme::font_size::HEADING_SMALL,
             theme::GOLD_LT,
         );
     } else {
@@ -180,7 +180,7 @@ fn draw_menu_button(font: Option<&Font>, rect: &Rect2, label: &str, accent: bool
             label,
             rect.center_x(),
             rect.center_y() + 6.0,
-            15,
+            theme::font_size::BODY,
             theme::TEXT,
         );
     }
@@ -210,7 +210,7 @@ fn draw_disabled_button(font: Option<&Font>, rect: &Rect2, label: &str) {
         label,
         rect.center_x(),
         rect.center_y() + 6.0,
-        15,
+        theme::font_size::BODY,
         theme::rgba(0xffffff, 0.25),
     );
 }
@@ -260,7 +260,7 @@ pub fn draw_top_menu(state: &GameState, font: Option<&Font>, tile_textures: &sup
         tr.get(Key::LanguageLabel),
         lang_rect.x,
         lang_rect.y - 12.0,
-        12,
+        theme::font_size::SMALL,
         theme::TEXT_DIM,
     );
     let active_lang = match state.lang {
@@ -268,7 +268,13 @@ pub fn draw_top_menu(state: &GameState, font: Option<&Font>, tile_textures: &sup
         Lang::En => 1,
     };
     for (idx, &label) in LANG_LABELS.iter().enumerate() {
-        draw_toggle(font, &top_lang_rect(idx), label, idx == active_lang, 14);
+        draw_toggle(
+            font,
+            &top_lang_rect(idx),
+            label,
+            idx == active_lang,
+            theme::font_size::LABEL,
+        );
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -277,7 +283,7 @@ pub fn draw_top_menu(state: &GameState, font: Option<&Font>, tile_textures: &sup
         tr.get(Key::ScreenshotHint),
         DESIGN_W / 2.0,
         664.0,
-        11,
+        theme::font_size::CAPTION,
         theme::TEXT_DIM,
     );
 }
@@ -628,7 +634,7 @@ fn mode_summary_lines(state: &GameState, origin: MenuOrigin) -> Vec<String> {
 /// Draws the mode-selection screen.
 pub fn draw_mode_select(state: &GameState, font: Option<&Font>, origin: MenuOrigin) {
     let tr = state.tr();
-    draw_menu_panel(font, tr.get(Key::ModeSelectTitle), 26);
+    draw_menu_panel(font, tr.get(Key::ModeSelectTitle), theme::font_size::TITLE);
 
     let current_mode = selected_mode(state, origin);
 
@@ -638,7 +644,7 @@ pub fn draw_mode_select(state: &GameState, font: Option<&Font>, origin: MenuOrig
             &mode_rect(idx),
             tr.get(mode.label_key()),
             mode == current_mode,
-            16,
+            theme::font_size::BODY_LARGE,
         );
     }
 
@@ -657,7 +663,7 @@ pub fn draw_mode_select(state: &GameState, font: Option<&Font>, origin: MenuOrig
         tr.get(Key::CurrentRulesTitle),
         summary.center_x(),
         summary.y + 22.0,
-        13,
+        theme::font_size::LABEL,
         theme::GOLD,
     );
     for (idx, line) in mode_summary_lines(state, origin).iter().enumerate() {
@@ -666,7 +672,7 @@ pub fn draw_mode_select(state: &GameState, font: Option<&Font>, origin: MenuOrig
             line,
             summary.center_x(),
             summary.y + 44.0 + idx as f32 * 20.0,
-            11,
+            theme::font_size::CAPTION,
             theme::TEXT_DIM,
         );
     }
@@ -729,7 +735,7 @@ fn draw_rule_settings_panel(font: Option<&Font>, title: &str) {
         title,
         DESIGN_W / 2.0,
         RULE_SETTINGS_TITLE_Y,
-        26,
+        theme::font_size::TITLE,
         theme::TEXT_BR,
     );
 }
@@ -872,7 +878,7 @@ fn draw_rule_button(
         label,
         rect.x + 12.0,
         rect.center_y() + 5.0,
-        12,
+        theme::font_size::SMALL,
         if selected {
             theme::GOLD_LT
         } else {
@@ -884,7 +890,7 @@ fn draw_rule_button(
         value,
         rect.x + rect.w - 64.0,
         rect.center_y() + 5.0,
-        9,
+        theme::font_size::MICRO,
         if enabled {
             theme::GOLD_LT
         } else {
@@ -957,7 +963,7 @@ fn draw_rule_value_selector(
         "←",
         previous.center_x(),
         previous.center_y() + 5.0,
-        12,
+        theme::font_size::SMALL,
         theme::GOLD_LT,
     );
     theme::draw_text_centered(
@@ -965,7 +971,7 @@ fn draw_rule_value_selector(
         value,
         selector.center_x(),
         selector.center_y() + 5.0,
-        12,
+        theme::font_size::SMALL,
         if enabled {
             theme::GOLD_LT
         } else {
@@ -977,7 +983,7 @@ fn draw_rule_value_selector(
         "→",
         next.center_x(),
         next.center_y() + 5.0,
-        12,
+        theme::font_size::SMALL,
         theme::GOLD_LT,
     );
 }
@@ -1046,7 +1052,7 @@ pub fn draw_rule_settings(state: &GameState, font: Option<&Font>, origin: MenuOr
             tr.get(key),
             rect.center_x(),
             rect.center_y() + 5.0,
-            12,
+            theme::font_size::SMALL,
             if selected {
                 theme::GOLD_LT
             } else {
@@ -1085,7 +1091,7 @@ pub fn draw_rule_settings(state: &GameState, font: Option<&Font>, origin: MenuOr
         tr.get(rule_label_key(state.selected_rule)),
         description.center_x(),
         description.y + 23.0,
-        14,
+        theme::font_size::LABEL,
         theme::GOLD,
     );
     let selected_enabled = state.selected_rule.is_enabled(rules);
@@ -1110,7 +1116,7 @@ pub fn draw_rule_settings(state: &GameState, font: Option<&Font>, origin: MenuOr
             line,
             description.center_x(),
             first_baseline + idx as f32 * 18.0,
-            11,
+            theme::font_size::CAPTION,
             theme::TEXT_DIM,
         );
     }

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -148,27 +148,16 @@ const SELF_MELD_GAP: f32 = 12.0;
 const SELF_MELD_RIGHT_EDGE: f32 = 1220.0;
 const SELF_HAND_MELD_GAP: f32 = 20.0;
 const SELF_HAND_LEFT_MARGIN: f32 = 40.0;
-const FONT_SIZE: u16 = 20;
-const SMALL_FONT: u16 = 16;
-const AGARI_FONT: u16 = 32;
-
-/// Every base font size actually used in the app (the `base_size`
-/// arguments of `draw_text`/`draw_text_centered`; add new sizes here
-/// when introducing them).
-///
-/// [`prewarm_fonts`] and `cache_dynamic_text` precache exactly these.
-/// Brute-forcing `8..=AGARI_FONT` (25 sizes) used to bloat the font
-/// atlas for the 16 sizes really in use (see the comment below).
-const USED_FONT_SIZES: [u16; 16] = [
-    9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 21, 24, 26, 28, 32,
-];
+const ACTION_FONT_SIZE: u16 = theme::font_size::HEADING;
+const SMALL_ACTION_FONT_SIZE: u16 = theme::font_size::BODY_LARGE;
+const AGARI_FONT_SIZE: u16 = theme::font_size::DISPLAY_LARGE;
 
 /// Startup units used to prepare the label font and all tile-related textures.
 pub const TEXTURE_LOAD_STEPS: usize = 1 + Tile::LEN + 3 + 4;
 
 /// Startup units used to prewarm each native font size.
 #[cfg(not(target_arch = "wasm32"))]
-pub const FONT_PREWARM_STEPS: usize = USED_FONT_SIZES.len();
+pub const FONT_PREWARM_STEPS: usize = theme::font_size::ALL.len();
 
 /// Design resolution. All UI coordinates live on this virtual canvas and
 /// scale to the real window. The HTML keeps this aspect ratio; native
@@ -540,8 +529,8 @@ pub async fn prewarm_fonts(
     for c in 0x20u8..0x7f {
         glyphs.push(c as char);
     }
-    for &base in &USED_FONT_SIZES {
-        let _ = theme::measure_scaled(font, &glyphs, base);
+    for &font_size in &theme::font_size::ALL {
+        let _ = theme::measure_text_size(font, &glyphs, font_size);
         loading_screen.complete_step().await;
     }
 }
@@ -555,7 +544,7 @@ pub async fn prewarm_fonts(
 /// black-square glyphs) especially during the game screen's camera
 /// switches.
 ///
-/// Sizes are limited to [`USED_FONT_SIZES`], as in [`prewarm_fonts`]
+/// Sizes are limited to [`theme::font_size::ALL`], as in [`prewarm_fonts`]
 /// (see that function's comment for why).
 pub fn cache_dynamic_text(font: Option<&Font>, state: &GameState) {
     use crate::game::PlayerLabel;
@@ -563,43 +552,58 @@ pub fn cache_dynamic_text(font: Option<&Font>, state: &GameState) {
         if s.is_empty() {
             return;
         }
-        debug_assert!(sizes.iter().all(|size| USED_FONT_SIZES.contains(size)));
-        for &base in sizes {
-            let _ = theme::measure_scaled(font, s, base);
+        debug_assert!(
+            sizes
+                .iter()
+                .all(|size| theme::font_size::ALL.contains(size))
+        );
+        for &font_size in sizes {
+            let _ = theme::measure_text_size(font, s, font_size);
         }
     };
     for label in &state.player_labels {
         if let PlayerLabel::Human(name) = label {
             // Score chip, center detail, ranking, and win heading.
-            cache(name, &[9, 11, 14, 21]);
+            cache(
+                name,
+                &[
+                    theme::font_size::MICRO,
+                    theme::font_size::CAPTION,
+                    theme::font_size::LABEL,
+                    theme::font_size::HEADING_LARGE,
+                ],
+            );
         }
     }
     let online = &state.online_state;
-    cache(&online.name_input, &[16]);
-    cache(&online.code_input, &[16]);
+    cache(&online.name_input, &[theme::font_size::BODY_LARGE]);
+    cache(&online.code_input, &[theme::font_size::BODY_LARGE]);
     if let Some(status) = &online.status_line {
-        cache(status, &[13, 15]);
+        cache(status, &[theme::font_size::LABEL, theme::font_size::BODY]);
     }
     if let Some(room) = &online.room {
-        cache(&room.code, &[28]);
+        cache(&room.code, &[theme::font_size::DISPLAY]);
         for label in &room.seat_labels {
-            cache(label, &[14]);
+            cache(label, &[theme::font_size::LABEL]);
         }
     }
 
     // Round results (yaku names, ranks, winner names, draw messages)
     // are external too.
     if let Some(message) = &state.result_message {
-        cache(message, &[14, 20]);
+        cache(
+            message,
+            &[theme::font_size::LABEL, theme::font_size::HEADING],
+        );
     }
     if let Some(result) = state.current_win_result() {
-        cache(&result.winner_name, &[21]);
+        cache(&result.winner_name, &[theme::font_size::HEADING_LARGE]);
         if let Some(loser) = &result.loser_name {
-            cache(loser, &[21]);
+            cache(loser, &[theme::font_size::HEADING_LARGE]);
         }
-        cache(&result.rank_name, &[28]);
+        cache(&result.rank_name, &[theme::font_size::DISPLAY]);
         for (name, _) in &result.yaku {
-            cache(name, &[14]);
+            cache(name, &[theme::font_size::LABEL]);
         }
     }
 }
@@ -607,14 +611,14 @@ pub fn cache_dynamic_text(font: Option<&Font>, state: &GameState) {
 /// Precaches a transient native-client notification before other text draws.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn cache_notification_text(font: Option<&Font>, text: &str) {
-    let _ = theme::measure_scaled(font, text, 13);
+    let _ = theme::measure_text_size(font, text, theme::font_size::LABEL);
 }
 
 /// Draws a transient native-client notification over the current screen.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn draw_notification(font: Option<&Font>, text: &str, is_error: bool) {
     set_design_camera();
-    let dimensions = theme::measure_scaled(font, text, 13);
+    let dimensions = theme::measure_text_size(font, text, theme::font_size::LABEL);
     let width = (dimensions.width + 48.0).min(DESIGN_W - 40.0);
     let x = (DESIGN_W - width) / 2.0;
     let border = if is_error {
@@ -629,7 +633,14 @@ pub fn draw_notification(font: Option<&Font>, text: &str, is_error: bool) {
     };
 
     theme::draw_panel(x, 18.0, width, 42.0, 7.0, theme::PANEL_BG, border);
-    theme::draw_text_centered(font, text, DESIGN_W / 2.0, 45.0, 13, color);
+    theme::draw_text_centered(
+        font,
+        text,
+        DESIGN_W / 2.0,
+        45.0,
+        theme::font_size::LABEL,
+        color,
+    );
 }
 
 pub fn draw_game(
@@ -672,7 +683,7 @@ pub fn draw_game(
                 state.tr().get(Key::GameStarting),
                 DESIGN_W / 2.0,
                 400.0,
-                28,
+                theme::font_size::DISPLAY,
                 theme::TEXT_BR,
             );
             None

--- a/crates/mahjong-client/src/renderer/online.rs
+++ b/crates/mahjong-client/src/renderer/online.rs
@@ -122,7 +122,14 @@ fn draw_online_panel(font: Option<&Font>, title: &str) {
         theme::PANEL_BORDER,
     );
     let cx = DESIGN_W / 2.0;
-    theme::draw_text_centered(font, title, cx, PANEL_Y + 60.0, 26, theme::TEXT_BR);
+    theme::draw_text_centered(
+        font,
+        title,
+        cx,
+        PANEL_Y + 60.0,
+        theme::font_size::TITLE,
+        theme::TEXT_BR,
+    );
 }
 
 fn draw_button(font: Option<&Font>, rect: &Rect2, label: &str, accent: bool) {
@@ -143,7 +150,7 @@ fn draw_button(font: Option<&Font>, rect: &Rect2, label: &str, accent: bool) {
             label,
             rect.center_x(),
             rect.y + rect.h / 2.0 + 7.0,
-            17,
+            theme::font_size::SUBHEADING,
             theme::GOLD_LT,
         );
     } else {
@@ -169,7 +176,7 @@ fn draw_button(font: Option<&Font>, rect: &Rect2, label: &str, accent: bool) {
             label,
             rect.center_x(),
             rect.y + rect.h / 2.0 + 6.0,
-            15,
+            theme::font_size::BODY,
             theme::TEXT,
         );
     }
@@ -201,7 +208,7 @@ fn draw_input_box(font: Option<&Font>, rect: &Rect2, text: &str, focused: bool) 
         &shown,
         rect.x + 14.0,
         rect.y + rect.h / 2.0 + 7.0,
-        16,
+        theme::font_size::BODY_LARGE,
         theme::TEXT,
     );
 }
@@ -213,7 +220,7 @@ fn draw_status_line(state: &GameState, font: Option<&Font>, y: f32) {
         } else {
             theme::TEXT_DIM
         };
-        theme::draw_text_centered(font, line, DESIGN_W / 2.0, y, 15, color);
+        theme::draw_text_centered(font, line, DESIGN_W / 2.0, y, theme::font_size::BODY, color);
     }
 }
 
@@ -229,7 +236,7 @@ pub fn draw_online_menu(state: &GameState, font: Option<&Font>) {
         tr.get(Key::NameLabel),
         NAME_BOX.x,
         NAME_BOX.y - 9.0,
-        11,
+        theme::font_size::CAPTION,
         theme::TEXT_DIM,
     );
     draw_input_box(font, &NAME_BOX, &online.name_input, !online.code_focused);
@@ -239,7 +246,7 @@ pub fn draw_online_menu(state: &GameState, font: Option<&Font>) {
         tr.get(Key::RoomCodeJoinLabel),
         CODE_BOX.x,
         CODE_BOX.y - 9.0,
-        11,
+        theme::font_size::CAPTION,
         theme::TEXT_DIM,
     );
     draw_input_box(font, &CODE_BOX, &online.code_input, online.code_focused);
@@ -320,7 +327,14 @@ pub fn draw_online_lobby(state: &GameState, font: Option<&Font>) {
     draw_online_panel(font, tr.get(Key::Lobby));
 
     let Some(room) = &online.room else {
-        theme::draw_text_centered(font, tr.get(Key::LoadingRoom), cx, 300.0, 18, theme::TEXT);
+        theme::draw_text_centered(
+            font,
+            tr.get(Key::LoadingRoom),
+            cx,
+            300.0,
+            theme::font_size::HEADING_SMALL,
+            theme::TEXT,
+        );
         draw_status_line(state, font, 340.0);
         return;
     };
@@ -331,7 +345,7 @@ pub fn draw_online_lobby(state: &GameState, font: Option<&Font>) {
         &tr.room_code(&room.code),
         cx,
         210.0,
-        28,
+        theme::font_size::DISPLAY,
         theme::GOLD_LT,
     );
     theme::draw_text_centered(
@@ -339,7 +353,7 @@ pub fn draw_online_lobby(state: &GameState, font: Option<&Font>) {
         tr.get(Key::ShareCodeHint),
         cx,
         236.0,
-        12,
+        theme::font_size::SMALL,
         theme::TEXT_DIM,
     );
     // Spell out the room's game mode.
@@ -348,7 +362,7 @@ pub fn draw_online_lobby(state: &GameState, font: Option<&Font>) {
         tr.get(room.mode.label_key()),
         cx,
         256.0,
-        13,
+        theme::font_size::LABEL,
         theme::GOLD_LT,
     );
 
@@ -370,7 +384,14 @@ pub fn draw_online_lobby(state: &GameState, font: Option<&Font>) {
         };
         theme::draw_rounded_rect(row_x, y, row_w, 38.0, 6.0, fill);
         theme::draw_rounded_rect_lines(row_x, y, row_w, 38.0, 6.0, 1.0, border);
-        draw_jp_text(font, label, row_x + 14.0, y + 24.0, 14, theme::TEXT);
+        draw_jp_text(
+            font,
+            label,
+            row_x + 14.0,
+            y + 24.0,
+            theme::font_size::LABEL,
+            theme::TEXT,
+        );
     }
 
     if room.is_host {
@@ -379,7 +400,7 @@ pub fn draw_online_lobby(state: &GameState, font: Option<&Font>) {
             tr.get(Key::EmptySeatsCpu),
             cx,
             CPU_SETUP_BTN.y - 10.0,
-            12,
+            theme::font_size::SMALL,
             theme::TEXT_DIM,
         );
         draw_button(font, &CPU_SETUP_BTN, tr.get(Key::CpuSetupTitle), false);
@@ -390,7 +411,7 @@ pub fn draw_online_lobby(state: &GameState, font: Option<&Font>) {
             tr.get(Key::WaitingHost),
             cx,
             START_BTN.y + 34.0,
-            16,
+            theme::font_size::BODY_LARGE,
             theme::TEXT_DIM,
         );
     }
@@ -432,7 +453,14 @@ pub fn draw_connection_banner(state: &GameState, font: Option<&Font>) {
         // A rounded red banner right under the top bar.
         theme::draw_rounded_rect(x, 56.0, w, 30.0, 6.0, theme::rgba(0x7a1010, 0.92));
         theme::draw_rounded_rect_lines(x, 56.0, w, 30.0, 6.0, 1.0, theme::RED);
-        theme::draw_text_centered(font, line, DESIGN_W / 2.0, 76.0, 13, WHITE);
+        theme::draw_text_centered(
+            font,
+            line,
+            DESIGN_W / 2.0,
+            76.0,
+            theme::font_size::LABEL,
+            WHITE,
+        );
     }
 }
 
@@ -465,7 +493,7 @@ pub fn draw_turn_timer(state: &GameState, font: Option<&Font>) {
         &state.tr().seconds_left(remaining),
         x + w / 2.0,
         y + h / 2.0 + 6.0,
-        16,
+        theme::font_size::BODY_LARGE,
         accent,
     );
 }

--- a/crates/mahjong-client/src/renderer/overlay.rs
+++ b/crates/mahjong-client/src/renderer/overlay.rs
@@ -9,8 +9,9 @@ use mahjong_core::tile::Tile;
 use mahjong_server::protocol::{AvailableCall, ClientAction};
 
 use super::{
-    AGARI_FONT, DESIGN_W, DORA_TILE_TINT, DoraTileTypes, FONT_SIZE, SMALL_FONT, TileTextures,
-    dora_tile_tint, dora_tile_types, draw_jp_text, draw_tile_sprite, theme, visible_tile_tint,
+    ACTION_FONT_SIZE, AGARI_FONT_SIZE, DESIGN_W, DORA_TILE_TINT, DoraTileTypes,
+    SMALL_ACTION_FONT_SIZE, TileTextures, dora_tile_tint, dora_tile_types, draw_jp_text,
+    draw_tile_sprite, theme, visible_tile_tint,
 };
 use crate::game::GameState;
 use crate::i18n::Key;
@@ -115,7 +116,7 @@ fn draw_call_button(
         label,
         x + w / 2.0,
         y + h / 2.0 + 6.0,
-        FONT_SIZE,
+        ACTION_FONT_SIZE,
         color,
     );
 }
@@ -176,7 +177,7 @@ pub(super) fn draw_action_buttons(
             tr.get(Key::WaitingOtherPlayer),
             DESIGN_W / 2.0,
             HINT_Y,
-            FONT_SIZE,
+            ACTION_FONT_SIZE,
             theme::TEXT_DIM,
         );
         return None;
@@ -188,7 +189,7 @@ pub(super) fn draw_action_buttons(
             tr.get(Key::RiichiSelectHint),
             DESIGN_W / 2.0,
             HINT_Y,
-            FONT_SIZE,
+            ACTION_FONT_SIZE,
             theme::GOLD_LT,
         );
     } else if state.is_riichi {
@@ -197,7 +198,7 @@ pub(super) fn draw_action_buttons(
             tr.get(Key::RiichiAutoDiscard),
             DESIGN_W / 2.0,
             HINT_Y,
-            FONT_SIZE,
+            ACTION_FONT_SIZE,
             theme::RED_LT,
         );
     }
@@ -251,7 +252,7 @@ pub(super) fn draw_action_buttons(
             tr.get(Key::Riichi),
             AGARI_BTN_X + RIICHI_BTN_W / 2.0,
             riichi_y + RIICHI_BTN_H / 2.0 + 6.0,
-            SMALL_FONT,
+            SMALL_ACTION_FONT_SIZE,
             WHITE,
         );
         if clicked
@@ -274,7 +275,7 @@ pub(super) fn draw_action_buttons(
             tr.get(Key::NormalPlayHint),
             DESIGN_W / 2.0,
             HINT_Y,
-            SMALL_FONT,
+            SMALL_ACTION_FONT_SIZE,
             theme::TEXT_DIM,
         );
     }
@@ -302,7 +303,7 @@ fn draw_agari_button(font: Option<&Font>, x: f32, y: f32, label: &str) {
         label,
         x + AGARI_BTN_W / 2.0,
         y + 40.0,
-        AGARI_FONT,
+        AGARI_FONT_SIZE,
         WHITE,
     );
 }
@@ -741,7 +742,7 @@ fn draw_meld_selection_overlay(
         title,
         panel_x + 20.0,
         panel_y + 30.0,
-        FONT_SIZE,
+        ACTION_FONT_SIZE,
         Color::new(1.0, 0.95, 0.5, 1.0),
     );
 
@@ -814,7 +815,7 @@ fn draw_meld_selection_overlay(
         cancel_label,
         cancel_x + 10.0,
         cancel_y + 24.0,
-        FONT_SIZE,
+        ACTION_FONT_SIZE,
         WHITE,
     );
 
@@ -861,7 +862,7 @@ fn draw_nine_terminals_overlay(
         tr.get(Key::NineTerminals),
         PANEL_X + 16.0,
         PANEL_Y + 30.0,
-        FONT_SIZE,
+        ACTION_FONT_SIZE,
         Color::new(1.0, 0.95, 0.5, 1.0),
     );
     draw_jp_text(
@@ -869,7 +870,7 @@ fn draw_nine_terminals_overlay(
         tr.get(Key::DeclareDrawPrompt),
         PANEL_X + 16.0,
         PANEL_Y + 54.0,
-        FONT_SIZE,
+        ACTION_FONT_SIZE,
         WHITE,
     );
 
@@ -893,7 +894,7 @@ fn draw_nine_terminals_overlay(
         tr.get(Key::DeclareDraw),
         declare_x + 22.0,
         BTN_Y + 26.0,
-        FONT_SIZE,
+        ACTION_FONT_SIZE,
         WHITE,
     );
 
@@ -910,7 +911,7 @@ fn draw_nine_terminals_overlay(
         tr.get(Key::Continue),
         pass_x + 26.0,
         BTN_Y + 26.0,
-        FONT_SIZE,
+        ACTION_FONT_SIZE,
         WHITE,
     );
 

--- a/crates/mahjong-client/src/renderer/result.rs
+++ b/crates/mahjong-client/src/renderer/result.rs
@@ -2,6 +2,117 @@
 
 use super::*;
 
+const YAKU_FONT_SIZE: u16 = theme::font_size::LABEL;
+pub(super) const YAKU_ROW_HEIGHT: f32 = 22.0;
+pub(super) const WIN_HAND_TILE_W: f32 = 40.0;
+pub(super) const WIN_HAND_TILE_H: f32 = 56.0;
+pub(super) const WIN_HAND_ROW_HEIGHT: f32 = 64.0;
+pub(super) const WIN_PANEL_WIDTH: f32 = 780.0;
+pub(super) const WIN_PANEL_CONTENT_PADDING: f32 = 40.0;
+pub(super) const WIN_PANEL_CONTENT_WIDTH: f32 = WIN_PANEL_WIDTH - 2.0 * WIN_PANEL_CONTENT_PADDING;
+pub(super) const RESULT_INDICATOR_TILE_W: f32 = 30.0;
+pub(super) const RESULT_INDICATOR_TILE_H: f32 = 42.0;
+pub(super) const RESULT_INDICATOR_ROW_HEIGHT: f32 = 50.0;
+pub(super) const WIN_TILE_OUTLINE_MARGIN: f32 = 2.0;
+const WIN_TILE_GAP: f32 = 14.0;
+const WIN_MELD_GAP: f32 = 4.0;
+const RESULT_INDICATOR_GAP: f32 = 2.0;
+const RESULT_INDICATOR_LABEL_GAP: f32 = 6.0;
+const RESULT_INDICATOR_SECTION_GAP: f32 = 18.0;
+const WIN_PANEL_BASE_HEIGHT: f32 = 340.0;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct WinHandLayout {
+    pub(super) tile_w: f32,
+    pub(super) tile_h: f32,
+    pub(super) row_width: f32,
+    pub(super) top_overhang: f32,
+}
+
+fn win_hand_row_width_at_size(
+    hand_len: usize,
+    has_win_tile: bool,
+    melds: &[Meld],
+    tile_w: f32,
+    tile_h: f32,
+) -> f32 {
+    let hand_width = hand_len as f32 * tile_w;
+    let win_width = if has_win_tile {
+        WIN_TILE_GAP + tile_w
+    } else {
+        0.0
+    };
+    let meld_width: f32 = melds
+        .iter()
+        .map(|meld| calc_meld_width(meld, tile_w, tile_h) + WIN_MELD_GAP)
+        .sum();
+    hand_width + win_width + meld_width
+}
+
+/// Chooses the largest winning-hand tiles that fit the result panel.
+pub(super) fn win_hand_layout(
+    hand_len: usize,
+    has_win_tile: bool,
+    melds: &[Meld],
+) -> WinHandLayout {
+    let natural_width = win_hand_row_width_at_size(
+        hand_len,
+        has_win_tile,
+        melds,
+        WIN_HAND_TILE_W,
+        WIN_HAND_TILE_H,
+    );
+    let fixed_gap_width =
+        if has_win_tile { WIN_TILE_GAP } else { 0.0 } + melds.len() as f32 * WIN_MELD_GAP;
+    let scalable_width = natural_width - fixed_gap_width;
+    let scale = if natural_width > WIN_PANEL_CONTENT_WIDTH && scalable_width > 0.0 {
+        ((WIN_PANEL_CONTENT_WIDTH - fixed_gap_width) / scalable_width).clamp(0.0, 1.0)
+    } else {
+        1.0
+    };
+    let tile_w = WIN_HAND_TILE_W * scale;
+    let tile_h = WIN_HAND_TILE_H * scale;
+    let row_width = win_hand_row_width_at_size(hand_len, has_win_tile, melds, tile_w, tile_h);
+    let has_stacked_kakan = melds
+        .iter()
+        .any(|meld| meld.category == MeldType::Kakan && meld.tiles.len() > 3);
+    let top_overhang = if has_stacked_kakan {
+        (2.0 * tile_w - tile_h).max(0.0)
+    } else {
+        0.0
+    };
+
+    WinHandLayout {
+        tile_w,
+        tile_h,
+        row_width,
+        top_overhang,
+    }
+}
+
+/// Returns a shared baseline that visually centers both columns in a yaku row.
+pub(super) fn yaku_row_baseline(
+    row_top: f32,
+    row_height: f32,
+    name_dimensions: TextDimensions,
+    han_dimensions: Option<TextDimensions>,
+) -> f32 {
+    let mut ascent = name_dimensions.offset_y;
+    let mut descent = name_dimensions.height - name_dimensions.offset_y;
+    if let Some(dimensions) = han_dimensions {
+        ascent = ascent.max(dimensions.offset_y);
+        descent = descent.max(dimensions.height - dimensions.offset_y);
+    }
+    descent += theme::TEXT_SHADOW_OFFSET;
+
+    row_top + (row_height + ascent - descent) / 2.0
+}
+
+/// Right-aligns text including the shadow drawn outside its measured width.
+pub(super) fn yaku_right_aligned_x(right: f32, dimensions: TextDimensions) -> f32 {
+    right - dimensions.width - theme::TEXT_SHADOW_OFFSET
+}
+
 /// The result overlay: a structured panel for wins, a message panel
 /// for draws.
 pub(super) fn draw_result(state: &GameState, font: Option<&Font>, tile_textures: &TileTextures) {
@@ -54,7 +165,14 @@ pub(super) fn draw_result_next_button(
     } else {
         state.tr().get(Key::Next)
     };
-    theme::draw_text_centered(font, label, cx, y + 25.0, 14, theme::GOLD_LT);
+    theme::draw_text_centered(
+        font,
+        label,
+        cx,
+        y + 25.0,
+        theme::font_size::LABEL,
+        theme::GOLD_LT,
+    );
 }
 
 /// Draws a horizontal row of indicator tiles (dora / ura dora).
@@ -69,9 +187,30 @@ pub(super) fn draw_indicator_row(
     let mut cx = x;
     for tile in tiles {
         draw_tile_sprite(tile_textures.for_tile(tile), cx, y, w, h, WHITE);
-        cx += w + 2.0;
+        cx += w + RESULT_INDICATOR_GAP;
     }
     cx
+}
+
+/// Width reserved for the centered dora and optional ura-dora row.
+pub(super) fn result_indicator_rows_width(
+    dora_count: usize,
+    ura_count: usize,
+    dora_label_width: f32,
+    ura_label_width: f32,
+) -> f32 {
+    let dora_width = dora_label_width
+        + RESULT_INDICATOR_LABEL_GAP
+        + dora_count as f32 * (RESULT_INDICATOR_TILE_W + RESULT_INDICATOR_GAP);
+    let ura_width = if ura_count == 0 {
+        0.0
+    } else {
+        RESULT_INDICATOR_SECTION_GAP
+            + ura_label_width
+            + RESULT_INDICATOR_LABEL_GAP
+            + ura_count as f32 * (RESULT_INDICATOR_TILE_W + RESULT_INDICATOR_GAP)
+    };
+    dora_width + ura_width
 }
 
 /// The win-result panel.
@@ -91,12 +230,20 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
     let yaku_count = wr.yaku.len().max(1);
     let kyoutaku_points = wr.riichi_points();
     let has_bonus_line = kyoutaku_points > 0 || wr.honba_points > 0;
-    let panel_w = 700.0;
-    let panel_h = 326.0 + yaku_count as f32 * 22.0 + if has_bonus_line { 26.0 } else { 0.0 };
-    let (panel_x, panel_y, panel_right) = draw_overlay_panel(panel_w, panel_h);
+    let hand_layout = win_hand_layout(
+        state.win_hand.len(),
+        state.win_tile.is_some(),
+        &state.win_melds,
+    );
+    let panel_w = WIN_PANEL_WIDTH;
+    let panel_h = WIN_PANEL_BASE_HEIGHT
+        + hand_layout.top_overhang
+        + yaku_count as f32 * YAKU_ROW_HEIGHT
+        + if has_bonus_line { 26.0 } else { 0.0 };
+    let (panel_x, panel_y, _) = draw_overlay_panel(panel_w, panel_h);
     let cx = panel_x + panel_w / 2.0;
-    let content_l = panel_x + 40.0;
-    let content_r = panel_right - 40.0;
+    let content_l = panel_x + WIN_PANEL_CONTENT_PADDING;
+    let content_r = content_l + WIN_PANEL_CONTENT_WIDTH;
     let mut y = panel_y + 28.0;
 
     let type_label = if wr.win_is_tsumo {
@@ -104,7 +251,14 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
     } else {
         tr.get(Key::Ron)
     };
-    theme::draw_text_centered(font, type_label, cx, y, 12, theme::GOLD);
+    theme::draw_text_centered(
+        font,
+        type_label,
+        cx,
+        y,
+        theme::font_size::SMALL,
+        theme::GOLD,
+    );
     y += 22.0;
 
     // The winner; a ron also names the deal-in player.
@@ -112,28 +266,21 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
         Some(loser) => format!("{} ← {}", wr.winner_name, loser),
         None => wr.winner_name.clone(),
     };
-    theme::draw_text_centered(font, &winner_line, cx, y, 21, theme::TEXT_BR);
+    theme::draw_text_centered(
+        font,
+        &winner_line,
+        cx,
+        y,
+        theme::font_size::HEADING_LARGE,
+        theme::TEXT_BR,
+    );
     y += 24.0;
 
     // The hand plus the winning tile, centered.
-    let tw = 26.0;
-    let th = 36.0;
-    let win_gap = 14.0;
-    let meld_gap = 4.0;
-    let hand_w = state.win_hand.len() as f32 * tw;
-    let win_w = if state.win_tile.is_some() {
-        win_gap + tw
-    } else {
-        0.0
-    };
-    let meld_w: f32 = state
-        .win_melds
-        .iter()
-        .map(|m| calc_meld_width(m, tw, th) + meld_gap)
-        .sum();
-    let row_w = hand_w + win_w + meld_w;
-    let mut x = cx - row_w / 2.0;
-    let hand_y = y;
+    let tw = hand_layout.tile_w;
+    let th = hand_layout.tile_h;
+    let mut x = cx - hand_layout.row_width / 2.0;
+    let hand_y = y + hand_layout.top_overhang;
     for tile in &state.win_hand {
         draw_tile_sprite(
             tile_textures.for_tile(tile),
@@ -146,12 +293,12 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
         x += tw;
     }
     if let Some(win_tile) = &state.win_tile {
-        x += win_gap;
+        x += WIN_TILE_GAP;
         theme::draw_rounded_rect_lines(
-            x - 2.0,
-            hand_y - 2.0,
-            tw + 4.0,
-            th + 4.0,
+            x - WIN_TILE_OUTLINE_MARGIN,
+            hand_y - WIN_TILE_OUTLINE_MARGIN,
+            tw + 2.0 * WIN_TILE_OUTLINE_MARGIN,
+            th + 2.0 * WIN_TILE_OUTLINE_MARGIN,
             4.0,
             2.0,
             theme::GOLD_LT,
@@ -167,91 +314,130 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
         x += tw;
     }
     for meld in &state.win_melds {
-        x += meld_gap;
+        x += WIN_MELD_GAP;
         draw_meld_group(meld, x, hand_y, tw, th, tile_textures, tile_tint);
         x += calc_meld_width(meld, tw, th);
     }
-    y = hand_y + th + 20.0;
+    y = hand_y + WIN_HAND_ROW_HEIGHT;
 
-    let dw = 20.0;
-    let dh = 28.0;
+    let dw = RESULT_INDICATOR_TILE_W;
+    let dh = RESULT_INDICATOR_TILE_H;
     let dora_text = DoraLabel::Dora.name(state.lang);
     let ura_text = DoraLabel::UraDora.name(state.lang);
-    let dora_label_w = theme::measure_scaled(font, dora_text, 11).width;
-    let dora_tiles_w = state.dora_indicators.len() as f32 * (dw + 2.0);
-    let ura_block_w = if state.uradora_indicators.is_empty() {
-        0.0
-    } else {
-        24.0 + theme::measure_scaled(font, ura_text, 11).width
-            + 6.0
-            + state.uradora_indicators.len() as f32 * (dw + 2.0)
-    };
-    let total_w = dora_label_w + 6.0 + dora_tiles_w + ura_block_w;
+    let dora_label_w = theme::measure_text_size(font, dora_text, theme::font_size::CAPTION).width;
+    let ura_label_w = theme::measure_text_size(font, ura_text, theme::font_size::CAPTION).width;
+    let total_w = result_indicator_rows_width(
+        state.dora_indicators.len(),
+        state.uradora_indicators.len(),
+        dora_label_w,
+        ura_label_w,
+    );
     let mut dx = cx - total_w / 2.0;
-    draw_jp_text(font, dora_text, dx, y + dh / 2.0 + 4.0, 11, theme::TEXT_DIM);
-    dx += dora_label_w + 6.0;
+    draw_jp_text(
+        font,
+        dora_text,
+        dx,
+        y + dh / 2.0 + 4.0,
+        theme::font_size::CAPTION,
+        theme::TEXT_DIM,
+    );
+    dx += dora_label_w + RESULT_INDICATOR_LABEL_GAP;
     dx = draw_indicator_row(&state.dora_indicators, dx, y, dw, dh, tile_textures);
     if !state.uradora_indicators.is_empty() {
-        dx += 18.0;
-        draw_jp_text(font, ura_text, dx, y + dh / 2.0 + 4.0, 11, theme::TEXT_DIM);
-        dx += theme::measure_scaled(font, ura_text, 11).width + 6.0;
+        dx += RESULT_INDICATOR_SECTION_GAP;
+        draw_jp_text(
+            font,
+            ura_text,
+            dx,
+            y + dh / 2.0 + 4.0,
+            theme::font_size::CAPTION,
+            theme::TEXT_DIM,
+        );
+        dx += ura_label_w + RESULT_INDICATOR_LABEL_GAP;
         draw_indicator_row(&state.uradora_indicators, dx, y, dw, dh, tile_textures);
     }
-    y += dh + 16.0;
+    y += RESULT_INDICATOR_ROW_HEIGHT;
 
     // The yaku list, separated by a rule.
     draw_rectangle(content_l, y, content_r - content_l, 1.0, theme::BORDER);
     y += 8.0;
     for (name, han) in &wr.yaku {
-        draw_jp_text(font, name, content_l, y + 14.0, 14, theme::TEXT);
-        if wr.yakuman_multiplier == 0 {
+        let name_dimensions = theme::measure_text_size(font, name, YAKU_FONT_SIZE);
+        let han_layout = if wr.yakuman_multiplier == 0 {
             let han_text = tr.han(*han);
-            let hw = theme::measure_scaled(font, &han_text, 14).width;
+            let dimensions = theme::measure_text_size(font, &han_text, YAKU_FONT_SIZE);
+            Some((han_text, dimensions))
+        } else {
+            None
+        };
+        let baseline = yaku_row_baseline(
+            y,
+            YAKU_ROW_HEIGHT,
+            name_dimensions,
+            han_layout.as_ref().map(|(_, dimensions)| *dimensions),
+        );
+
+        draw_jp_text(font, name, content_l, baseline, YAKU_FONT_SIZE, theme::TEXT);
+        if let Some((han_text, dimensions)) = han_layout {
             draw_jp_text(
                 font,
                 &han_text,
-                content_r - hw,
-                y + 14.0,
-                14,
+                yaku_right_aligned_x(content_r, dimensions),
+                baseline,
+                YAKU_FONT_SIZE,
                 theme::GOLD_LT,
             );
         }
         draw_rectangle(
             content_l,
-            y + 22.0,
+            y + YAKU_ROW_HEIGHT,
             content_r - content_l,
             1.0,
             theme::rgba(0xffffff, 0.04),
         );
-        y += 22.0;
+        y += YAKU_ROW_HEIGHT;
     }
     if wr.yaku.is_empty() {
-        y += 22.0;
+        y += YAKU_ROW_HEIGHT;
     }
     y += 8.0;
 
     // Totals: non-yakuman han/fu on the left, rank + big score on the right.
     if wr.rank != ScoreRank::Yakuman {
         let hanfu = tr.han_fu(wr.han, wr.fu);
-        draw_jp_text(font, &hanfu, content_l, y + 24.0, 13, theme::TEXT_DIM);
+        draw_jp_text(
+            font,
+            &hanfu,
+            content_l,
+            y + 24.0,
+            theme::font_size::LABEL,
+            theme::TEXT_DIM,
+        );
     }
 
     // Keep the hand score separate from table bonuses, whose breakdown is
     // shown on the line below.
     let pts = tr.points(&format_score(wr.hand_points()));
-    let pw = theme::measure_scaled(font, &pts, 28).width;
+    let pw = theme::measure_text_size(font, &pts, theme::font_size::DISPLAY).width;
     let pts_x = content_r - pw;
-    draw_jp_text(font, &pts, pts_x, y + 28.0, 28, theme::GOLD_LT);
+    draw_jp_text(
+        font,
+        &pts,
+        pts_x,
+        y + 28.0,
+        theme::font_size::DISPLAY,
+        theme::GOLD_LT,
+    );
 
     // Mangan-and-up rank names match the score's size and color.
     if !wr.rank_name.is_empty() {
-        let rw = theme::measure_scaled(font, &wr.rank_name, 28).width;
+        let rw = theme::measure_text_size(font, &wr.rank_name, theme::font_size::DISPLAY).width;
         draw_jp_text(
             font,
             &wr.rank_name,
             pts_x - 14.0 - rw,
             y + 28.0,
-            28,
+            theme::font_size::DISPLAY,
             theme::GOLD_LT,
         );
     }
@@ -267,8 +453,15 @@ pub(super) fn draw_win_panel(state: &GameState, font: Option<&Font>, tile_textur
             bonus_parts.push(tr.honba_points(wr.honba, &format_score(wr.honba_points)));
         }
         let bonus_text = bonus_parts.join(" ");
-        let bw = theme::measure_scaled(font, &bonus_text, 13).width;
-        draw_jp_text(font, &bonus_text, content_r - bw, y, 13, theme::TEXT_DIM);
+        let bw = theme::measure_text_size(font, &bonus_text, theme::font_size::LABEL).width;
+        draw_jp_text(
+            font,
+            &bonus_text,
+            content_r - bw,
+            y,
+            theme::font_size::LABEL,
+            theme::TEXT_DIM,
+        );
         y += 20.0;
     }
 
@@ -290,15 +483,15 @@ pub(super) fn draw_draw_panel(state: &GameState, font: Option<&Font>) {
     let cx = panel_x + panel_w / 2.0;
     let mut y = panel_y + 40.0;
 
-    theme::draw_text_centered(font, heading, cx, y, 12, theme::GOLD);
+    theme::draw_text_centered(font, heading, cx, y, theme::font_size::SMALL, theme::GOLD);
     y += 30.0;
     for (i, line) in lines.iter().enumerate() {
-        let (size, color) = if i == 0 {
-            (20, theme::TEXT_BR)
+        let (font_size, color) = if i == 0 {
+            (theme::font_size::HEADING, theme::TEXT_BR)
         } else {
-            (14, theme::TEXT)
+            (theme::font_size::LABEL, theme::TEXT)
         };
-        theme::draw_text_centered(font, line, cx, y, size, color);
+        theme::draw_text_centered(font, line, cx, y, font_size, color);
         y += 30.0;
     }
     y += 4.0;
@@ -329,7 +522,7 @@ pub(super) fn draw_game_over(state: &GameState, font: Option<&Font>) {
         tr.get(Key::GameOver),
         cx,
         panel_y + 52.0,
-        26,
+        theme::font_size::TITLE,
         theme::TEXT_BR,
     );
 
@@ -371,19 +564,40 @@ pub(super) fn draw_game_over(state: &GameState, font: Option<&Font>) {
             &format!("{}", rank + 1),
             row_x + 16.0,
             ry + 32.0,
-            24,
+            theme::font_size::TITLE_SMALL,
             rc,
         );
-        draw_jp_text(font, tr.place_suffix(rank), row_x + 34.0, ry + 32.0, 11, rc);
+        draw_jp_text(
+            font,
+            tr.place_suffix(rank),
+            row_x + 34.0,
+            ry + 32.0,
+            theme::font_size::CAPTION,
+            rc,
+        );
 
         // Names; CPU numbers match the score chips' relative order.
         let cpu_number = (*player_idx + state.player_count - state.my_seat) % state.player_count;
         let name = state.player_labels[*player_idx].name(cpu_number, state.lang);
-        draw_jp_text(font, &name, row_x + 64.0, ry + 30.0, 14, theme::TEXT);
+        draw_jp_text(
+            font,
+            &name,
+            row_x + 64.0,
+            ry + 30.0,
+            theme::font_size::LABEL,
+            theme::TEXT,
+        );
 
         let pts = tr.points(&format_score(*score));
-        let pw = theme::measure_scaled(font, &pts, 17).width;
-        draw_jp_text(font, &pts, row_x + row_w - pw - 8.0, ry + 32.0, 17, rc);
+        let pw = theme::measure_text_size(font, &pts, theme::font_size::SUBHEADING).width;
+        draw_jp_text(
+            font,
+            &pts,
+            row_x + row_w - pw - 8.0,
+            ry + 32.0,
+            theme::font_size::SUBHEADING,
+            rc,
+        );
 
         ry += row_h + row_gap;
     }
@@ -408,7 +622,7 @@ pub(super) fn draw_game_over(state: &GameState, font: Option<&Font>) {
         tr.get(Key::PlayAgain),
         cx,
         btn_y + 31.0,
-        16,
+        theme::font_size::BODY_LARGE,
         theme::GOLD_LT,
     );
 }

--- a/crates/mahjong-client/src/renderer/setup.rs
+++ b/crates/mahjong-client/src/renderer/setup.rs
@@ -97,7 +97,14 @@ pub(super) fn draw_setup_option(
     };
     theme::draw_rounded_rect(btn.x, btn.y, btn.w, btn.h, 4.0, fill);
     theme::draw_rounded_rect_lines(btn.x, btn.y, btn.w, btn.h, 4.0, 1.0, border);
-    draw_jp_text(font, label, btn.x + 12.0, btn.y + 18.0, 13, text_color);
+    draw_jp_text(
+        font,
+        label,
+        btn.x + 12.0,
+        btn.y + 18.0,
+        theme::font_size::LABEL,
+        text_color,
+    );
 }
 
 /// Draws the CPU-setup screen.
@@ -127,7 +134,7 @@ pub(super) fn draw_setup(state: &GameState, font: Option<&Font>, origin: MenuOri
         tr.get(Key::CpuSetupTitle),
         cx,
         SETUP_PANEL_Y + 52.0,
-        26,
+        theme::font_size::TITLE,
         theme::TEXT_BR,
     );
     theme::draw_text_centered(
@@ -135,7 +142,7 @@ pub(super) fn draw_setup(state: &GameState, font: Option<&Font>, origin: MenuOri
         tr.get(setup.mode.label_key()),
         cx,
         SETUP_PANEL_Y + 78.0,
-        13,
+        theme::font_size::LABEL,
         theme::GOLD_LT,
     );
 
@@ -172,7 +179,7 @@ pub(super) fn draw_setup(state: &GameState, font: Option<&Font>, origin: MenuOri
             &format!("{}", cpu_idx + 1),
             ring_cx,
             ring_cy + 6.0,
-            16,
+            theme::font_size::BODY_LARGE,
             theme::GOLD_LT,
         );
         draw_jp_text(
@@ -180,7 +187,7 @@ pub(super) fn draw_setup(state: &GameState, font: Option<&Font>, origin: MenuOri
             &tr.cpu_slot(cpu_idx),
             card_x + 56.0,
             SETUP_CARD_Y + 39.0,
-            15,
+            theme::font_size::BODY,
             theme::TEXT,
         );
 
@@ -189,7 +196,7 @@ pub(super) fn draw_setup(state: &GameState, font: Option<&Font>, origin: MenuOri
             tr.get(Key::CpuStrengthLabel),
             card_x + 14.0,
             SETUP_CARD_Y + 76.0,
-            10,
+            theme::font_size::TINY,
             theme::TEXT_DIM,
         );
         for level_idx in 0..SetupState::level_count() {
@@ -207,7 +214,7 @@ pub(super) fn draw_setup(state: &GameState, font: Option<&Font>, origin: MenuOri
             tr.get(Key::CpuPersonalityLabel),
             card_x + 14.0,
             SETUP_CARD_Y + 202.0,
-            10,
+            theme::font_size::TINY,
             theme::TEXT_DIM,
         );
         for pers_idx in 0..SetupState::personality_count() {
@@ -242,14 +249,21 @@ pub(super) fn draw_setup(state: &GameState, font: Option<&Font>, origin: MenuOri
         tr.get(confirm_key),
         cx,
         s.y + 34.0,
-        20,
+        theme::font_size::HEADING,
         theme::GOLD_LT,
     );
 
     let b = setup_back_rect();
     theme::draw_rounded_rect(b.x, b.y, b.w, b.h, 6.0, theme::rgba(0xffffff, 0.05));
     theme::draw_rounded_rect_lines(b.x, b.y, b.w, b.h, 6.0, 1.0, theme::rgba(0xc8a227, 0.3));
-    theme::draw_text_centered(font, tr.get(Key::Back), cx, b.y + 24.0, 14, theme::TEXT);
+    theme::draw_text_centered(
+        font,
+        tr.get(Key::Back),
+        cx,
+        b.y + 24.0,
+        theme::font_size::LABEL,
+        theme::TEXT,
+    );
 }
 
 /// CPU-setup screen actions.

--- a/crates/mahjong-client/src/renderer/tests.rs
+++ b/crates/mahjong-client/src/renderer/tests.rs
@@ -1,18 +1,101 @@
 //! Unit tests for the rendering layout.
 
-use super::{
-    DORA_TILE_TINT, DRAWN_GAP, PLAYER_ROTATIONS, PUBLIC_TILE_HIGHLIGHT_TINT, SELF_HAND_LEFT_MARGIN,
-    SELF_HAND_MELD_GAP, SELF_MELD_GAP, SELF_MELD_RIGHT_EDGE, SELF_MELD_TILE_H, SELF_MELD_TILE_W,
-    TILE_W, add_dora_tile_types, buffer_to_design, calc_meld_width, dora_tile_tint,
-    dora_tile_tint_with_base, dora_tile_types, other_meld_x_positions, pei_tile_x,
-    player_hand_start_x, player_hand_tile_x, public_tile_tint, public_tile_tint_with_base,
-    rotation_index, score_chip_entries, score_delta_color, seat_at_relative_position,
-    self_meld_x_positions, visible_tile_tint,
+use super::board::{
+    DISCARD_FIRST_ROW_OFFSET, DISCARD_TILE_H, DORA_PANEL_HEIGHT, DORA_PANEL_Y,
+    TABLE_DORA_INDICATOR_TILE_H, TABLE_DORA_INDICATOR_TILE_W, TOP_BAR_HEIGHT,
 };
-use super::{format_score_delta, theme};
+use super::{
+    BOARD_CENTER_Y, DORA_TILE_TINT, DRAWN_GAP, HAND_Y, PLAYER_ROTATIONS,
+    PUBLIC_TILE_HIGHLIGHT_TINT, SELF_HAND_LEFT_MARGIN, SELF_HAND_MELD_GAP, SELF_MELD_GAP,
+    SELF_MELD_RIGHT_EDGE, SELF_MELD_TILE_H, SELF_MELD_TILE_W, TILE_W, add_dora_tile_types,
+    buffer_to_design, calc_meld_width, dora_tile_tint, dora_tile_tint_with_base, dora_tile_types,
+    other_meld_x_positions, pei_tile_x, player_hand_start_x, player_hand_tile_x, public_tile_tint,
+    public_tile_tint_with_base, rotation_index, score_chip_entries, score_delta_color,
+    seat_at_relative_position, self_meld_x_positions, visible_tile_tint,
+};
+use super::{
+    format_score_delta,
+    result::{
+        RESULT_INDICATOR_ROW_HEIGHT, RESULT_INDICATOR_TILE_H, RESULT_INDICATOR_TILE_W,
+        WIN_HAND_ROW_HEIGHT, WIN_HAND_TILE_H, WIN_HAND_TILE_W, WIN_PANEL_CONTENT_WIDTH,
+        WIN_PANEL_WIDTH, WIN_TILE_OUTLINE_MARGIN, YAKU_ROW_HEIGHT, result_indicator_rows_width,
+        win_hand_layout, yaku_right_aligned_x, yaku_row_baseline,
+    },
+    theme,
+};
 use crate::game::{GameState, SelfTedashiAnim, SelfTileOrigin};
+use macroquad::prelude::TextDimensions;
 use mahjong_core::hand_info::meld::{Meld, MeldFrom, MeldType};
 use mahjong_core::tile::{Tile, TileType};
+
+#[test]
+fn named_font_sizes_match_the_rendered_pixel_sizes() {
+    let named_sizes = [
+        theme::font_size::MICRO,
+        theme::font_size::TINY,
+        theme::font_size::CAPTION,
+        theme::font_size::SMALL,
+        theme::font_size::LABEL,
+        theme::font_size::BODY,
+        theme::font_size::BODY_LARGE,
+        theme::font_size::SUBHEADING,
+        theme::font_size::HEADING_SMALL,
+        theme::font_size::HEADING,
+        theme::font_size::HEADING_LARGE,
+        theme::font_size::TITLE_SMALL,
+        theme::font_size::TITLE,
+        theme::font_size::DISPLAY,
+        theme::font_size::DISPLAY_LARGE,
+    ];
+    let expected = [13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 25, 29, 31, 34, 38];
+
+    assert_eq!(named_sizes, expected);
+    assert_eq!(&theme::font_size::ALL[..], &expected);
+}
+
+#[test]
+fn font_size_catalog_is_strictly_increasing() {
+    assert!(
+        theme::font_size::ALL
+            .windows(2)
+            .all(|pair| pair[0] < pair[1])
+    );
+}
+
+#[test]
+fn yaku_text_and_shadow_are_centered_between_row_dividers() {
+    let name = TextDimensions {
+        width: 48.0,
+        height: 16.0,
+        offset_y: 15.0,
+    };
+    let han = TextDimensions {
+        width: 24.0,
+        height: 17.0,
+        offset_y: 14.0,
+    };
+    let row_top = 100.0;
+    let baseline = yaku_row_baseline(row_top, YAKU_ROW_HEIGHT, name, Some(han));
+    let visible_top = baseline - name.offset_y.max(han.offset_y);
+    let visible_bottom = baseline
+        + (name.height - name.offset_y).max(han.height - han.offset_y)
+        + theme::TEXT_SHADOW_OFFSET;
+
+    assert!((visible_top - row_top - (row_top + YAKU_ROW_HEIGHT - visible_bottom)).abs() < 0.001);
+}
+
+#[test]
+fn yaku_han_shadow_ends_at_the_row_divider_edge() {
+    let dimensions = TextDimensions {
+        width: 24.0,
+        height: 17.0,
+        offset_y: 14.0,
+    };
+    let right = 620.0;
+    let x = yaku_right_aligned_x(right, dimensions);
+
+    assert_eq!(x + dimensions.width + theme::TEXT_SHADOW_OFFSET, right);
+}
 
 #[test]
 fn buffer_to_design_scales_each_axis_independently() {
@@ -124,6 +207,107 @@ fn called_kan(tile_type: TileType) -> Meld {
     }
 }
 
+/// Minimal added quad for vertical result-layout tests.
+fn added_kan(tile_type: TileType) -> Meld {
+    let tile = Tile::new(tile_type);
+    Meld {
+        tiles: vec![tile; 4],
+        category: MeldType::Kakan,
+        from: MeldFrom::Previous,
+        called_tile: Some(tile),
+    }
+}
+
+#[test]
+fn enlarged_dora_indicators_fit_their_rows() {
+    const {
+        assert!(TABLE_DORA_INDICATOR_TILE_H <= DORA_PANEL_HEIGHT);
+        assert!(DORA_PANEL_Y + DORA_PANEL_HEIGHT <= TOP_BAR_HEIGHT);
+        assert!(RESULT_INDICATOR_TILE_H <= RESULT_INDICATOR_ROW_HEIGHT);
+    }
+    assert_eq!(TABLE_DORA_INDICATOR_TILE_W, 26.0);
+    assert_eq!(TABLE_DORA_INDICATOR_TILE_H, 37.0);
+    assert_eq!(RESULT_INDICATOR_TILE_W, 30.0);
+    assert_eq!(RESULT_INDICATOR_TILE_H, 42.0);
+
+    let ten_tiles_without_labels = result_indicator_rows_width(5, 5, 0.0, 0.0);
+    assert_eq!(ten_tiles_without_labels, 350.0);
+    assert!(ten_tiles_without_labels < WIN_PANEL_CONTENT_WIDTH);
+}
+
+#[test]
+fn normal_win_hand_uses_the_enlarged_tile_size() {
+    const {
+        assert!(WIN_HAND_TILE_H + 2.0 * WIN_TILE_OUTLINE_MARGIN <= WIN_HAND_ROW_HEIGHT);
+    }
+    let layout = win_hand_layout(13, true, &[]);
+
+    assert_eq!(WIN_PANEL_WIDTH, 780.0);
+    assert_eq!(WIN_PANEL_CONTENT_WIDTH, 700.0);
+    assert_eq!(layout.tile_w, WIN_HAND_TILE_W);
+    assert_eq!(layout.tile_h, WIN_HAND_TILE_H);
+    assert_eq!(layout.row_width, 574.0);
+}
+
+#[test]
+fn widest_win_hand_scales_down_to_the_panel_width() {
+    let melds = vec![
+        called_kan(Tile::M1),
+        called_kan(Tile::P2),
+        called_kan(Tile::S3),
+        called_kan(Tile::Z1),
+    ];
+    let layout = win_hand_layout(1, true, &melds);
+
+    assert_eq!(WIN_HAND_TILE_W, 40.0);
+    assert_eq!(WIN_HAND_TILE_H, 56.0);
+    assert!(layout.tile_w >= 34.0);
+    assert!(layout.tile_h >= 47.0);
+    assert!(layout.tile_w < WIN_HAND_TILE_W);
+    assert!((layout.row_width - WIN_PANEL_CONTENT_WIDTH).abs() < 0.001);
+}
+
+#[test]
+fn added_quad_reserves_space_above_the_win_hand() {
+    let layout = win_hand_layout(10, true, &[added_kan(Tile::M1)]);
+
+    assert_eq!(layout.tile_w, WIN_HAND_TILE_W);
+    assert_eq!(layout.tile_h, WIN_HAND_TILE_H);
+    assert_eq!(layout.top_overhang, 24.0);
+}
+
+#[test]
+fn enlarged_opponent_tiles_fit_between_the_top_bar_and_our_hand() {
+    const DISCARD_ROW_COUNT: f32 = 3.0;
+
+    let normal = opponent_tile_layout(13, true, false, &[]);
+    assert_eq!(OTHER_HAND_TILE_W, 33.0);
+    assert_eq!(OTHER_HAND_TILE_H, 46.0);
+    assert_eq!(normal.tile_w, OTHER_HAND_TILE_W);
+    assert_eq!(normal.tile_h, OTHER_HAND_TILE_H);
+    assert_eq!(normal.row_width, 470.0);
+
+    let melds = vec![
+        called_kan(Tile::M1),
+        called_kan(Tile::P2),
+        called_kan(Tile::S3),
+        called_kan(Tile::Z1),
+    ];
+    let widest = opponent_tile_layout(1, true, false, &melds);
+    let half_width = widest.row_width / 2.0;
+
+    assert!(widest.tile_w < OTHER_HAND_TILE_W);
+    assert!(widest.row_width <= OTHER_HAND_MAX_ROW_WIDTH + 0.001);
+    assert!(BOARD_CENTER_Y - half_width >= TOP_BAR_HEIGHT);
+    assert!(BOARD_CENTER_Y + half_width <= HAND_Y);
+    assert_eq!(BOARD_CENTER_Y - OTHER_HAND_OUTER_DISTANCE, TOP_BAR_HEIGHT);
+
+    let discard_edge =
+        BOARD_CENTER_Y + DISCARD_FIRST_ROW_OFFSET + DISCARD_ROW_COUNT * DISCARD_TILE_H;
+    let stacked_kakan_edge = BOARD_CENTER_Y + OTHER_HAND_OUTER_DISTANCE - 2.0 * OTHER_HAND_TILE_W;
+    assert_eq!(stacked_kakan_edge - discard_edge, 2.0);
+}
+
 // Melds must lay out earliest-rightmost from the player's view;
 // our own pack right-to-left from the right edge.
 #[test]
@@ -149,7 +333,7 @@ fn self_melds_place_first_called_on_the_right() {
 // Opponents' melds are also earliest-rightmost from their own view.
 #[test]
 fn other_melds_place_first_called_on_the_right() {
-    let (tw, th, gap, start_x) = (28.0, 40.0, 6.0, 100.0);
+    let (tw, th, gap, start_x) = (OTHER_HAND_TILE_W, OTHER_HAND_TILE_H, OTHER_MELD_GAP, 100.0);
     let melds = vec![pon(Tile::M1), pon(Tile::P2), pon(Tile::S3)];
     let xs = other_meld_x_positions(&melds, tw, th, gap, start_x);
 
@@ -475,8 +659,9 @@ fn export_labeled_tiles_for_visual_check() {
 // --- Opponent hand-discard animation ---
 
 use super::tiles::{
-    TEDASHI_GAP_HOLD_SECS, TEDASHI_SLIDE_SECS, opponent_drawn_slot_width, tedashi_progress,
-    tedashi_tile_offset,
+    OTHER_HAND_MAX_ROW_WIDTH, OTHER_HAND_OUTER_DISTANCE, OTHER_HAND_TILE_H, OTHER_HAND_TILE_W,
+    OTHER_MELD_GAP, TEDASHI_GAP_HOLD_SECS, TEDASHI_SLIDE_SECS, opponent_drawn_slot_width,
+    opponent_tile_layout, tedashi_progress, tedashi_tile_offset,
 };
 
 #[test]

--- a/crates/mahjong-client/src/renderer/theme.rs
+++ b/crates/mahjong-client/src/renderer/theme.rs
@@ -223,22 +223,51 @@ pub fn draw_radial_bg(
     }
 }
 
-/// Uniform font scale for readability.
-///
-/// The original pixel sizes feel small on the dark board, so text draws
-/// slightly larger; [`measure_scaled`] applies the same factor, keeping
-/// layout consistent.
-const FONT_SCALE: f32 = 1.2;
+/// Final rendered font sizes used by the UI, in design-canvas pixels.
+pub mod font_size {
+    pub const MICRO: u16 = 13;
+    pub const TINY: u16 = 14;
+    pub const CAPTION: u16 = 15;
+    pub const SMALL: u16 = 16;
+    pub const LABEL: u16 = 17;
+    pub const BODY: u16 = 18;
+    pub const BODY_LARGE: u16 = 19;
+    pub const SUBHEADING: u16 = 20;
+    pub const HEADING_SMALL: u16 = 22;
+    pub const HEADING: u16 = 24;
+    pub const HEADING_LARGE: u16 = 25;
+    pub const TITLE_SMALL: u16 = 29;
+    pub const TITLE: u16 = 31;
+    pub const DISPLAY: u16 = 34;
+    pub const DISPLAY_LARGE: u16 = 38;
 
-/// Base size to actual rendered size.
-pub fn scaled_size(base: u16) -> u16 {
-    (base as f32 * FONT_SCALE).round() as u16
+    /// Every font size used to prewarm the native font atlas.
+    pub const ALL: [u16; 15] = [
+        MICRO,
+        TINY,
+        CAPTION,
+        SMALL,
+        LABEL,
+        BODY,
+        BODY_LARGE,
+        SUBHEADING,
+        HEADING_SMALL,
+        HEADING,
+        HEADING_LARGE,
+        TITLE_SMALL,
+        TITLE,
+        DISPLAY,
+        DISPLAY_LARGE,
+    ];
 }
 
-/// Measures text at the scaled size, for manual layout.
-pub fn measure_scaled(font: Option<&Font>, text: &str, base: u16) -> TextDimensions {
-    measure_text(text, font, scaled_size(base), 1.0)
+/// Measures text at its final rendered size, for manual layout.
+pub fn measure_text_size(font: Option<&Font>, text: &str, font_size: u16) -> TextDimensions {
+    measure_text(text, font, font_size, 1.0)
 }
+
+/// Pixel offset used by the text shadow on both axes.
+pub(super) const TEXT_SHADOW_OFFSET: f32 = 1.0;
 
 /// Draws text with a shadow and faux bold (no scaling; internal).
 fn draw_text_raw(font: Option<&Font>, text: &str, x: f32, y: f32, fs: u16, color: Color) {
@@ -255,7 +284,11 @@ fn draw_text_raw(font: Option<&Font>, text: &str, x: f32, y: f32, fs: u16, color
             },
         );
     };
-    draw(Color::new(0.0, 0.0, 0.0, 0.55), 1.0, 1.0);
+    draw(
+        Color::new(0.0, 0.0, 0.0, 0.55),
+        TEXT_SHADOW_OFFSET,
+        TEXT_SHADOW_OFFSET,
+    );
     // Faux bold: draw twice with a slight horizontal offset.
     draw(color, 0.0, 0.0);
     draw(color, 0.55, 0.0);
@@ -264,9 +297,9 @@ fn draw_text_raw(font: Option<&Font>, text: &str, x: f32, y: f32, fs: u16, color
 /// Draws readable text; `x` is the left edge, `y` the baseline.
 ///
 /// A dark shadow boosts contrast and a slightly offset double draw fakes
-/// bold, keeping thin faces legible; sizes scale by [`FONT_SCALE`].
-pub fn draw_text(font: Option<&Font>, text: &str, x: f32, y: f32, base_size: u16, color: Color) {
-    draw_text_raw(font, text, x, y, scaled_size(base_size), color);
+/// bold, keeping thin faces legible.
+pub fn draw_text(font: Option<&Font>, text: &str, x: f32, y: f32, font_size: u16, color: Color) {
+    draw_text_raw(font, text, x, y, font_size, color);
 }
 
 /// Draws centered text; `y` is the baseline.
@@ -275,17 +308,16 @@ pub fn draw_text_centered(
     text: &str,
     center_x: f32,
     baseline_y: f32,
-    base_size: u16,
+    font_size: u16,
     color: Color,
 ) {
-    let fs = scaled_size(base_size);
-    let dims = measure_text(text, font, fs, 1.0);
+    let dims = measure_text(text, font, font_size, 1.0);
     draw_text_raw(
         font,
         text,
         center_x - dims.width / 2.0,
         baseline_y,
-        fs,
+        font_size,
         color,
     );
 }

--- a/crates/mahjong-client/src/renderer/tiles.rs
+++ b/crates/mahjong-client/src/renderer/tiles.rs
@@ -44,7 +44,7 @@ pub(super) fn draw_hand(state: &GameState, font: Option<&Font>, tile_textures: &
             tr.get(Key::Tsumo),
             drawn_x + TILE_W / 2.0,
             hand_y + y_offset - 8.0,
-            11,
+            theme::font_size::CAPTION,
             theme::GOLD_LT,
         );
 
@@ -63,7 +63,7 @@ pub(super) fn draw_hand(state: &GameState, font: Option<&Font>, tile_textures: &
 
     // Status badges (furiten, riichi, riichi-discard choice, swap-calling
     // warning) draw after the hand so tiles cannot cover them.
-    let badge_y = hand_y - 26.0;
+    let badge_y = hand_y - 28.0;
     let mut bx = hand_start_x;
     if state.is_furiten {
         bx = draw_badge(
@@ -469,6 +469,13 @@ pub(super) fn draw_tile_sprite_rotated(
     );
 }
 
+pub(super) const OTHER_HAND_TILE_W: f32 = 33.0;
+pub(super) const OTHER_HAND_TILE_H: f32 = 46.0;
+pub(super) const OTHER_MELD_GAP: f32 = 6.0;
+/// Keeps the opposite player's outer tile edge below the top bar.
+pub(super) const OTHER_HAND_OUTER_DISTANCE: f32 = BOARD_CENTER_Y - TOP_BAR_HEIGHT;
+/// Keeps a rotated side-player row above our hand.
+pub(super) const OTHER_HAND_MAX_ROW_WIDTH: f32 = 2.0 * (HAND_Y - BOARD_CENTER_Y);
 /// Gap for an opponent's drawn tile, matching their reduced tile size.
 pub(super) const OTHER_DRAWN_GAP: f32 = 8.0;
 /// Hand-discard animation: how long the vacated gap shows (seconds).
@@ -533,6 +540,89 @@ pub(super) fn opponent_drawn_slot_width(
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(super) struct OpponentTileLayout {
+    pub(super) tile_w: f32,
+    pub(super) tile_h: f32,
+    pub(super) meld_gap: f32,
+    pub(super) drawn_gap: f32,
+    pub(super) drawn_slot: f32,
+    pub(super) row_width: f32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct OpponentTileMetrics {
+    tile_w: f32,
+    tile_h: f32,
+    meld_gap: f32,
+    drawn_gap: f32,
+}
+
+fn opponent_row_width(
+    hand_count: usize,
+    has_drawn: bool,
+    revealed: bool,
+    melds: &[Meld],
+    metrics: OpponentTileMetrics,
+) -> (f32, f32) {
+    let drawn_slot = if revealed {
+        0.0
+    } else {
+        opponent_drawn_slot_width(hand_count, has_drawn, metrics.tile_w, metrics.drawn_gap)
+    };
+    let meld_widths: f32 = melds
+        .iter()
+        .map(|meld| calc_meld_width(meld, metrics.tile_w, metrics.tile_h))
+        .sum();
+    let row_width = hand_count as f32 * metrics.tile_w
+        + drawn_slot
+        + meld_widths
+        + melds.len() as f32 * metrics.meld_gap;
+    (row_width, drawn_slot)
+}
+
+/// Enlarges normal opponent tiles while fitting rare four-quad rows.
+pub(super) fn opponent_tile_layout(
+    hand_count: usize,
+    has_drawn: bool,
+    revealed: bool,
+    melds: &[Meld],
+) -> OpponentTileLayout {
+    let natural = OpponentTileMetrics {
+        tile_w: OTHER_HAND_TILE_W,
+        tile_h: OTHER_HAND_TILE_H,
+        meld_gap: OTHER_MELD_GAP,
+        drawn_gap: OTHER_DRAWN_GAP,
+    };
+    let (natural_width, _) = opponent_row_width(hand_count, has_drawn, revealed, melds, natural);
+    let scale = if natural_width > OTHER_HAND_MAX_ROW_WIDTH {
+        OTHER_HAND_MAX_ROW_WIDTH / natural_width
+    } else {
+        1.0
+    };
+    let tile_w = OTHER_HAND_TILE_W * scale;
+    let tile_h = OTHER_HAND_TILE_H * scale;
+    let meld_gap = OTHER_MELD_GAP * scale;
+    let drawn_gap = OTHER_DRAWN_GAP * scale;
+    let scaled = OpponentTileMetrics {
+        tile_w,
+        tile_h,
+        meld_gap,
+        drawn_gap,
+    };
+    let (row_width, drawn_slot) =
+        opponent_row_width(hand_count, has_drawn, revealed, melds, scaled);
+
+    OpponentTileLayout {
+        tile_w,
+        tile_h,
+        meld_gap,
+        drawn_gap,
+        drawn_slot,
+        row_width,
+    }
+}
+
 /// Draws the other players' hands.
 ///
 /// Like the discards, drawn in the normalized self view (left to right)
@@ -542,13 +632,6 @@ pub(super) fn opponent_drawn_slot_width(
 /// so centering never shifts the whole hand on each draw/discard; the
 /// drawn tile hangs out with a gap, as with our own hand.
 pub(super) fn draw_other_player_hands(state: &GameState, tile_textures: &TileTextures) {
-    let tw: f32 = 28.0; // natural tile width
-    let th: f32 = 40.0; // natural tile height
-    let meld_gap: f32 = 6.0;
-    let tile_step: f32 = tw; // tiles touch
-    let hand_distance: f32 = 290.0; // center to the hand
-
-    let base_y = BOARD_CENTER_Y + hand_distance;
     let now = get_time();
     let selected_tile_type = state.selected_tile_type();
     let dora_tile_types = dora_tile_types(&state.dora_indicators, state.is_three_player());
@@ -565,19 +648,16 @@ pub(super) fn draw_other_player_hands(state: &GameState, tile_textures: &TileTex
         } else {
             other.concealed_count
         };
-        let drawn_slot = if other.revealed {
-            0.0
-        } else {
-            opponent_drawn_slot_width(hand_count, other.has_drawn, tile_step, OTHER_DRAWN_GAP)
-        };
-        let meld_widths: f32 = other.melds.iter().map(|m| calc_meld_width(m, tw, th)).sum();
-        let meld_gaps = if other.melds.is_empty() {
-            0.0
-        } else {
-            meld_gap + (other.melds.len() as f32 - 1.0) * meld_gap
-        };
-        let total_width = hand_count as f32 * tile_step + drawn_slot + meld_widths + meld_gaps;
-        let start_x = BOARD_CENTER_X - total_width / 2.0;
+        let layout =
+            opponent_tile_layout(hand_count, other.has_drawn, other.revealed, &other.melds);
+        let tw = layout.tile_w;
+        let th = layout.tile_h;
+        let meld_gap = layout.meld_gap;
+        let drawn_gap = layout.drawn_gap;
+        let drawn_slot = layout.drawn_slot;
+        let tile_step = tw;
+        let base_y = BOARD_CENTER_Y + OTHER_HAND_OUTER_DISTANCE - th;
+        let start_x = BOARD_CENTER_X - layout.row_width / 2.0;
 
         set_camera(&make_board_camera(
             PLAYER_ROTATIONS[rotation_index(
@@ -615,7 +695,7 @@ pub(super) fn draw_other_player_hands(state: &GameState, tile_textures: &TileTex
                         a.gap_index,
                         a.had_drawn,
                         tile_step,
-                        OTHER_DRAWN_GAP,
+                        drawn_gap,
                         p,
                     )
                 });
@@ -624,14 +704,7 @@ pub(super) fn draw_other_player_hands(state: &GameState, tile_textures: &TileTex
             }
 
             if other.has_drawn {
-                draw_tile_sprite(
-                    &tile_textures.back,
-                    x + OTHER_DRAWN_GAP,
-                    base_y,
-                    tw,
-                    th,
-                    WHITE,
-                );
+                draw_tile_sprite(&tile_textures.back, x + drawn_gap, base_y, tw, th, WHITE);
             }
             x += drawn_slot;
         }


### PR DESCRIPTION
## Summary

- replace indirect font scaling and numeric font-size literals with named final-pixel typography constants
- update menu, setup, online, board, overlay, banner, and result layouts for the larger text
- vertically align yaku names and han values with their result-row dividers
- enlarge table dora indicators, opponent hands, winning-hand tiles, and result dora indicators
- widen the win result panel and adaptively scale unusually wide winning hands
- reserve space for added-quad tile overhangs
- add renderer layout tests for typography, result rows, dora bounds, wide hands, and opponent-hand bounds

## Why

Small text and several important tile groups were difficult to read at the current canvas size. The previous global font-scaling layer also obscured the actual rendered sizes.

Winning-hand tiles were constrained by rare worst-case layouts such as four called quads, even though ordinary hands had substantial unused space. Adaptive sizing allows normal hands to use larger tiles while keeping exceptional layouts inside the panel.

## Impact

The client UI is easier to read while retaining bounded layouts for long or unusual hands. No game rules, server behavior, dependencies, or assets are changed.

## Validation

- `cargo fmt`
- `cargo build --target-dir target/codex-verify`
- `cargo test`
- `cargo clippy --all-targets --all-features`
- `git diff --check`

Manual visual verification was not performed, as requested.

Fixes #362