### PR TITLE
Translate non-localized Japanese strings to English

### DIFF
--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -127,7 +127,7 @@
         if (typeof load === "function") {
             load("mahjong-client.wasm");
         } else {
-            document.body.innerHTML = "<p style='color:white;text-align:center;margin-top:40vh'>エラー: mq_js_bundle.js が読み込めませんでした</p>";
+            document.body.innerHTML = "<p style='color:white;text-align:center;margin-top:40vh'>Error: failed to load mq_js_bundle.js</p>";
         }
     </script>
 </body>

--- a/crates/mahjong-client/js/ws.js
+++ b/crates/mahjong-client/js/ws.js
@@ -55,11 +55,11 @@ function mahjong_ws_connect(url_ptr, url_len) {
             }
         };
         ws.onerror = (event) => {
-            console.error("mahjong_ws: WebSocketエラー", event);
+            console.error("mahjong_ws: WebSocket error", event);
             entry.status = MAHJONG_WS_ERROR;
         };
     } catch (err) {
-        console.error("mahjong_ws: 接続に失敗しました", err);
+        console.error("mahjong_ws: connection failed", err);
         entry.status = MAHJONG_WS_ERROR;
     }
 
@@ -82,7 +82,7 @@ function mahjong_ws_send(handle, ptr, len) {
         entry.ws.send(mahjong_ws.read_str(ptr, len));
         return 0;
     } catch (err) {
-        console.error("mahjong_ws: 送信に失敗しました", err);
+        console.error("mahjong_ws: send failed", err);
         entry.status = MAHJONG_WS_ERROR;
         return -1;
     }
@@ -141,7 +141,7 @@ function mahjong_ws_default_url(buf_ptr, cap) {
     }
     const bytes = mahjong_ws.encoder.encode(url);
     if (bytes.length > cap) {
-        console.error("mahjong_ws: MAHJONG_SERVER_URL が長すぎます");
+        console.error("mahjong_ws: MAHJONG_SERVER_URL is too long");
         return 0;
     }
     new Uint8Array(wasm_memory.buffer, buf_ptr, bytes.length).set(bytes);

--- a/crates/mahjong-client/src/adapter/remote.rs
+++ b/crates/mahjong-client/src/adapter/remote.rs
@@ -677,9 +677,9 @@ mod tests {
     fn build_test(transport: Box<dyn Transport>, intent: LobbyIntent) -> RemoteAdapter {
         RemoteAdapter::build(
             transport,
-            Box::new(|_| panic!("このテストでは再接続を想定していません")),
+            Box::new(|_| panic!("this test does not expect a reconnection attempt")),
             Box::new(|| 0.0),
-            "テスト",
+            "Test",
             intent,
         )
     }
@@ -708,7 +708,7 @@ mod tests {
             code: "ABC234".to_string(),
             seats: [
                 SeatInfo::Human {
-                    name: "ホスト".to_string(),
+                    name: "Host".to_string(),
                     connected: true,
                 },
                 SeatInfo::Empty,
@@ -756,9 +756,9 @@ mod tests {
                 ..
             } => {
                 assert_eq!(*protocol_version, PROTOCOL_VERSION);
-                assert_eq!(display_name, "テスト");
+                assert_eq!(display_name, "Test");
             }
-            other => panic!("Helloでないメッセージ: {other:?}"),
+            other => panic!("expected Hello message, got {other:?}"),
         }
 
         handle.push_msg(&welcome());
@@ -772,7 +772,7 @@ mod tests {
                 assert_eq!(*length, GameLength::EastOnly);
                 assert_eq!(*rules, Settings::new());
             }
-            other => panic!("CreateRoomでないメッセージ: {other:?}"),
+            other => panic!("expected CreateRoom message, got {other:?}"),
         }
     }
 
@@ -796,14 +796,14 @@ mod tests {
         let sent = handle.sent();
         match &sent[1] {
             ClientMessage::CreateRoom { length, .. } => assert_eq!(*length, GameLength::Hanchan),
-            other => panic!("CreateRoomでないメッセージ: {other:?}"),
+            other => panic!("expected CreateRoom message, got {other:?}"),
         }
 
         let msg = ServerMessage::RoomState {
             code: "ABC234".to_string(),
             seats: [
                 SeatInfo::Human {
-                    name: "ホスト".to_string(),
+                    name: "Host".to_string(),
                     connected: true,
                 },
                 SeatInfo::Empty,
@@ -819,7 +819,7 @@ mod tests {
         handle.push_msg(&msg);
         adapter.tick();
 
-        let room = adapter.room().expect("入室しているはず");
+        let room = adapter.room().expect("adapter should be in a room");
         assert_eq!(room.length, GameLength::Hanchan);
         assert!(!room.three_player());
     }
@@ -841,7 +841,7 @@ mod tests {
         let sent = handle.sent();
         match &sent[1] {
             ClientMessage::JoinRoom { code } => assert_eq!(code, "ABC234"),
-            other => panic!("JoinRoomでないメッセージ: {other:?}"),
+            other => panic!("expected JoinRoom message, got {other:?}"),
         }
     }
 
@@ -853,7 +853,7 @@ mod tests {
         handle.push_msg(&room_state(0));
         adapter.tick();
 
-        let room = adapter.room().expect("ルーム情報が無い");
+        let room = adapter.room().expect("room information is missing");
         assert_eq!(room.code, "ABC234");
         assert_eq!(room.your_seat, 0);
         assert!(room.is_host());
@@ -892,7 +892,7 @@ mod tests {
             code: "ABC234".to_string(),
             seats: [
                 SeatInfo::Human {
-                    name: "ホスト".to_string(),
+                    name: "Host".to_string(),
                     connected: true,
                 },
                 SeatInfo::Empty,
@@ -908,7 +908,7 @@ mod tests {
         handle.push_msg(&msg);
         adapter.tick();
 
-        let room = adapter.room().expect("入室しているはず");
+        let room = adapter.room().expect("adapter should be in a room");
         assert_eq!(room.cpu_configs, Some(specs));
     }
 
@@ -936,7 +936,7 @@ mod tests {
         });
         adapter.tick();
 
-        let err = adapter.take_error().expect("エラーが記録されていない");
+        let err = adapter.take_error().expect("error was not recorded");
         assert_eq!(err.code, Some(ErrorCode::RoomNotFound));
         assert!(adapter.take_error().is_none());
     }
@@ -969,7 +969,7 @@ mod tests {
     #[test]
     fn test_transport_error_disconnects() {
         let (mut adapter, handle) = create_adapter();
-        handle.push(WsEvent::Error("接続に失敗しました".to_string()));
+        handle.push(WsEvent::Error("connection failed".to_string()));
         adapter.tick();
 
         assert_eq!(adapter.status(), ConnStatus::Disconnected);
@@ -1032,7 +1032,7 @@ mod tests {
     /// Start the server first with `cargo run -p mahjong-net-server`:
     /// `cargo test -p mahjong-client -- --ignored e2e`
     #[test]
-    #[ignore = "要ローカルサーバ (cargo run -p mahjong-net-server)"]
+    #[ignore = "requires a local server (cargo run -p mahjong-net-server)"]
     fn test_e2e_full_game_against_local_server() {
         let url = crate::transport::default_server_url();
         // The production clock needs a macroquad window; headless E2E
@@ -1044,7 +1044,7 @@ mod tests {
             transport,
             connector,
             Box::new(move || clock_start.elapsed().as_secs_f64()),
-            "E2Eテスト",
+            "E2E Test",
             LobbyIntent::Create {
                 length: GameLength::EastOnly,
                 rules: Settings::new(),
@@ -1061,18 +1061,18 @@ mod tests {
         loop {
             assert!(
                 start.elapsed() < std::time::Duration::from_secs(120),
-                "E2Eテストがタイムアウトした"
+                "E2E test timed out"
             );
             std::thread::sleep(std::time::Duration::from_millis(5));
 
             adapter.tick();
             if let Some(err) = adapter.take_error() {
-                panic!("サーバエラー: {:?} {}", err.code, err.message);
+                panic!("server error: {:?} {}", err.code, err.message);
             }
             assert_ne!(
                 adapter.status(),
                 ConnStatus::Disconnected,
-                "サーバから切断された"
+                "disconnected from the server"
             );
             if adapter.is_game_over() {
                 break;
@@ -1177,7 +1177,9 @@ mod tests {
         let record = calls.clone();
         let connector = Box::new(move |room: Option<&str>| {
             record.borrow_mut().push(room.map(String::from));
-            queue.pop_front().expect("コネクタが想定より多く呼ばれた")
+            queue
+                .pop_front()
+                .expect("connector was called more times than expected")
         });
         (connector, calls)
     }
@@ -1195,7 +1197,7 @@ mod tests {
             t1,
             connector,
             Box::new(move || *now_clock.borrow()),
-            "テスト",
+            "Test",
             LobbyIntent::Join {
                 code: "ABC234".to_string(),
             },
@@ -1279,7 +1281,7 @@ mod tests {
             t1,
             connector,
             Box::new(move || *now_clock.borrow()),
-            "テスト",
+            "Test",
             LobbyIntent::Join {
                 code: "ABC234".to_string(),
             },
@@ -1338,7 +1340,7 @@ mod tests {
             t1,
             connector,
             Box::new(move || *now_clock.borrow()),
-            "テスト",
+            "Test",
             LobbyIntent::Join {
                 code: "ABC234".to_string(),
             },
@@ -1384,7 +1386,7 @@ mod tests {
             t1,
             connector,
             Box::new(move || *now_clock.borrow()),
-            "テスト",
+            "Test",
             LobbyIntent::Join {
                 code: "ABC234".to_string(),
             },
@@ -1415,7 +1417,7 @@ mod tests {
             adapter.status_text(Lang::Ja).as_deref(),
             Some("ルームが見つかりません")
         );
-        let err = adapter.take_error().expect("エラーが記録されていない");
+        let err = adapter.take_error().expect("error was not recorded");
         assert_eq!(err.code, Some(ErrorCode::RoomNotFound));
     }
 
@@ -1432,7 +1434,7 @@ mod tests {
             t1,
             connector,
             Box::new(move || *now_clock.borrow()),
-            "テスト",
+            "Test",
             LobbyIntent::Join {
                 code: "ABC234".to_string(),
             },
@@ -1515,9 +1517,9 @@ mod tests {
         let now_clock = now.clone();
         let mut adapter = RemoteAdapter::build(
             transport,
-            Box::new(|_| panic!("再接続なし")),
+            Box::new(|_| panic!("unexpected reconnection attempt")),
             Box::new(move || *now_clock.borrow()),
-            "テスト",
+            "Test",
             LobbyIntent::Create {
                 length: GameLength::EastOnly,
                 rules: Settings::new(),
@@ -1543,9 +1545,9 @@ mod tests {
         let now_clock = now.clone();
         let mut adapter = RemoteAdapter::build(
             transport,
-            Box::new(|_| panic!("再接続なし")),
+            Box::new(|_| panic!("unexpected reconnection attempt")),
             Box::new(move || *now_clock.borrow()),
-            "テスト",
+            "Test",
             LobbyIntent::Create {
                 length: GameLength::EastOnly,
                 rules: Settings::new(),
@@ -1567,7 +1569,7 @@ mod tests {
         handle.push_msg(&room_state(0));
         adapter.tick();
 
-        handle.push(WsEvent::Error("接続失敗".to_string()));
+        handle.push(WsEvent::Error("connection failed".to_string()));
         adapter.tick();
 
         assert_eq!(adapter.status(), ConnStatus::Disconnected);

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -37,7 +37,7 @@ fn test_set_local_players_assigns_cpu_labels_to_seats_1_to_3() {
 fn test_set_online_players_keeps_seat_order_and_self() {
     let mut state = GameState::new();
     let labels = [
-        PlayerLabel::Human("ホスト".to_string()),
+        PlayerLabel::Human("Host".to_string()),
         PlayerLabel::Me,
         PlayerLabel::Cpu {
             level: "Normal".to_string(),
@@ -54,7 +54,7 @@ fn test_set_online_players_keeps_seat_order_and_self() {
     assert!(matches!(state.player_labels[1], PlayerLabel::Me));
     assert_eq!(
         state.player_labels[0].detail(3, Lang::Ja),
-        Some("ホスト".to_string())
+        Some("Host".to_string())
     );
     assert_eq!(
         state.player_labels[2].detail(1, Lang::Ja),
@@ -385,7 +385,7 @@ fn test_hand_selection_still_discards_on_second_click_during_our_turn() {
         state
             .self_tedashi_anim
             .as_ref()
-            .expect("手出しアニメーションが開始されていない")
+            .expect("discard-from-hand animation did not start")
             .origins,
         vec![SelfTileOrigin::Hand(0), SelfTileOrigin::Drawn]
     );
@@ -417,7 +417,7 @@ fn test_local_hand_discard_tracks_origins_through_sorting() {
     let anim = state
         .self_tedashi_anim
         .as_ref()
-        .expect("手出しアニメーションが開始されていない");
+        .expect("discard-from-hand animation did not start");
     assert_eq!(anim.pre_hand_len, 3);
     assert_eq!(anim.started_at, 100.0);
     assert_eq!(
@@ -522,7 +522,7 @@ fn test_sanma_relative_player_index_wraps_at_three() {
     assert_eq!(
         state.discards[1].len(),
         1,
-        "三麻で西家から見た東家は下家（相対1）のはず"
+        "in a three-player game, East should be to West's right (relative seat 1)"
     );
 }
 
@@ -555,7 +555,10 @@ fn test_sanma_can_pei_with_north_in_hand() {
         can_riichi: false,
         is_furiten: false,
     });
-    assert!(state.can_pei, "手牌に北があるのに北抜き不可");
+    assert!(
+        state.can_pei,
+        "North extraction should be available when North is in the hand"
+    );
 
     // Under riichi a North in the hand alone is not extractable.
     state.is_riichi = true;
@@ -566,7 +569,10 @@ fn test_sanma_can_pei_with_north_in_hand() {
         can_riichi: false,
         is_furiten: false,
     });
-    assert!(!state.can_pei, "リーチ中の手牌北で北抜き可になっている");
+    assert!(
+        !state.can_pei,
+        "North extraction should not be available for a concealed North during riichi"
+    );
 
     // A drawn North is.
     state.handle_event(ServerEvent::TileDrawn {
@@ -576,7 +582,10 @@ fn test_sanma_can_pei_with_north_in_hand() {
         can_riichi: false,
         is_furiten: false,
     });
-    assert!(state.can_pei, "リーチ中のツモ北で北抜き不可");
+    assert!(
+        state.can_pei,
+        "a drawn North should be extractable during riichi"
+    );
 }
 
 /// Regression: a North drawn under riichi must offer pei instead of
@@ -595,7 +604,10 @@ fn test_riichi_drawn_north_holds_auto_discard_for_pei() {
         can_riichi: false,
         is_furiten: false,
     });
-    assert!(state.can_pei, "リーチ中のツモ北で北抜き不可");
+    assert!(
+        state.can_pei,
+        "a drawn North should be extractable during riichi"
+    );
 
     // While pei is available the auto-discard stays held even past
     // its delay (#291).
@@ -605,7 +617,10 @@ fn test_riichi_drawn_north_holds_auto_discard_for_pei() {
             .handle_input(None, 100.0 + RIICHI_AUTO_DISCARD_SECS * 2.0)
             .is_none()
     );
-    assert!(state.drawn.is_some(), "自動ツモ切りが発火した");
+    assert!(
+        state.drawn.is_some(),
+        "automatic discard of the drawn tile was triggered"
+    );
 
     let action = state.handle_input(
         Some(crate::renderer::OverlayClick::Action(ClientAction::Pei)),
@@ -634,7 +649,10 @@ fn test_riichi_pei_pass_discards_drawn_north() {
     // The pass discards immediately, with no delay.
     let action = state.handle_input(Some(crate::renderer::OverlayClick::PassSelfCall), 100.0);
     assert!(matches!(action, Some(ClientAction::Discard { tile: None })));
-    assert!(state.drawn.is_none(), "ツモ切り後もツモ牌が残っている");
+    assert!(
+        state.drawn.is_none(),
+        "the drawn tile should be cleared after discarding it"
+    );
     assert!(!state.can_pei);
 }
 
@@ -654,7 +672,10 @@ fn test_sanma_no_pei_on_last_draw() {
         can_riichi: false,
         is_furiten: false,
     });
-    assert!(!state.can_pei, "海底ツモで北抜き可になっている");
+    assert!(
+        !state.can_pei,
+        "North extraction should not be available on the last tile"
+    );
 }
 
 #[test]
@@ -663,7 +684,11 @@ fn test_setup_state_build_game_settings() {
     let settings = setup.build_game_settings();
     assert!(!settings.rules.three_player);
     assert!(settings.rules.double_yakuman);
-    assert_eq!(settings.length, GameLength::EastOnly, "既定は東風戦");
+    assert_eq!(
+        settings.length,
+        GameLength::EastOnly,
+        "the default game length should be East-only"
+    );
     assert_eq!(setup.cpu_count(), 3);
 
     setup.mode = GameMode::ThreeHanchan;
@@ -680,7 +705,7 @@ fn test_setup_state_build_game_settings() {
     assert_eq!(
         settings.length,
         GameLength::Hanchan,
-        "半荘戦が length に反映されない"
+        "a hanchan game should update the length setting"
     );
     assert_eq!(settings.initial_score, 35000);
     assert_eq!(setup.cpu_count(), 2);
@@ -1491,7 +1516,10 @@ fn test_other_player_draw_marks_drawn_without_moving_hand() {
 
     let other = &state.other_players[0];
     assert!(other.has_drawn);
-    assert_eq!(other.concealed_count, 13, "ツモ牌は手牌の枚数に含めない");
+    assert_eq!(
+        other.concealed_count, 13,
+        "the drawn tile should not count toward the concealed hand size"
+    );
 }
 
 /// A tsumogiri leaves the hand untouched, with no gap animation.
@@ -1514,7 +1542,10 @@ fn test_other_player_tsumogiri_keeps_hand_untouched() {
     let other = &state.other_players[0];
     assert!(!other.has_drawn);
     assert_eq!(other.concealed_count, 13);
-    assert!(other.tedashi_anim.is_none(), "ツモ切りでは詰め演出をしない");
+    assert!(
+        other.tedashi_anim.is_none(),
+        "discarding the drawn tile should not start a hand-compaction animation"
+    );
 }
 
 /// A hand discard merges the drawn tile in (count unchanged) and starts
@@ -1537,8 +1568,13 @@ fn test_other_player_tedashi_starts_gap_animation() {
 
     let other = &state.other_players[0];
     assert!(!other.has_drawn);
-    assert_eq!(other.concealed_count, 13, "手出しではツモ牌が手牌へ入る");
-    let anim = other.tedashi_anim.expect("詰め演出が開始されていない");
+    assert_eq!(
+        other.concealed_count, 13,
+        "discarding from the hand should move the drawn tile into the hand"
+    );
+    let anim = other
+        .tedashi_anim
+        .expect("hand-compaction animation did not start");
     assert_eq!(anim.gap_index, 4);
     assert!(anim.had_drawn);
     assert_eq!(anim.started_at, 100.0);
@@ -1569,7 +1605,9 @@ fn test_other_player_tedashi_after_call_decrements_count() {
 
     let other = &state.other_players[0];
     assert_eq!(other.concealed_count, 10);
-    let anim = other.tedashi_anim.expect("詰め演出が開始されていない");
+    let anim = other
+        .tedashi_anim
+        .expect("hand-compaction animation did not start");
     assert!(!anim.had_drawn);
 }
 
@@ -1593,7 +1631,10 @@ fn test_other_player_ankan_consumes_four_tiles() {
     });
 
     let other = &state.other_players[0];
-    assert_eq!(other.concealed_count, 10, "13枚＋ツモ1枚から4枚が副露へ");
+    assert_eq!(
+        other.concealed_count, 10,
+        "four tiles should move into the meld from 13 concealed tiles plus one draw"
+    );
     assert!(!other.has_drawn);
 
     // The replacement draw restores the overhang.
@@ -1632,7 +1673,10 @@ fn test_sanma_pei_with_drawn_keeps_hand_count() {
 fn test_turn_player_tracks_events() {
     let mut state = GameState::new();
     state.handle_event(game_started_4p(Wind::East, 0));
-    assert_eq!(state.turn_player, None, "局開始直後は手番未確定");
+    assert_eq!(
+        state.turn_player, None,
+        "the current player should be unknown immediately after the round starts"
+    );
 
     // Our own draw makes it our turn.
     state.handle_event(ServerEvent::TileDrawn {
@@ -1682,5 +1726,8 @@ fn test_turn_player_tracks_events() {
         player_hands: vec![],
         declarer: None,
     });
-    assert_eq!(state.turn_player, None, "流局後も手番表示が残っている");
+    assert_eq!(
+        state.turn_player, None,
+        "the current-player indicator should be cleared after a drawn round"
+    );
 }

--- a/crates/mahjong-client/src/main.rs
+++ b/crates/mahjong-client/src/main.rs
@@ -52,20 +52,20 @@ impl ScreenshotNotice {
 fn app_icon() -> Icon {
     fn rgba(png: &[u8]) -> Vec<u8> {
         Image::from_file_with_format(png, Some(ImageFormat::Png))
-            .expect("組み込みアイコンPNGのデコードに失敗")
+            .expect("failed to decode the embedded icon PNG")
             .bytes
     }
 
     Icon {
         small: rgba(include_bytes!("../../../assets/images/others/icon-16.png"))
             .try_into()
-            .expect("16x16アイコンのサイズが不正"),
+            .expect("invalid dimensions for the 16x16 icon"),
         medium: rgba(include_bytes!("../../../assets/images/others/icon-32.png"))
             .try_into()
-            .expect("32x32アイコンのサイズが不正"),
+            .expect("invalid dimensions for the 32x32 icon"),
         big: rgba(include_bytes!("../../../assets/images/others/icon-64.png"))
             .try_into()
-            .expect("64x64アイコンのサイズが不正"),
+            .expect("invalid dimensions for the 64x64 icon"),
     }
 }
 
@@ -210,7 +210,7 @@ async fn main() {
     let tile_textures = TileTextures::load(font_bytes, &mut loading_screen).await;
 
     if font.is_none() {
-        eprintln!("警告: 日本語フォントを読み込めませんでした。デフォルトフォントで表示します。");
+        eprintln!("warning: failed to load the Japanese font; falling back to the default font");
     }
 
     // Build the font atlas up front on native, where lazily cached glyphs

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -465,7 +465,7 @@ impl TileTextures {
 
 fn image_from_png(bytes: &[u8]) -> Image {
     Image::from_file_with_format(bytes, Some(ImageFormat::Png))
-        .expect("組み込み牌PNGのデコードに失敗")
+        .expect("failed to decode the embedded tile PNG")
 }
 
 fn texture_from_image(img: &Image) -> Texture2D {

--- a/crates/mahjong-client/src/renderer/tests.rs
+++ b/crates/mahjong-client/src/renderer/tests.rs
@@ -719,12 +719,19 @@ fn post_call_discard_keeps_hand_edges_and_melds_fixed() {
     let before_slot = opponent_drawn_slot_width(before_count, false, step, gap);
     let after_slot = opponent_drawn_slot_width(after_count, false, step, gap);
 
-    assert_eq!(before_slot, gap, "鳴き直後は余分な手牌がツモ牌枠を占める");
-    assert_eq!(after_slot, step + gap, "打牌後は通常のツモ牌枠を戻す");
+    assert_eq!(
+        before_slot, gap,
+        "the extra concealed tile should occupy the drawn-tile slot immediately after a call"
+    );
+    assert_eq!(
+        after_slot,
+        step + gap,
+        "the normal drawn-tile slot should be restored after the discard"
+    );
     assert_eq!(
         before_count as f32 * step + before_slot,
         after_count as f32 * step + after_slot,
-        "打牌の前後で手牌領域の両端と後続する副露位置を固定する"
+        "the hand bounds and following meld position should stay fixed across the discard"
     );
 }
 
@@ -734,7 +741,7 @@ fn own_post_call_discard_keeps_the_hand_left_edge_fixed() {
     assert_eq!(
         player_hand_start_x(11, &melds),
         player_hand_start_x(10, &melds),
-        "鳴き直後の打牌で手牌の左端を動かさない"
+        "the left edge of the hand should not move on the discard after a call"
     );
 }
 
@@ -764,11 +771,14 @@ fn own_hand_shifts_left_to_clear_three_melds() {
     .into_iter()
     .fold(f32::INFINITY, f32::min);
 
-    assert!(hand_start_x < centered_x, "重なる場合だけ手牌を左へ寄せる");
+    assert!(
+        hand_start_x < centered_x,
+        "the hand should shift left only when it would overlap"
+    );
     assert_eq!(
         meld_left_x - reserved_hand_right_x,
         SELF_HAND_MELD_GAP,
-        "予約ツモ牌枠と副露の間に一定の余白を空ける"
+        "a fixed gap should remain between the reserved drawn-tile slot and melds"
     );
 }
 
@@ -820,12 +830,12 @@ fn own_tedashi_tiles_move_from_pre_discard_origins() {
     assert_eq!(
         player_hand_tile_x(&state, 1, 100.0),
         start_x + 2.0 * TILE_W,
-        "打牌位置の空きを保持する"
+        "the vacated discard position should remain open"
     );
     assert_eq!(
         player_hand_tile_x(&state, 2, 100.0),
         start_x + 3.0 * TILE_W + DRAWN_GAP,
-        "ツモ牌はツモ牌位置から移動を始める"
+        "the drawn tile should start moving from the drawn-tile position"
     );
 
     let finished_at = 100.0 + TEDASHI_GAP_HOLD_SECS + TEDASHI_SLIDE_SECS;

--- a/crates/mahjong-core/src/scoring/fu.rs
+++ b/crates/mahjong-core/src/scoring/fu.rs
@@ -35,7 +35,7 @@ pub fn calculate_fu(analyzer: &HandAnalyzer, hand: &Hand, status: &Status) -> Re
         return Ok(FuResult {
             total: 30,
             details: vec![FuDetail {
-                name: "流し満貫",
+                name: "Nagashi Mangan",
                 fu: 30,
             }],
         });
@@ -46,7 +46,7 @@ pub fn calculate_fu(analyzer: &HandAnalyzer, hand: &Hand, status: &Status) -> Re
         return Ok(FuResult {
             total: 25,
             details: vec![FuDetail {
-                name: "七対子",
+                name: "Seven Pairs",
                 fu: 25,
             }],
         });
@@ -57,7 +57,7 @@ pub fn calculate_fu(analyzer: &HandAnalyzer, hand: &Hand, status: &Status) -> Re
         return Ok(FuResult {
             total: 30,
             details: vec![FuDetail {
-                name: "国士無双",
+                name: "Thirteen Orphans",
                 fu: 30,
             }],
         });
@@ -67,7 +67,7 @@ pub fn calculate_fu(analyzer: &HandAnalyzer, hand: &Hand, status: &Status) -> Re
 
     // Base fu (futei / 副底).
     details.push(FuDetail {
-        name: "副底",
+        name: "Base fu",
         fu: 20,
     });
 
@@ -88,7 +88,7 @@ pub fn calculate_fu(analyzer: &HandAnalyzer, hand: &Hand, status: &Status) -> Re
         return Ok(FuResult {
             total: 20,
             details: vec![FuDetail {
-                name: "平和ツモ",
+                name: "Pinfu tsumo",
                 fu: 20,
             }],
         });
@@ -204,15 +204,15 @@ fn calculate_mentsu_fu(
 
         let name = if is_concealed {
             if is_terminal_or_honour {
-                "么九牌暗刻"
+                "Concealed terminal or honour triplet"
             } else {
-                "中張牌暗刻"
+                "Concealed simple triplet"
             }
         } else {
             if is_terminal_or_honour {
-                "么九牌明刻"
+                "Open terminal or honour triplet"
             } else {
-                "中張牌明刻"
+                "Open simple triplet"
             }
         };
 
@@ -225,9 +225,9 @@ fn calculate_mentsu_fu(
                 let is_terminal_or_honour = open.tiles[0].is_1_9_honour();
                 let fu = if is_terminal_or_honour { 4 } else { 2 };
                 let name = if is_terminal_or_honour {
-                    "么九牌明刻"
+                    "Open terminal or honour triplet"
                 } else {
-                    "中張牌明刻"
+                    "Open simple triplet"
                 };
                 details.push(FuDetail { name, fu });
             }
@@ -241,15 +241,15 @@ fn calculate_mentsu_fu(
                 };
                 let name = if is_concealed {
                     if is_terminal_or_honour {
-                        "么九牌暗槓"
+                        "Concealed terminal or honour quad"
                     } else {
-                        "中張牌暗槓"
+                        "Concealed simple quad"
                     }
                 } else {
                     if is_terminal_or_honour {
-                        "么九牌明槓"
+                        "Open terminal or honour quad"
                     } else {
-                        "中張牌明槓"
+                        "Open simple quad"
                     }
                 };
                 details.push(FuDetail { name, fu });
@@ -274,21 +274,21 @@ fn calculate_jantou_fu(
 
         if Dragon::is_tile_type(tile).is_some() {
             details.push(FuDetail {
-                name: "三元牌雀頭",
+                name: "Dragon pair",
                 fu: 2,
             });
         }
 
         if Wind::is_tile_type(tile) == Some(status.seat_wind) {
             details.push(FuDetail {
-                name: "自風牌雀頭",
+                name: "Seat-wind pair",
                 fu: 2,
             });
         }
 
         if Wind::is_tile_type(tile) == Some(status.round_wind) {
             details.push(FuDetail {
-                name: "場風牌雀頭",
+                name: "Round-wind pair",
                 fu: 2,
             });
         }
@@ -309,7 +309,7 @@ fn calculate_machi_fu(
         match analyzer.winning_tile_placement {
             Some(WinningTilePlacement::Pair) => {
                 details.push(FuDetail {
-                    name: "単騎待ち",
+                    name: "Single wait",
                     fu: 2,
                 });
                 return Ok(());
@@ -326,7 +326,7 @@ fn calculate_machi_fu(
         for head in &analyzer.same2 {
             if head.get()[0] == wt {
                 details.push(FuDetail {
-                    name: "単騎待ち",
+                    name: "Single wait",
                     fu: 2,
                 });
                 return Ok(());
@@ -354,7 +354,7 @@ fn add_sequence_wait_fu(
     // Closed wait (kanchan / 嵌張): won on the middle tile.
     if winning_tile == tiles[1] {
         details.push(FuDetail {
-            name: "嵌張待ち",
+            name: "Closed wait",
             fu: 2,
         });
         return true;
@@ -365,7 +365,7 @@ fn add_sequence_wait_fu(
         || (winning_tile == tiles[0] && suit_rank(tiles[0]) == Some(7))
     {
         details.push(FuDetail {
-            name: "辺張待ち",
+            name: "Edge wait",
             fu: 2,
         });
         return true;
@@ -384,7 +384,7 @@ fn calculate_tsumo_fu(
     // breakdown afterwards, so no exception is needed.
     if status.is_self_drawn {
         details.push(FuDetail {
-            name: "自摸",
+            name: "Tsumo",
             fu: 2,
         });
     }
@@ -396,7 +396,7 @@ fn calculate_tsumo_fu(
 fn calculate_menzen_ron_fu(status: &Status, details: &mut Vec<FuDetail>) -> Result<()> {
     if !status.has_claimed_open && !status.is_self_drawn {
         details.push(FuDetail {
-            name: "門前加符",
+            name: "Closed ron",
             fu: 10,
         });
     }

--- a/crates/mahjong-net-server/src/lobby.rs
+++ b/crates/mahjong-net-server/src/lobby.rs
@@ -126,7 +126,7 @@ mod tests {
             assert_eq!(code.len(), CODE_LEN);
             assert!(
                 code.bytes().all(|b| CODE_ALPHABET.contains(&b)),
-                "コードに不正な文字が含まれる: {code}"
+                "room code contains an invalid character: {code}"
             );
             // No confusable characters.
             assert!(!code.contains(['0', 'O', '1', 'I']));

--- a/crates/mahjong-net-server/src/ratelimit.rs
+++ b/crates/mahjong-net-server/src/ratelimit.rs
@@ -88,10 +88,13 @@ mod tests {
         let limiter = RateLimiter::new();
         let now = Instant::now();
         for i in 0..MAX_ATTEMPTS {
-            assert!(limiter.check_at(ip(), now), "{i}回目は許可されるべき");
+            assert!(limiter.check_at(ip(), now), "request {i} should be allowed");
         }
 
-        assert!(!limiter.check_at(ip(), now), "上限超過は拒否されるべき");
+        assert!(
+            !limiter.check_at(ip(), now),
+            "a request above the limit should be rejected"
+        );
     }
 
     #[test]
@@ -123,7 +126,11 @@ mod tests {
         // An attempt after the window sweeps the stale IPs.
         let later = start + WINDOW + Duration::from_secs(1);
         assert!(limiter.check_at(ip(), later));
-        assert_eq!(limiter.tracked_ips(), 1, "古いIPの記録が残っている");
+        assert_eq!(
+            limiter.tracked_ips(),
+            1,
+            "the stale IP record was not removed"
+        );
     }
 
     #[test]

--- a/crates/mahjong-net-server/tests/integration.rs
+++ b/crates/mahjong-net-server/tests/integration.rs
@@ -51,11 +51,14 @@ async fn start_server(config: RoomConfig) -> SocketAddr {
 /// 1000 x the remaining deposits.
 fn assert_scores_consistent(scores: [i32; 4]) {
     let sum: i32 = scores.iter().sum();
-    assert!(sum <= 25000 * 4, "総和が初期点数を超えている: {scores:?}");
+    assert!(
+        sum <= 25000 * 4,
+        "score total exceeds the initial points: {scores:?}"
+    );
     assert_eq!(
         (25000 * 4 - sum) % 1000,
         0,
-        "総和の差が供託単位でない: {scores:?}"
+        "score-total difference is not a multiple of the deposit value: {scores:?}"
     );
 }
 
@@ -106,16 +109,16 @@ impl TestClient {
         loop {
             let frame = tokio::time::timeout(Duration::from_secs(30), self.ws.next())
                 .await
-                .expect("受信がタイムアウトした")
-                .expect("接続が閉じられた")
-                .expect("WebSocketエラー");
+                .expect("receive timed out")
+                .expect("connection closed")
+                .expect("WebSocket error");
             match frame {
                 Message::Text(text) => {
-                    return ServerMessage::from_json(text.as_str()).expect("不正なJSON");
+                    return ServerMessage::from_json(text.as_str()).expect("invalid JSON");
                 }
                 Message::Ping(_) | Message::Pong(_) => continue,
-                Message::Close(_) => panic!("接続が閉じられた"),
-                other => panic!("予期しないフレーム: {other:?}"),
+                Message::Close(_) => panic!("connection closed"),
+                other => panic!("unexpected frame: {other:?}"),
             }
         }
     }
@@ -127,7 +130,7 @@ impl TestClient {
                 return code;
             }
         }
-        panic!("Errorメッセージが届かなかった");
+        panic!("Error message did not arrive");
     }
 
     /// Sends Hello and returns Welcome's session token.
@@ -145,7 +148,7 @@ impl TestClient {
         .await;
         match self.recv().await {
             ServerMessage::Welcome { session_token, .. } => session_token,
-            other => panic!("Welcomeでないメッセージ: {other:?}"),
+            other => panic!("expected Welcome message, got {other:?}"),
         }
     }
 
@@ -158,7 +161,7 @@ impl TestClient {
         .await;
         match self.recv().await {
             ServerMessage::RoomState { code, .. } => code,
-            other => panic!("RoomStateでないメッセージ: {other:?}"),
+            other => panic!("expected RoomState message, got {other:?}"),
         }
     }
 
@@ -176,11 +179,11 @@ impl TestClient {
             ServerMessage::RoomState { code, rules, .. } => {
                 assert!(
                     rules.three_player,
-                    "三麻ルームの RoomState に three_player が立っていない"
+                    "three_player is not set in a three-player room's RoomState"
                 );
                 code
             }
-            other => panic!("RoomStateでないメッセージ: {other:?}"),
+            other => panic!("expected RoomState message, got {other:?}"),
         }
     }
 
@@ -199,7 +202,7 @@ impl TestClient {
             };
             match frame {
                 Message::Text(text) => {
-                    batch.push(ServerMessage::from_json(text.as_str()).expect("不正なJSON"));
+                    batch.push(ServerMessage::from_json(text.as_str()).expect("invalid JSON"));
                 }
                 Message::Ping(_) | Message::Pong(_) => continue,
                 _ => break,
@@ -264,7 +267,7 @@ impl TestClient {
                         // harmless for a tsumogiri bot.
                     }
                     ServerMessage::Error { code, message } => {
-                        panic!("予期しないエラー: {code:?} {message}");
+                        panic!("unexpected error: {code:?} {message}");
                     }
                     _ => {}
                 }
@@ -280,18 +283,18 @@ async fn test_full_game_with_two_humans() {
         let addr = start_server(fast_config()).await;
 
         let mut host = TestClient::connect(addr).await;
-        host.hello("ホスト").await;
+        host.hello("Host").await;
         let code = host.create_room().await;
 
         let mut guest = TestClient::connect(addr).await;
-        guest.hello("ゲスト").await;
+        guest.hello("Guest").await;
         guest
             .send(&ClientMessage::JoinRoom { code: code.clone() })
             .await;
 
         match guest.recv().await {
             ServerMessage::RoomState { your_seat, .. } => assert_eq!(your_seat, 1),
-            other => panic!("RoomStateでないメッセージ: {other:?}"),
+            other => panic!("expected RoomState message, got {other:?}"),
         }
         match host.recv().await {
             ServerMessage::RoomState { seats, .. } => {
@@ -300,7 +303,7 @@ async fn test_full_game_with_two_humans() {
                     mahjong_server::protocol::net::SeatInfo::Human { .. }
                 ));
             }
-            other => panic!("RoomStateでないメッセージ: {other:?}"),
+            other => panic!("expected RoomState message, got {other:?}"),
         }
 
         host.send(&ClientMessage::StartGame { cpu_configs: None })
@@ -316,7 +319,7 @@ async fn test_full_game_with_two_humans() {
         assert_scores_consistent(host_scores);
     })
     .await
-    .expect("テスト全体がタイムアウトした");
+    .expect("test timed out");
 }
 
 /// The auto-advance must reach GameOver even when nobody sends
@@ -327,7 +330,7 @@ async fn test_ready_timeout_auto_advances() {
         let addr = start_server(fast_config()).await;
 
         let mut host = TestClient::connect(addr).await;
-        host.hello("ホスト").await;
+        host.hello("Host").await;
         host.create_room().await;
         host.send(&ClientMessage::StartGame { cpu_configs: None })
             .await;
@@ -336,7 +339,7 @@ async fn test_ready_timeout_auto_advances() {
         assert_scores_consistent(scores);
     })
     .await
-    .expect("テスト全体がタイムアウトした");
+    .expect("test timed out");
 }
 
 /// The host's CPU configs must reach the seats.
@@ -348,7 +351,7 @@ async fn test_host_chosen_cpu_configs_apply() {
     tokio::time::timeout(Duration::from_secs(30), async {
         let addr = start_server(fast_config()).await;
         let mut host = TestClient::connect(addr).await;
-        host.hello("ホスト").await;
+        host.hello("Host").await;
         host.create_room().await;
 
         let specs = [
@@ -389,12 +392,12 @@ async fn test_host_chosen_cpu_configs_apply() {
                 .count();
             assert_eq!(
                 count, 1,
-                "指定したCPU構成 {spec:?} がCPU席にちょうど1つ存在するべき"
+                "exactly one CPU seat should have the requested configuration {spec:?}"
             );
         }
     })
     .await
-    .expect("テスト全体がタイムアウトした");
+    .expect("test timed out");
 }
 
 /// The host's SetCpuConfigs must reach everyone's RoomState (#245).
@@ -406,11 +409,11 @@ async fn test_set_cpu_configs_shared_in_lobby() {
     tokio::time::timeout(Duration::from_secs(30), async {
         let addr = start_server(fast_config()).await;
         let mut host = TestClient::connect(addr).await;
-        host.hello("ホスト").await;
+        host.hello("Host").await;
         let code = host.create_room().await;
 
         let mut guest = TestClient::connect(addr).await;
-        guest.hello("ゲスト").await;
+        guest.hello("Guest").await;
         guest
             .send(&ClientMessage::JoinRoom { code: code.clone() })
             .await;
@@ -419,10 +422,10 @@ async fn test_set_cpu_configs_shared_in_lobby() {
             ServerMessage::RoomState { cpu_configs, .. } => {
                 assert!(
                     cpu_configs.is_some(),
-                    "ロビーの RoomState はCPU設定を含むべき"
+                    "lobby RoomState should include the CPU configuration"
                 );
             }
-            other => panic!("RoomStateでないメッセージ: {other:?}"),
+            other => panic!("expected RoomState message, got {other:?}"),
         }
         host.recv().await;
 
@@ -460,12 +463,12 @@ async fn test_set_cpu_configs_shared_in_lobby() {
                     // them.
                     assert!(matches!(seats[2], SeatInfo::Empty));
                 }
-                other => panic!("RoomStateでないメッセージ: {other:?}"),
+                other => panic!("expected RoomState message, got {other:?}"),
             }
         }
     })
     .await
-    .expect("テスト全体がタイムアウトした");
+    .expect("test timed out");
 }
 
 /// A protocol-version mismatch errors with VersionMismatch.
@@ -477,7 +480,7 @@ async fn test_version_mismatch() {
         .send(&ClientMessage::Hello {
             protocol_version: PROTOCOL_VERSION + 1,
             session_token: None,
-            display_name: "古いクライアント".to_string(),
+            display_name: "Old Client".to_string(),
         })
         .await;
     assert_eq!(client.recv_error().await, ErrorCode::VersionMismatch);
@@ -499,7 +502,7 @@ async fn test_message_before_hello() {
 async fn test_join_unknown_room() {
     let addr = start_server(fast_config()).await;
     let mut client = TestClient::connect(addr).await;
-    client.hello("迷子").await;
+    client.hello("Lost Client").await;
     client
         .send(&ClientMessage::JoinRoom {
             code: "ZZZZZZ".to_string(),
@@ -514,25 +517,25 @@ async fn test_room_full() {
     let addr = start_server(fast_config()).await;
 
     let mut host = TestClient::connect(addr).await;
-    host.hello("ホスト").await;
+    host.hello("Host").await;
     let code = host.create_room().await;
 
     let mut guests = Vec::new();
     for i in 0..3 {
         let mut guest = TestClient::connect(addr).await;
-        guest.hello(&format!("ゲスト{i}")).await;
+        guest.hello(&format!("Guest {i}")).await;
         guest
             .send(&ClientMessage::JoinRoom { code: code.clone() })
             .await;
         match guest.recv().await {
             ServerMessage::RoomState { .. } => {}
-            other => panic!("RoomStateでないメッセージ: {other:?}"),
+            other => panic!("expected RoomState message, got {other:?}"),
         }
         guests.push(guest);
     }
 
     let mut fifth = TestClient::connect(addr).await;
-    fifth.hello("5人目").await;
+    fifth.hello("Fifth Player").await;
     fifth
         .send(&ClientMessage::JoinRoom { code: code.clone() })
         .await;
@@ -545,25 +548,25 @@ async fn test_sanma_room_full_at_three() {
     let addr = start_server(fast_config()).await;
 
     let mut host = TestClient::connect(addr).await;
-    host.hello("ホスト").await;
+    host.hello("Host").await;
     let code = host.create_sanma_room().await;
 
     let mut guests = Vec::new();
     for i in 0..2 {
         let mut guest = TestClient::connect(addr).await;
-        guest.hello(&format!("ゲスト{i}")).await;
+        guest.hello(&format!("Guest {i}")).await;
         guest
             .send(&ClientMessage::JoinRoom { code: code.clone() })
             .await;
         match guest.recv().await {
             ServerMessage::RoomState { your_seat, .. } => assert_eq!(your_seat, i + 1),
-            other => panic!("RoomStateでないメッセージ: {other:?}"),
+            other => panic!("expected RoomState message, got {other:?}"),
         }
         guests.push(guest);
     }
 
     let mut fourth = TestClient::connect(addr).await;
-    fourth.hello("4人目").await;
+    fourth.hello("Fourth Player").await;
     fourth
         .send(&ClientMessage::JoinRoom { code: code.clone() })
         .await;
@@ -578,21 +581,21 @@ async fn test_sanma_full_game_with_two_humans() {
         let addr = start_server(fast_config()).await;
 
         let mut host = TestClient::connect(addr).await;
-        host.hello("ホスト").await;
+        host.hello("Host").await;
         let code = host.create_sanma_room().await;
 
         let mut guest = TestClient::connect(addr).await;
-        guest.hello("ゲスト").await;
+        guest.hello("Guest").await;
         guest
             .send(&ClientMessage::JoinRoom { code: code.clone() })
             .await;
         match guest.recv().await {
             ServerMessage::RoomState { your_seat, .. } => assert_eq!(your_seat, 1),
-            other => panic!("RoomStateでないメッセージ: {other:?}"),
+            other => panic!("expected RoomState message, got {other:?}"),
         }
         match host.recv().await {
             ServerMessage::RoomState { .. } => {}
-            other => panic!("RoomStateでないメッセージ: {other:?}"),
+            other => panic!("expected RoomState message, got {other:?}"),
         }
 
         host.send(&ClientMessage::StartGame { cpu_configs: None })
@@ -605,21 +608,24 @@ async fn test_sanma_full_game_with_two_humans() {
 
         assert_eq!(host_scores, guest_scores);
         // The dummy seat's score stays 0.
-        assert_eq!(host_scores[3], 0, "三麻でシート3に点数が入っている");
+        assert_eq!(
+            host_scores[3], 0,
+            "seat 3 has points in a three-player game"
+        );
         // The total is at most 35000 x 3, short only by whole deposits.
         let sum: i32 = host_scores.iter().sum();
         assert!(
             sum <= 35000 * 3,
-            "総和が初期点数を超えている: {host_scores:?}"
+            "score total exceeds the initial points: {host_scores:?}"
         );
         assert_eq!(
             (35000 * 3 - sum) % 1000,
             0,
-            "総和の差が供託単位でない: {host_scores:?}"
+            "score-total difference is not a multiple of the deposit value: {host_scores:?}"
         );
     })
     .await
-    .expect("テスト全体がタイムアウトした");
+    .expect("test timed out");
 }
 
 /// StartGame from a non-host errors with NotHost.
@@ -628,11 +634,11 @@ async fn test_non_host_cannot_start() {
     let addr = start_server(fast_config()).await;
 
     let mut host = TestClient::connect(addr).await;
-    host.hello("ホスト").await;
+    host.hello("Host").await;
     let code = host.create_room().await;
 
     let mut guest = TestClient::connect(addr).await;
-    guest.hello("ゲスト").await;
+    guest.hello("Guest").await;
     guest
         .send(&ClientMessage::JoinRoom { code: code.clone() })
         .await;
@@ -648,11 +654,11 @@ async fn test_out_of_turn_action_rejected() {
     let addr = start_server(fast_config()).await;
 
     let mut host = TestClient::connect(addr).await;
-    host.hello("ホスト").await;
+    host.hello("Host").await;
     let code = host.create_room().await;
 
     let mut guest = TestClient::connect(addr).await;
-    guest.hello("ゲスト").await;
+    guest.hello("Guest").await;
     guest
         .send(&ClientMessage::JoinRoom { code: code.clone() })
         .await;
@@ -696,13 +702,13 @@ async fn test_join_after_start_rejected() {
     let addr = start_server(fast_config()).await;
 
     let mut host = TestClient::connect(addr).await;
-    host.hello("ホスト").await;
+    host.hello("Host").await;
     let code = host.create_room().await;
     host.send(&ClientMessage::StartGame { cpu_configs: None })
         .await;
 
     let mut late = TestClient::connect(addr).await;
-    late.hello("遅刻").await;
+    late.hello("Late Player").await;
     late.send(&ClientMessage::JoinRoom { code: code.clone() })
         .await;
     assert_eq!(late.recv_error().await, ErrorCode::GameInProgress);
@@ -718,13 +724,13 @@ async fn test_lobby_room_expires() {
     let addr = start_server(config).await;
 
     let mut host = TestClient::connect(addr).await;
-    host.hello("ホスト").await;
+    host.hello("Host").await;
     let code = host.create_room().await;
 
     tokio::time::sleep(Duration::from_millis(600)).await;
 
     let mut guest = TestClient::connect(addr).await;
-    guest.hello("ゲスト").await;
+    guest.hello("Guest").await;
     guest
         .send(&ClientMessage::JoinRoom { code: code.clone() })
         .await;
@@ -739,11 +745,11 @@ async fn test_disconnect_mid_game_cpu_takes_over() {
         let addr = start_server(fast_config()).await;
 
         let mut host = TestClient::connect(addr).await;
-        host.hello("ホスト").await;
+        host.hello("Host").await;
         let code = host.create_room().await;
 
         let mut guest = TestClient::connect(addr).await;
-        guest.hello("ゲスト").await;
+        guest.hello("Guest").await;
         guest
             .send(&ClientMessage::JoinRoom { code: code.clone() })
             .await;
@@ -765,7 +771,7 @@ async fn test_disconnect_mid_game_cpu_takes_over() {
         assert_scores_consistent(scores);
     })
     .await
-    .expect("テスト全体がタイムアウトした");
+    .expect("test timed out");
 }
 
 /// The game must finish despite an AFK player, via the turn timeout.
@@ -779,7 +785,7 @@ async fn test_action_timeout_auto_acts() {
         let addr = start_server(config).await;
 
         let mut host = TestClient::connect(addr).await;
-        host.hello("AFKホスト").await;
+        host.hello("AFK Host").await;
         host.create_room().await;
         host.send(&ClientMessage::StartGame { cpu_configs: None })
             .await;
@@ -800,10 +806,10 @@ async fn test_action_timeout_auto_acts() {
                 _ => {}
             }
         }
-        assert!(saw_turn_timer, "TurnTimer が一度も届かなかった");
+        assert!(saw_turn_timer, "TurnTimer never arrived");
     })
     .await
-    .expect("テスト全体がタイムアウトした");
+    .expect("test timed out");
 }
 
 /// Spamming invalid actions must not extend the turn timer.
@@ -821,7 +827,7 @@ async fn test_action_timeout_not_extended_by_invalid_actions() {
         let addr = start_server(config).await;
 
         let mut host = TestClient::connect(addr).await;
-        host.hello("ホスト").await;
+        host.hello("Host").await;
         host.create_room().await;
         host.send(&ClientMessage::StartGame { cpu_configs: None })
             .await;
@@ -838,7 +844,7 @@ async fn test_action_timeout_not_extended_by_invalid_actions() {
         loop {
             assert!(
                 start.elapsed() < Duration::from_secs(5),
-                "制限時間が延長され続けてタイムアウトしなかった"
+                "the deadline kept being extended and never timed out"
             );
             host.send(&ClientMessage::Action(ClientAction::Ron)).await;
             let deadline = tokio::time::sleep(Duration::from_millis(100));
@@ -861,7 +867,7 @@ async fn test_action_timeout_not_extended_by_invalid_actions() {
         }
     })
     .await
-    .expect("テスト全体がタイムアウトした");
+    .expect("test timed out");
 }
 
 /// Too many join attempts from one IP get RateLimited.
@@ -869,7 +875,7 @@ async fn test_action_timeout_not_extended_by_invalid_actions() {
 async fn test_join_rate_limit() {
     let addr = start_server(fast_config()).await;
     let mut client = TestClient::connect(addr).await;
-    client.hello("スパマー").await;
+    client.hello("Spammer").await;
 
     // Up to the cap (10), a missing room answers RoomNotFound.
     for _ in 0..10 {
@@ -908,11 +914,11 @@ async fn test_reconnect_resyncs_and_resumes() {
         let addr = start_server(config).await;
 
         let mut host = TestClient::connect(addr).await;
-        host.hello("ホスト").await;
+        host.hello("Host").await;
         let code = host.create_room().await;
 
         let mut guest = TestClient::connect(addr).await;
-        let guest_token = guest.hello("ゲスト").await;
+        let guest_token = guest.hello("Guest").await;
         guest
             .send(&ClientMessage::JoinRoom { code: code.clone() })
             .await;
@@ -937,7 +943,7 @@ async fn test_reconnect_resyncs_and_resumes() {
             tokio::time::sleep(Duration::from_millis(300)).await;
 
             let mut rejoin = TestClient::connect(addr).await;
-            rejoin.hello_with_token("ゲスト", Some(guest_token)).await;
+            rejoin.hello_with_token("Guest", Some(guest_token)).await;
             rejoin
                 .send(&ClientMessage::JoinRoom { code: code.clone() })
                 .await;
@@ -948,7 +954,10 @@ async fn test_reconnect_resyncs_and_resumes() {
             for _ in 0..100 {
                 match rejoin.recv().await {
                     ServerMessage::RoomState { your_seat, .. } => {
-                        assert_eq!(your_seat, 1, "再入室の座席が元と違う");
+                        assert_eq!(
+                            your_seat, 1,
+                            "the rejoined client received a different seat"
+                        );
                         saw_room_state = true;
                     }
                     ServerMessage::Resync { events } => {
@@ -958,8 +967,8 @@ async fn test_reconnect_resyncs_and_resumes() {
                     _ => {}
                 }
             }
-            assert!(saw_room_state, "再入室で RoomState が届かなかった");
-            let events = resync_events.expect("Resync が届かなかった");
+            assert!(saw_room_state, "RoomState did not arrive after rejoining");
+            let events = resync_events.expect("Resync did not arrive");
             // The replay starts at the current hand's GameStarted;
             // histories reset per hand.
             assert_eq!(
@@ -968,7 +977,7 @@ async fn test_reconnect_resyncs_and_resumes() {
                     .filter(|e| matches!(e, ServerEvent::GameStarted { .. }))
                     .count(),
                 1,
-                "Resync に GameStarted がちょうど1つ含まれるべき"
+                "Resync should contain exactly one GameStarted event"
             );
 
             // Verification done, disconnect again without acting; the
@@ -980,7 +989,7 @@ async fn test_reconnect_resyncs_and_resumes() {
         assert_scores_consistent(scores);
     })
     .await
-    .expect("テスト全体がタイムアウトした");
+    .expect("test timed out");
 }
 
 /// A stale disconnect notice from an old connection must not disconnect
@@ -992,11 +1001,11 @@ async fn test_reconnect_keeps_seat_connected() {
         let addr = start_server(fast_config()).await;
 
         let mut host = TestClient::connect(addr).await;
-        host.hello("ホスト").await;
+        host.hello("Host").await;
         let code = host.create_room().await;
 
         let mut guest = TestClient::connect(addr).await;
-        let guest_token = guest.hello("ゲスト").await;
+        let guest_token = guest.hello("Guest").await;
         guest
             .send(&ClientMessage::JoinRoom { code: code.clone() })
             .await;
@@ -1012,7 +1021,7 @@ async fn test_reconnect_keeps_seat_connected() {
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let mut rejoin = TestClient::connect(addr).await;
-        rejoin.hello_with_token("ゲスト", Some(guest_token)).await;
+        rejoin.hello_with_token("Guest", Some(guest_token)).await;
         rejoin
             .send(&ClientMessage::JoinRoom { code: code.clone() })
             .await;
@@ -1035,8 +1044,11 @@ async fn test_reconnect_keeps_seat_connected() {
                 break;
             }
         }
-        assert!(saw_reconnect, "ホストに再接続通知が届かなかった");
+        assert!(
+            saw_reconnect,
+            "the host did not receive a reconnection notification"
+        );
     })
     .await
-    .expect("テスト全体がタイムアウトした");
+    .expect("test timed out");
 }

--- a/crates/mahjong-net-server/tests/multi_machine.rs
+++ b/crates/mahjong-net-server/tests/multi_machine.rs
@@ -88,7 +88,7 @@ impl TestClient {
     }
 
     async fn connect_with(request: tungstenite::handshake::client::Request) -> Self {
-        let (ws, _) = connect_async(request).await.expect("接続に失敗した");
+        let (ws, _) = connect_async(request).await.expect("connection failed");
         TestClient { ws }
     }
 
@@ -101,15 +101,15 @@ impl TestClient {
         loop {
             let frame = tokio::time::timeout(std::time::Duration::from_secs(30), self.ws.next())
                 .await
-                .expect("受信がタイムアウトした")
-                .expect("接続が閉じられた")
-                .expect("WebSocketエラー");
+                .expect("receive timed out")
+                .expect("connection closed")
+                .expect("WebSocket error");
             match frame {
                 Message::Text(text) => {
-                    return ServerMessage::from_json(text.as_str()).expect("不正なJSON");
+                    return ServerMessage::from_json(text.as_str()).expect("invalid JSON");
                 }
                 Message::Ping(_) | Message::Pong(_) => continue,
-                other => panic!("予期しないフレーム: {other:?}"),
+                other => panic!("unexpected frame: {other:?}"),
             }
         }
     }
@@ -123,7 +123,7 @@ impl TestClient {
         .await;
         match self.recv().await {
             ServerMessage::Welcome { .. } => {}
-            other => panic!("Welcomeでないメッセージ: {other:?}"),
+            other => panic!("expected Welcome message, got {other:?}"),
         }
     }
 
@@ -135,7 +135,7 @@ impl TestClient {
         .await;
         match self.recv().await {
             ServerMessage::RoomState { code, .. } => code,
-            other => panic!("RoomStateでないメッセージ: {other:?}"),
+            other => panic!("expected RoomState message, got {other:?}"),
         }
     }
 
@@ -155,7 +155,7 @@ async fn test_join_foreign_room_returns_fly_replay() {
     let (machine_a, machine_b) = start_two_machines().await;
 
     let mut host = TestClient::connect(&format!("ws://{}/ws", machine_a.public)).await;
-    host.hello("ホスト").await;
+    host.hello("Host").await;
     let code = host.create_room().await;
 
     // A ?room=CODE connection to machine B returns a fly-replay to
@@ -168,13 +168,13 @@ async fn test_join_foreign_room_returns_fly_replay() {
             let replay = response
                 .headers()
                 .get("fly-replay")
-                .expect("fly-replay ヘッダが無い")
+                .expect("fly-replay header is missing")
                 .to_str()
                 .unwrap();
             assert_eq!(replay, "instance=machinea");
         }
-        Ok(_) => panic!("アップグレードされてしまった（fly-replay が返るべき）"),
-        Err(other) => panic!("予期しないエラー: {other:?}"),
+        Ok(_) => panic!("connection was upgraded instead of returning fly-replay"),
+        Err(other) => panic!("unexpected error: {other:?}"),
     }
 }
 
@@ -185,15 +185,15 @@ async fn test_join_local_room_with_query_param() {
     let (machine_a, _machine_b) = start_two_machines().await;
 
     let mut host = TestClient::connect(&format!("ws://{}/ws", machine_a.public)).await;
-    host.hello("ホスト").await;
+    host.hello("Host").await;
     let code = host.create_room().await;
 
     let mut guest =
         TestClient::connect(&format!("ws://{}/ws?room={}", machine_a.public, code)).await;
-    guest.hello("ゲスト").await;
+    guest.hello("Guest").await;
     match guest.join_room(&code).await {
         ServerMessage::RoomState { your_seat, .. } => assert_eq!(your_seat, 1),
-        other => panic!("RoomStateでないメッセージ: {other:?}"),
+        other => panic!("expected RoomState message, got {other:?}"),
     }
 }
 
@@ -207,7 +207,7 @@ async fn test_replayed_request_is_not_replayed_again() {
     let (machine_a, machine_b) = start_two_machines().await;
 
     let mut host = TestClient::connect(&format!("ws://{}/ws", machine_a.public)).await;
-    host.hello("ホスト").await;
+    host.hello("Host").await;
     let code = host.create_room().await;
 
     let with_replay_src = |addr: SocketAddr| {
@@ -223,19 +223,19 @@ async fn test_replayed_request_is_not_replayed_again() {
 
     // Owning machine A: the replayed request joins normally.
     let mut guest = TestClient::connect_with(with_replay_src(machine_a.public)).await;
-    guest.hello("ゲスト").await;
+    guest.hello("Guest").await;
     match guest.join_room(&code).await {
         ServerMessage::RoomState { your_seat, .. } => assert_eq!(your_seat, 1),
-        other => panic!("RoomStateでないメッセージ: {other:?}"),
+        other => panic!("expected RoomState message, got {other:?}"),
     }
 
     // Non-owning machine B upgrades without re-forwarding;
     // JoinRoom yields RoomNotFound.
     let mut lost = TestClient::connect_with(with_replay_src(machine_b.public)).await;
-    lost.hello("迷子").await;
+    lost.hello("Lost Client").await;
     match lost.join_room(&code).await {
         ServerMessage::Error { code, .. } => assert_eq!(code, ErrorCode::RoomNotFound),
-        other => panic!("Errorでないメッセージ: {other:?}"),
+        other => panic!("expected Error message, got {other:?}"),
     }
 }
 
@@ -247,7 +247,7 @@ async fn test_unknown_or_invalid_code_upgrades_normally() {
     for room in ["ZZZZZZ", "abc", "%2F%2F", ""] {
         let mut client =
             TestClient::connect(&format!("ws://{}/ws?room={}", machine_a.public, room)).await;
-        client.hello("探検者").await;
+        client.hello("Explorer").await;
     }
 }
 
@@ -257,7 +257,7 @@ async fn test_peer_lookup_finds_room_owner() {
     let (machine_a, _machine_b) = start_two_machines().await;
 
     let mut host = TestClient::connect(&format!("ws://{}/ws", machine_a.public)).await;
-    host.hello("ホスト").await;
+    host.hello("Host").await;
     let code = host.create_room().await;
 
     // Query machine A's internal listener from a third party's
@@ -301,7 +301,7 @@ async fn test_create_room_completes_with_lying_peer() {
     let machine = serve_machine(state, internal).await;
 
     let mut host = TestClient::connect(&format!("ws://{}/ws", machine.public)).await;
-    host.hello("ホスト").await;
+    host.hello("Host").await;
     // Past the collision-check cap, local uniqueness decides and
     // creation completes.
     let code = host.create_room().await;

--- a/crates/mahjong-server/src/cpu/client_tests.rs
+++ b/crates/mahjong-server/src/cpu/client_tests.rs
@@ -65,7 +65,7 @@ fn test_should_attack_counts_melds_when_tenpai() {
 
     assert!(
         client.should_attack(),
-        "副露込みで聴牌している手は終盤でも攻撃を続けるはず"
+        "a hand in tenpai with melds should keep attacking late in the hand"
     );
 }
 
@@ -204,7 +204,10 @@ fn test_resync_hand_updated_does_not_trigger_discard() {
 
     // A resync HandUpdated (no own call): no discard.
     let action = client.handle_event(&ServerEvent::HandUpdated { hand: hand.clone() });
-    assert_eq!(action, None, "再同期の HandUpdated に打牌を返している");
+    assert_eq!(
+        action, None,
+        "the CPU returned a discard for a resynchronization HandUpdated event"
+    );
 
     // A HandUpdated following our pon still discards.
     client.handle_event(&ServerEvent::PlayerCalled {
@@ -216,7 +219,7 @@ fn test_resync_hand_updated_does_not_trigger_discard() {
     let action = client.handle_event(&ServerEvent::HandUpdated { hand });
     assert!(
         matches!(action, Some(ClientAction::Discard { .. })),
-        "ポン直後の HandUpdated で打牌していない"
+        "the CPU did not discard on HandUpdated immediately after a pon"
     );
 }
 
@@ -598,7 +601,11 @@ fn test_discards_isolated_guest_wind_before_terminal() {
     let action = client.handle_event(&draw_event(Tile::S9));
 
     let tile = discarded_tile(&action).expect("expected a hand discard");
-    assert_eq!(tile.get(), Tile::Z3, "客風牌を最初に切るべき");
+    assert_eq!(
+        tile.get(),
+        Tile::Z3,
+        "the guest wind should be discarded first"
+    );
 }
 
 #[test]
@@ -631,7 +638,7 @@ fn test_discard_prefers_breaking_penchan_over_ryanmen() {
     let tile = discarded_tile(&action).expect("expected a hand discard");
     assert!(
         tile.get() == Tile::P1 || tile.get() == Tile::P2,
-        "両面(S6S7)ではなく辺張(P1P2)を整理すべき, got {tile:?}"
+        "the edge wait (P1P2) should be discarded before the two-sided wait (S6S7), got {tile:?}"
     );
 }
 
@@ -674,7 +681,7 @@ fn test_dora_float_kept_over_plain_float() {
     let action = client.handle_event(&draw_event(Tile::S9));
     assert!(
         matches!(action, Some(ClientAction::Discard { tile: None })),
-        "ドラ(P9)を残して S9 をツモ切りすべき, got {action:?}"
+        "P9 dora should be kept and the drawn S9 discarded, got {action:?}"
     );
 
     // Control: with heuristics off P9 goes (no dora protection;
@@ -697,7 +704,7 @@ fn test_dora_float_kept_over_plain_float() {
     let action = client.handle_event(&draw_event(Tile::S9));
     assert!(
         matches!(action, Some(ClientAction::Discard { tile: Some(t) }) if t.get() == Tile::P9),
-        "定石無効時はドラ保護が効かない, got {action:?}"
+        "dora protection should be disabled when heuristics are disabled, got {action:?}"
     );
 }
 
@@ -741,7 +748,11 @@ fn test_weak_folds_with_genbutsu_against_riichi() {
     let action = client.handle_event(&draw_event(Tile::M5));
 
     let tile = discarded_tile(&action).expect("expected a hand discard");
-    assert_eq!(tile.get(), Tile::Z3, "現物(Z3)を最優先で切るべき");
+    assert_eq!(
+        tile.get(),
+        Tile::Z3,
+        "the guaranteed-safe Z3 should be discarded first"
+    );
 }
 
 #[test]
@@ -783,7 +794,11 @@ fn test_defense_prefers_suji_over_dangerous_tiles() {
     let action = client.handle_event(&draw_event(Tile::P5));
 
     let tile = discarded_tile(&action).expect("expected a hand discard");
-    assert_eq!(tile.get(), Tile::M7, "筋牌(M7)を選ぶべき, got {tile:?}");
+    assert_eq!(
+        tile.get(),
+        Tile::M7,
+        "the suji tile M7 should be selected, got {tile:?}"
+    );
 }
 
 #[test]
@@ -829,7 +844,7 @@ fn test_riichi_declared_with_no_yaku_tenpai() {
     let action = client.handle_event(&draw);
     assert!(
         matches!(action, Some(ClientAction::Riichi { .. })),
-        "役なし聴牌はリーチすべき, got {action:?}"
+        "a no-yaku tenpai hand should declare riichi, got {action:?}"
     );
 
     // Heuristics off: legacy stays quiet against two riichi.
@@ -888,7 +903,7 @@ fn test_damaten_with_confirmed_mangan() {
     let action = client.handle_event(&draw);
     assert!(
         matches!(action, Some(ClientAction::Discard { .. })),
-        "満貫確定はダマにすべき, got {action:?}"
+        "a guaranteed mangan hand should remain in damaten, got {action:?}"
     );
 
     // Heuristics off: the aggressiveness judgement declares.
@@ -940,7 +955,11 @@ fn test_cheap_bad_shape_tenpai_folds_against_riichi() {
     riichi_with_genbutsu(&mut client);
     let action = client.handle_event(&draw_event(Tile::Z4));
     let tile = discarded_tile(&action).expect("expected a hand discard");
-    assert_eq!(tile.get(), Tile::S2, "愚形安手聴牌は現物から降りるべき");
+    assert_eq!(
+        tile.get(),
+        Tile::S2,
+        "a cheap bad-wait tenpai hand should fold with a guaranteed-safe tile"
+    );
 
     // Heuristics off: keep tenpai and push (tsumogiri).
     let config = CpuConfig::new(CpuLevel::Normal, CpuPersonality::Balanced).without_heuristics();
@@ -950,7 +969,7 @@ fn test_cheap_bad_shape_tenpai_folds_against_riichi() {
     let action = client.handle_event(&draw_event(Tile::Z4));
     assert!(
         matches!(action, Some(ClientAction::Discard { tile: None })),
-        "定石無効時は聴牌維持（ツモ切り）, got {action:?}"
+        "with heuristics disabled, tenpai should be maintained by discarding the drawn tile, got {action:?}"
     );
 }
 
@@ -1014,7 +1033,7 @@ fn test_folds_against_three_meld_opponent() {
     assert_eq!(
         tile.get(),
         Tile::Z3,
-        "3副露の他家に対して現物(Z3)からベタオリすべき"
+        "the CPU should fully fold against an opponent with three melds, starting with safe Z3"
     );
 
     // Heuristics off: melds are not a threat; normal discard.
@@ -1030,7 +1049,11 @@ fn test_folds_against_three_meld_opponent() {
     });
     let action = client.handle_event(&draw_event(Tile::M5));
     if let Some(t) = discarded_tile(&action) {
-        assert_ne!(t.get(), Tile::Z3, "定石無効時は対子の現物を崩さない");
+        assert_ne!(
+            t.get(),
+            Tile::Z3,
+            "with heuristics disabled, a safe pair should not be broken"
+        );
     }
 }
 
@@ -1075,7 +1098,7 @@ fn test_six_block_hand_dismantles_dead_kanchan_first() {
     let tile = discarded_tile(&action).expect("expected a hand discard");
     assert!(
         tile.get() == Tile::S2 || tile.get() == Tile::S4,
-        "死に嵌張(S2S4)を整理すべき, got {tile:?}"
+        "the dead closed wait (S2S4) should be discarded, got {tile:?}"
     );
 }
 
@@ -1151,7 +1174,7 @@ fn test_kokushi_hand_keeps_orphans() {
     if let Some(t) = tile {
         assert!(
             !t.is_1_9_honour(),
-            "国士無双ルートでは么九牌を切らない, got {t:?}"
+            "the Thirteen Orphans route should not discard a terminal or honour, got {t:?}"
         );
     }
 }
@@ -1797,7 +1820,7 @@ fn test_shuffle_cpu_configs_preserves_configs() {
             configs
                 .iter()
                 .any(|s| s.level == c.level && s.personality == c.personality),
-            "シャッフルで設定が失われた"
+            "the settings were lost during shuffling"
         );
     }
 }

--- a/crates/mahjong-server/src/cpu/defense.rs
+++ b/crates/mahjong-server/src/cpu/defense.rs
@@ -675,7 +675,10 @@ mod tests {
         state.all_discards[2] = vec![Tile::new(Tile::Z7); 2];
         state.my_hand = vec![Tile::new(Tile::Z7); 2]; // publicly only 2 visible
         let threat = assess_threat(&state, 1, &test_config()).expect("kokushi signs");
-        assert!(threat.kokushi_alert, "自分の手牌を見切り判定に含めない");
+        assert!(
+            threat.kokushi_alert,
+            "the CPU's own hand should not count toward the tile-visibility check"
+        );
 
         // Fewer than five discards is too early to judge.
         let mut state = CpuGameState::new();
@@ -713,11 +716,17 @@ mod tests {
         let honour = evaluate_safety(Tile::new(Tile::Z1), &state, &config);
         let middle = evaluate_safety(Tile::new(Tile::S2), &state, &config);
 
-        assert!(terminal <= 0.1, "生牌の么九牌は最危険: {terminal}");
-        assert!(honour <= 0.1, "生牌の字牌は最危険: {honour}");
+        assert!(
+            terminal <= 0.1,
+            "an unseen terminal should be in the highest-risk tier: {terminal}"
+        );
+        assert!(
+            honour <= 0.1,
+            "an unseen honour should be in the highest-risk tier: {honour}"
+        );
         assert!(
             middle > terminal && middle > honour,
-            "中張牌は么九牌より安全: {middle}"
+            "a simple tile should be safer than a terminal or honour: {middle}"
         );
 
         let genbutsu = evaluate_safety(Tile::new(Tile::M5), &state, &config);
@@ -754,9 +763,12 @@ mod tests {
 
         assert!(
             in_suit < off_suit,
-            "染め色は他色より危険: {in_suit} vs {off_suit}"
+            "the flush suit should be riskier than an off-suit tile: {in_suit} vs {off_suit}"
         );
-        assert!(honour < 1.0, "染め手相手の字牌も警戒する");
+        assert!(
+            honour < 1.0,
+            "honours should also be treated cautiously against a flush hand"
+        );
     }
 
     #[test]
@@ -790,7 +802,7 @@ mod tests {
         let guest = evaluate_safety(Tile::new(Tile::Z3), &state, &config);
         assert!(
             yakuhai < guest,
-            "生牌役牌({yakuhai}) < 客風({guest}) のはず"
+            "an unseen value honour ({yakuhai}) should be riskier than a guest wind ({guest})"
         );
 
         // The weak level keeps the visibility-only estimate.

--- a/crates/mahjong-server/src/cpu/evaluator.rs
+++ b/crates/mahjong-server/src/cpu/evaluator.rs
@@ -304,10 +304,10 @@ mod tests {
         let z7 = candidates
             .iter()
             .find(|c| c.tile.get() == Tile::Z7)
-            .expect("7z は打牌候補にあるはず");
+            .expect("7z should be among the discard candidates");
         assert!(
             z7.shanten.is_ready(),
-            "副露を含めれば 7z 切りで聴牌のはず（shanten = {}）",
+            "discarding 7z should leave the hand in tenpai when melds are included (shanten = {})",
             z7.shanten
         );
     }

--- a/crates/mahjong-server/src/cpu/heuristics_tests.rs
+++ b/crates/mahjong-server/src/cpu/heuristics_tests.rs
@@ -137,12 +137,16 @@ fn test_isolated_tile_bonus_ordering() {
 
     let bonus = |t: u32| isolated_tile_bonus(&ctx, &make_candidate(t));
 
-    assert!(bonus(Tile::Z3) > bonus(Tile::M1), "客風 > 1/9");
-    assert!(bonus(Tile::M1) > bonus(Tile::Z5), "1/9 > 役牌");
-    assert!(bonus(Tile::Z5) > bonus(Tile::S8), "役牌 > 2/8");
-    assert!(bonus(Tile::S8) > bonus(Tile::M5), "2/8 > 中張");
-    assert_eq!(bonus(Tile::M5), 0.0, "孤立中張牌は雑に切らない");
-    assert_eq!(bonus(Tile::P7), 0.0, "対子は孤立牌ではない");
+    assert!(bonus(Tile::Z3) > bonus(Tile::M1), "guest wind > terminal");
+    assert!(bonus(Tile::M1) > bonus(Tile::Z5), "terminal > value honour");
+    assert!(bonus(Tile::Z5) > bonus(Tile::S8), "value honour > 2 or 8");
+    assert!(bonus(Tile::S8) > bonus(Tile::M5), "2 or 8 > middle tile");
+    assert_eq!(
+        bonus(Tile::M5),
+        0.0,
+        "an isolated middle tile should not be discarded indiscriminately"
+    );
+    assert_eq!(bonus(Tile::P7), 0.0, "a pair is not an isolated tile");
 }
 
 #[test]
@@ -180,12 +184,27 @@ fn test_shape_protection_bonus() {
 
     let bonus = |t: u32| shape_protection_bonus(&ctx, &make_candidate(t));
 
-    assert!(bonus(Tile::M2) < 0.0, "両面の牌は守る");
-    assert!(bonus(Tile::M3) < 0.0, "両面の牌は守る");
-    assert!(bonus(Tile::P1) > 0.0, "辺張は整理しやすい");
-    assert!(bonus(Tile::S3) > 0.0, "嵌張は整理しやすい");
-    assert!(bonus(Tile::S5) > 0.0, "嵌張は整理しやすい");
-    assert_eq!(bonus(Tile::S8), 0.0, "対子は対象外");
+    assert!(
+        bonus(Tile::M2) < 0.0,
+        "tiles in a two-sided shape should be protected"
+    );
+    assert!(
+        bonus(Tile::M3) < 0.0,
+        "tiles in a two-sided shape should be protected"
+    );
+    assert!(
+        bonus(Tile::P1) > 0.0,
+        "an edge-wait shape should be easier to discard"
+    );
+    assert!(
+        bonus(Tile::S3) > 0.0,
+        "a closed-wait shape should be easier to discard"
+    );
+    assert!(
+        bonus(Tile::S5) > 0.0,
+        "a closed-wait shape should be easier to discard"
+    );
+    assert_eq!(bonus(Tile::S8), 0.0, "pairs should be excluded");
 }
 
 #[test]
@@ -482,8 +501,8 @@ fn test_excess_pair_bonus() {
     let m5 = excess_pair_bonus(&ctx, &make_candidate(Tile::M5));
     let m9 = excess_pair_bonus(&ctx, &make_candidate(Tile::M9));
     let z2 = excess_pair_bonus(&ctx, &make_candidate(Tile::Z2));
-    assert!(m5 > m9, "中張牌対子からほぐす");
-    assert!(m9 > z2, "字牌対子は残す");
+    assert!(m5 > m9, "a simple-tile pair should be broken first");
+    assert!(m9 > z2, "an honour pair should be retained");
     assert_eq!(z2, 0.0);
 
     // Non-pair tiles are exempt.
@@ -632,7 +651,10 @@ fn test_is_stiff_pair() {
     assert!(is_stiff_pair(&counts, Tile::Z1));
     assert!(is_stiff_pair(&counts, Tile::M9));
     assert!(is_stiff_pair(&counts, Tile::P5));
-    assert!(!is_stiff_pair(&counts, Tile::S5), "S6が隣にあるので伸びる");
+    assert!(
+        !is_stiff_pair(&counts, Tile::S5),
+        "the adjacent S6 gives the pair room to develop"
+    );
 }
 
 #[test]
@@ -666,7 +688,7 @@ fn test_route_lock_penalizes_off_route_discards() {
     let cut_float = route_lock_bonus(&ctx, &make_candidate(Tile::M1));
     assert!(
         break_taatsu < cut_float,
-        "ターツ壊し({break_taatsu}) < 浮き牌切り({cut_float}) のはず"
+        "breaking a taatsu ({break_taatsu}) should score below discarding a floating tile ({cut_float})"
     );
     assert_eq!(cut_float, 0.0);
 }
@@ -706,7 +728,7 @@ fn test_route_lock_follows_seven_pairs_route() {
     let cut_float = route_lock_bonus(&ctx, &make_candidate(Tile::M2));
     assert!(
         break_pair < cut_float,
-        "対子壊し({break_pair}) < 浮き牌切り({cut_float}) のはず"
+        "breaking a pair ({break_pair}) should score below discarding a floating tile ({cut_float})"
     );
     assert_eq!(cut_float, 0.0);
 }

--- a/crates/mahjong-server/src/cpu/state.rs
+++ b/crates/mahjong-server/src/cpu/state.rs
@@ -1101,7 +1101,7 @@ mod tests {
         assert_eq!(
             state.all_discards[0].len(),
             1,
-            "守備評価用の捨て牌は保持する"
+            "discards used for defensive evaluation should be retained"
         );
     }
 

--- a/crates/mahjong-server/src/driver.rs
+++ b/crates/mahjong-server/src/driver.rs
@@ -646,7 +646,7 @@ mod tests {
             seen.insert(dealer);
         }
         // Odds of one dealer in 64 runs are (1/4)^63: effectively zero.
-        assert!(seen.len() > 1, "起家がランダム化されていない");
+        assert!(seen.len() > 1, "starting dealer was not randomized");
     }
 
     /// Seeded starts keep the dealer at seat 0 for reproducibility.
@@ -667,7 +667,7 @@ mod tests {
             events
                 .iter()
                 .any(|e| matches!(e, ServerEvent::GameStarted { .. })),
-            "GameStartedイベントが人間座席に届いていない"
+            "GameStarted event was not delivered to the human seat"
         );
 
         // Pure CPU seats never buffer.
@@ -747,10 +747,10 @@ mod tests {
             }
         }
 
-        assert!(driver.is_round_over(), "局が終了しなかった");
+        assert!(driver.is_round_over(), "round did not end");
 
         let round = driver.table().current_round().unwrap();
-        assert!(round.result.is_some(), "局結果が設定されていない");
+        assert!(round.result.is_some(), "round result was not set");
     }
 
     /// A shadow CPU receives events but never acts.
@@ -775,7 +775,7 @@ mod tests {
             events
                 .iter()
                 .any(|e| matches!(e, ServerEvent::TileDrawn { .. })),
-            "シャドーCPU座席にTileDrawnが届いていない"
+            "TileDrawn event was not delivered to the shadow CPU seat"
         );
     }
 
@@ -798,7 +798,10 @@ mod tests {
         assert!(driver.force_default_action(0));
         driver.run_until_blocked();
 
-        assert!(driver.is_round_over(), "代打ち後に局が進行しなかった");
+        assert!(
+            driver.is_round_over(),
+            "round did not progress after the substitute CPU took over"
+        );
     }
 
     /// Shadow seats must keep buffering during substitution, so the room
@@ -830,12 +833,12 @@ mod tests {
         let events = driver.drain_events(0);
         assert!(
             !events.is_empty(),
-            "代打ち中のシャドーCPU席にイベントが記録されていない"
+            "no event was recorded for the shadow CPU seat during substitution"
         );
 
         assert!(
             driver.drain_events(1).is_empty(),
-            "純粋なCPU席にイベントがバッファされている"
+            "events were buffered for a CPU-only seat"
         );
     }
 
@@ -848,7 +851,10 @@ mod tests {
         let round = driver.table().current_round().unwrap();
         assert_eq!(round.current_player, 0);
         assert_eq!(round.phase, TurnPhase::WaitForDiscard);
-        assert!(!driver.needs_tick(), "人間の打牌待ちでは tick 不要");
+        assert!(
+            !driver.needs_tick(),
+            "a tick should not be needed while waiting for a human discard"
+        );
 
         driver.handle_action(0, ClientAction::Discard { tile: None });
         // Immediate mode races through the CPUs, so use a paced driver
@@ -862,9 +868,15 @@ mod tests {
             }
             paced.tick_at(0.0);
         }
-        assert!(!paced.needs_tick(), "人間の打牌待ちで停止するはず");
+        assert!(
+            !paced.needs_tick(),
+            "the driver should stop while waiting for a human discard"
+        );
         paced.handle_action_at(0, ClientAction::Discard { tile: None }, 0.0);
-        assert!(paced.needs_tick(), "打牌後は CPU 進行のため tick が必要");
+        assert!(
+            paced.needs_tick(),
+            "a tick should be needed for CPU progression after the discard"
+        );
     }
 
     #[test]
@@ -959,7 +971,11 @@ mod tests {
 
         assert!(driver.force_default_action(0));
         let round = driver.table().current_round().unwrap();
-        assert_eq!(round.players[0].discards.len(), 1, "既定打牌が空振りした");
+        assert_eq!(
+            round.players[0].discards.len(),
+            1,
+            "default discard had no effect"
+        );
         // Skips the forbidden 3p and discards the next-from-last 2p.
         assert_eq!(round.players[0].discards[0].tile.get(), Tile::P2);
     }
@@ -991,7 +1007,7 @@ mod tests {
         assert_eq!(
             round.players[1].discards.len(),
             1,
-            "却下されたCPUアクションがフォールバックされず局が停止している"
+            "a rejected CPU action did not fall back and stalled the round"
         );
     }
 
@@ -1035,19 +1051,22 @@ mod tests {
                 tile_index: Tile::M1 as usize,
             },
         );
-        assert!(kan_result, "カンが失敗した");
+        assert!(kan_result, "quad declaration failed");
 
         {
             let round = driver.table().current_round().unwrap();
             assert_eq!(
                 round.phase,
                 TurnPhase::WaitForDiscard,
-                "カン後のフェーズがWaitForDiscardでない"
+                "phase after the quad is not WaitForDiscard"
             );
-            assert_eq!(round.current_player, 0, "カン後の現在プレイヤーが0でない");
+            assert_eq!(
+                round.current_player, 0,
+                "current player after the quad is not player 0"
+            );
             assert!(
                 round.players[0].hand.drawn().is_some(),
-                "カン後に嶺上牌が設定されていない"
+                "replacement tile was not set after the quad"
             );
         }
 
@@ -1057,7 +1076,7 @@ mod tests {
             .any(|e| matches!(e, ServerEvent::TileDrawn { .. }));
         assert!(
             has_tile_drawn,
-            "カン後にTileDrawnイベントが来なかった: {:?}",
+            "TileDrawn event did not arrive after the quad: {:?}",
             events
                 .iter()
                 .map(std::mem::discriminant)
@@ -1065,7 +1084,7 @@ mod tests {
         );
 
         let discard_result = driver.handle_action(0, ClientAction::Discard { tile: None });
-        assert!(discard_result, "カン後の打牌が失敗した");
+        assert!(discard_result, "discard after the quad failed");
     }
 
     #[test]
@@ -1096,7 +1115,7 @@ mod tests {
             phase == TurnPhase::WaitForDiscard
                 || phase == TurnPhase::Draw
                 || phase == TurnPhase::WaitForCalls,
-            "CPUカン後にゲームが詰まった: フェーズ = {:?}",
+            "game stalled after a CPU quad: phase = {:?}",
             phase
         );
 
@@ -1147,7 +1166,7 @@ mod tests {
                 events
                     .iter()
                     .any(|e| matches!(e, ServerEvent::GameStarted { .. })),
-                "座席{}にGameStartedが届いていない",
+                "seat {} did not receive GameStarted",
                 seat
             );
         }
@@ -1327,7 +1346,7 @@ mod tests {
             per_seat[0]
                 .iter()
                 .any(|e| matches!(e, ServerEvent::CallAvailable { .. })),
-            "座席0にCallAvailableが同一フラッシュで届いていない: {:?}",
+            "seat 0 did not receive CallAvailable in the same flush: {:?}",
             per_seat[0]
         );
     }

--- a/crates/mahjong-server/src/player.rs
+++ b/crates/mahjong-server/src/player.rs
@@ -185,7 +185,7 @@ impl Player {
     pub fn discard(&mut self, tile: Option<Tile>) -> Tile {
         match self.try_discard(tile) {
             Some(discarded) => discarded,
-            None => panic!("捨てる牌が手牌またはツモ牌にありません"),
+            None => panic!("discarded tile is not in the hand or drawn tile slot"),
         }
     }
 
@@ -475,7 +475,11 @@ impl Player {
                 indices.push(i);
             }
         }
-        assert_eq!(indices.len(), 3, "大明カンに必要な3枚がありません");
+        assert_eq!(
+            indices.len(),
+            3,
+            "called quad requires three matching tiles"
+        );
 
         let t1 = self.hand.tiles()[indices[0]];
         let t2 = self.hand.tiles()[indices[1]];
@@ -507,7 +511,7 @@ impl Player {
         assert_eq!(
             indices.len() + usize::from(drawn_matches),
             4,
-            "暗カンに必要な4枚が揃っていません"
+            "concealed quad requires four matching tiles"
         );
 
         let mut kan_tiles: Vec<Tile> = indices.iter().map(|&idx| self.hand.tiles()[idx]).collect();
@@ -548,7 +552,10 @@ impl Player {
             .map(|t| t.get() == tile_type)
             .unwrap_or(false);
         let added_tile = if drawn_matches {
-            let tile = self.hand.drawn().expect("加カンに必要なツモ牌がありません");
+            let tile = self
+                .hand
+                .drawn()
+                .expect("promoted quad requires a drawn tile");
             self.hand.set_drawn(None);
             tile
         } else {
@@ -557,7 +564,7 @@ impl Player {
                 .tiles()
                 .iter()
                 .position(|t| t.get() == tile_type)
-                .expect("加カンに必要な牌が手牌にありません");
+                .expect("tile required for the promoted quad is not in the hand");
             let tile = self.hand.tiles_mut().remove(idx);
 
             if let Some(drawn_tile) = self.hand.drawn() {
@@ -573,7 +580,7 @@ impl Player {
             .melds_mut()
             .iter_mut()
             .find(|open| open.category == MeldType::Pon && open.tiles[0].get() == tile_type)
-            .expect("加カン対象のポンがありません");
+            .expect("matching triplet for the promoted quad was not found");
         open.category = MeldType::Kakan;
         open.called_tile = Some(added_tile);
 
@@ -921,7 +928,7 @@ mod tests {
                 .tiles
                 .iter()
                 .any(|tile| tile.is_red_dora()),
-            "暗カンの赤ドラ牌が副露情報に残ること"
+            "the red dora tile in a concealed quad should remain in the meld data"
         );
     }
 
@@ -940,15 +947,15 @@ mod tests {
         assert!(player.hand.drawn().is_none());
         assert!(
             !player.hand.tiles().iter().any(|t| t.get() == Tile::S9),
-            "9sは全てカンされて手牌に残らないこと"
+            "all 9s tiles should be moved into the quad"
         );
         assert!(
             player.hand.tiles().contains(&Tile::new(Tile::M1)),
-            "ツモ牌の1mが手牌に戻ること"
+            "the drawn 1m should return to the hand"
         );
         assert!(
             player.hand.tiles().contains(&Tile::new(Tile::P4)),
-            "カンと無関係な牌が誤って削除されないこと"
+            "tiles unrelated to the quad should not be removed"
         );
         assert_eq!(player.hand.melds().len(), 1);
         assert_eq!(player.hand.melds()[0].category, MeldType::Kan);

--- a/crates/mahjong-server/src/protocol/net.rs
+++ b/crates/mahjong-server/src/protocol/net.rs
@@ -260,7 +260,7 @@ mod tests {
             ClientMessage::Hello {
                 protocol_version: PROTOCOL_VERSION,
                 session_token: Some("abc123".to_string()),
-                display_name: "テスト".to_string(),
+                display_name: "Test".to_string(),
             },
             ClientMessage::Hello {
                 protocol_version: PROTOCOL_VERSION,
@@ -347,11 +347,11 @@ mod tests {
                 code: "XYZ789".to_string(),
                 seats: [
                     SeatInfo::Human {
-                        name: "ホスト".to_string(),
+                        name: "Host".to_string(),
                         connected: true,
                     },
                     SeatInfo::Human {
-                        name: "ゲスト".to_string(),
+                        name: "Guest".to_string(),
                         connected: false,
                     },
                     SeatInfo::Cpu {

--- a/crates/mahjong-server/src/round/tests.rs
+++ b/crates/mahjong-server/src/round/tests.rs
@@ -513,7 +513,7 @@ fn test_open_tanyao_disabled_does_not_offer_ron() {
         !call_state.available_calls[1]
             .iter()
             .any(|call| matches!(call, AvailableCall::Ron)),
-        "喰いタンなしではオープン断么九のみのロンを提示しない"
+        "an open All Simples-only ron should not be offered when open tanyao is disabled"
     );
 }
 
@@ -1069,7 +1069,10 @@ fn test_do_nine_terminals_declare() {
             }
         )
     });
-    assert!(has_round_draw, "九種九牌流局イベントが生成されていない");
+    assert!(
+        has_round_draw,
+        "Nine Terminals abortive-draw event was not generated"
+    );
 }
 
 #[test]
@@ -1122,7 +1125,7 @@ fn test_do_draw_triggers_nine_terminals_phase() {
     assert_eq!(
         round.phase,
         TurnPhase::WaitForNineTerminals,
-        "九種九牌条件達成時にWaitForNineTerminalsになるべき"
+        "the phase should be WaitForNineTerminals when its conditions are met"
     );
 
     let events = round.drain_events();
@@ -1131,7 +1134,7 @@ fn test_do_draw_triggers_nine_terminals_phase() {
         .any(|(_idx, e)| matches!(e, ServerEvent::NineTerminalsAvailable));
     assert!(
         has_available,
-        "NineTerminalsAvailableイベントが生成されていない"
+        "NineTerminalsAvailable event was not generated"
     );
 }
 
@@ -1166,7 +1169,7 @@ fn test_nine_terminals_continue_resends_tile_drawn() {
     let resent = events
         .iter()
         .any(|(idx, e)| *idx == 0 && matches!(e, ServerEvent::TileDrawn { .. }));
-    assert!(resent, "続行時に TileDrawn が再送されるべき");
+    assert!(resent, "TileDrawn should be resent when play continues");
 
     // The re-sent draw allows the discard; the hand moves on.
     assert!(round.do_discard(None));
@@ -1250,7 +1253,10 @@ fn test_triple_ron_draw_enabled() {
             }
         )
     });
-    assert!(has_triple_ron, "三家和流局イベントが生成されていない");
+    assert!(
+        has_triple_ron,
+        "Triple Ron abortive-draw event was not generated"
+    );
 }
 
 #[test]
@@ -1272,7 +1278,7 @@ fn test_triple_ron_draw_takes_priority_over_multiple_ron() {
     assert_eq!(round.phase, TurnPhase::RoundOver);
     assert!(
         matches!(round.result, Some(RoundResult::SpecialDraw)),
-        "triple_ron_draw が multiple_ron より優先されること"
+        "triple_ron_draw should take precedence over multiple_ron"
     );
     let events = round.drain_events();
     assert!(events.iter().any(|(_, e)| matches!(
@@ -1308,7 +1314,7 @@ fn test_triple_ron_draw_disabled_multiple_ron_disabled_picks_winner() {
             assert_eq!(winners, &vec![1]);
             assert_eq!(*loser, 0);
         }
-        _ => panic!("ロン結果が期待されたが別の結果: {:?}", round.result),
+        _ => panic!("expected a ron result, got {:?}", round.result),
     }
 }
 
@@ -1335,7 +1341,7 @@ fn test_two_ron_no_draw() {
             assert_eq!(winners, &vec![1, 2]);
             assert_eq!(*loser, 0);
         }
-        _ => panic!("Ron結果が期待されたが別の結果: {:?}", round.result),
+        _ => panic!("expected a ron result, got {:?}", round.result),
     }
 }
 
@@ -1362,7 +1368,7 @@ fn test_two_ron_disabled_picks_winner() {
             assert_eq!(winners, &vec![1]);
             assert_eq!(*loser, 0);
         }
-        _ => panic!("Ron結果が期待されたが別の結果: {:?}", round.result),
+        _ => panic!("expected a ron result, got {:?}", round.result),
     }
 }
 
@@ -1382,10 +1388,14 @@ fn test_double_ron_both_win() {
     assert_eq!(round.phase, TurnPhase::RoundOver);
     match &round.result {
         Some(RoundResult::Ron { winners, loser, .. }) => {
-            assert_eq!(winners, &vec![1, 2], "打順優先順で並んでいること");
+            assert_eq!(
+                winners,
+                &vec![1, 2],
+                "winners should be ordered by turn priority"
+            );
             assert_eq!(*loser, 0);
         }
-        _ => panic!("Ron結果が期待されたが別の結果: {:?}", round.result),
+        _ => panic!("expected a ron result, got {:?}", round.result),
     }
 }
 
@@ -1411,7 +1421,7 @@ fn test_triple_ron_all_win() {
             assert_eq!(winners, &vec![1, 2, 3]);
             assert_eq!(*loser, 0);
         }
-        _ => panic!("Ron結果が期待されたが別の結果: {:?}", round.result),
+        _ => panic!("expected a ron result, got {:?}", round.result),
     }
 }
 
@@ -1437,14 +1447,14 @@ fn test_double_ron_scores() {
     let p2_gain = round.players[2].score - initial_score_p2;
     assert!(
         p1_gain > p2_gain,
-        "最初の和了者が本場ボーナスを得ること: p1={}, p2={}",
+        "the first winner should receive the honba bonus: p1={}, p2={}",
         p1_gain,
         p2_gain
     );
     assert_eq!(
         p1_gain - p2_gain,
         300,
-        "本場ボーナスの差は1本場=300点であること"
+        "the honba bonus difference should be 300 points for one honba"
     );
 
     // The deal-in player pays both.
@@ -1452,7 +1462,7 @@ fn test_double_ron_scores() {
     let total_gain = p1_gain + p2_gain;
     assert_eq!(
         loser_loss, total_gain,
-        "放銃者の支払いが全和了者の取得合計と一致すること"
+        "the discarder payment should equal the total received by all winners"
     );
 }
 
@@ -1477,7 +1487,7 @@ fn test_double_ron_events_generated() {
     assert_eq!(
         won_events.len(),
         2,
-        "ダブロンで2件のRoundWonイベントが生成されること"
+        "a double ron should generate two RoundWon events"
     );
     let ServerEvent::RoundWon {
         honba: first_honba,
@@ -1521,9 +1531,12 @@ fn test_multi_ron_riichi_sticks_first_winner_only() {
     assert_eq!(
         p1_gain - p2_gain,
         2000,
-        "供託2本はプレイヤー1のみ取得: 差は2000点"
+        "only player 1 should receive the two riichi deposits, for a 2,000-point difference"
     );
-    assert_eq!(round.riichi_sticks, 0, "供託棒はすべて消費されること");
+    assert_eq!(
+        round.riichi_sticks, 0,
+        "all riichi deposits should be consumed"
+    );
 }
 
 // --- auto_pass_cpu ---
@@ -1723,7 +1736,7 @@ fn test_sanma_round_setup() {
         for tile in round.players[i].hand.tiles() {
             assert!(
                 !(Tile::M2..=Tile::M8).contains(&tile.get()),
-                "三麻の手牌に萬子2〜8が含まれている: {:?}",
+                "a three-player hand contains a 2-8 characters tile: {:?}",
                 tile
             );
         }
@@ -1800,7 +1813,7 @@ fn test_sanma_no_chi_offered() {
         call_state.available_calls[1]
             .iter()
             .all(|c| !matches!(c, AvailableCall::Chi { .. })),
-        "三麻でチーが提供された"
+        "chi was offered in a three-player game"
     );
 }
 
@@ -1816,7 +1829,7 @@ fn test_sanma_pon_still_offered() {
         call_state.available_calls[2]
             .iter()
             .any(|c| matches!(c, AvailableCall::Pon { .. })),
-        "三麻でポンが提供されない"
+        "pon was not offered in a three-player game"
     );
     // The dummy seat always counts as responded.
     assert!(call_state.responded[3]);
@@ -1938,7 +1951,7 @@ fn test_pei_win_adds_pei_dora() {
         .iter()
         .find(|(_, e)| matches!(e, ServerEvent::RoundWon { .. }));
     let Some((_, ServerEvent::RoundWon { yaku_list, .. })) = won else {
-        panic!("RoundWon イベントがない");
+        panic!("RoundWon event is missing");
     };
     assert!(
         yaku_list.iter().any(|(item, han)| *item
@@ -1946,7 +1959,7 @@ fn test_pei_win_adds_pei_dora() {
                 mahjong_core::scoring::score::DoraLabel::PeiDora
             )
             && *han == 1),
-        "北ドラが加算されていない: {:?}",
+        "North dora han were not added: {:?}",
         yaku_list
     );
 }
@@ -2168,7 +2181,10 @@ fn test_sanma_three_winds_draw() {
             is_called: false,
         });
     }
-    assert!(round.check_four_winds_draw(), "三麻の四風連打が成立しない");
+    assert!(
+        round.check_four_winds_draw(),
+        "Four Winds abortive draw was not recognized in a three-player game"
+    );
 }
 
 /// A hand-discard TileDiscarded carries the pre-discard sorted position.
@@ -2195,7 +2211,7 @@ fn test_tedashi_discard_event_includes_hand_index() {
             } => Some((*is_tsumogiri, *hand_index)),
             _ => None,
         })
-        .expect("TileDiscarded イベントがない");
+        .expect("TileDiscarded event is missing");
     assert_eq!(discarded, (false, Some(3)));
 }
 
@@ -2221,6 +2237,6 @@ fn test_tsumogiri_discard_event_has_no_hand_index() {
             } => Some((*is_tsumogiri, *hand_index)),
             _ => None,
         })
-        .expect("TileDiscarded イベントがない");
+        .expect("TileDiscarded event is missing");
     assert_eq!(discarded, (true, None));
 }

--- a/crates/mahjong-server/src/scoring.rs
+++ b/crates/mahjong-server/src/scoring.rs
@@ -730,7 +730,7 @@ mod tests {
             fu_result: FuResult {
                 total: 30,
                 details: vec![FuDetail {
-                    name: "副底",
+                    name: "Base fu",
                     fu: 20,
                 }],
             },
@@ -847,7 +847,7 @@ mod tests {
             fu_result: FuResult {
                 total: 30,
                 details: vec![FuDetail {
-                    name: "副底",
+                    name: "Base fu",
                     fu: 20,
                 }],
             },
@@ -882,7 +882,7 @@ mod tests {
             score
                 .yaku_list
                 .contains(&(ScoreItem::Dora(DoraLabel::Dora), 1)),
-            "三麻の1m表示で9mがドラとしてカウントされない: {:?}",
+            "9m was not counted as dora for a 1m indicator in a three-player game: {:?}",
             score.yaku_list
         );
     }
@@ -903,7 +903,7 @@ mod tests {
             fu_result: FuResult {
                 total: 30,
                 details: vec![FuDetail {
-                    name: "副底",
+                    name: "Base fu",
                     fu: 20,
                 }],
             },
@@ -941,14 +941,14 @@ mod tests {
             score
                 .yaku_list
                 .contains(&(ScoreItem::Dora(DoraLabel::PeiDora), 2)),
-            "北ドラ2翻が加算されていない: {:?}",
+            "two han of North dora were not added: {:?}",
             score.yaku_list
         );
         assert!(
             score
                 .yaku_list
                 .contains(&(ScoreItem::Dora(DoraLabel::Dora), 2)),
-            "西表示牌による北のドラ2翻が加算されていない: {:?}",
+            "two han of North dora from a West indicator were not added: {:?}",
             score.yaku_list
         );
         // 1 (All Inside) + 2 (pei dora) + 2 (indicator dora) = 5 han
@@ -1352,7 +1352,7 @@ mod tests {
         let fu_result = FuResult {
             total: 30,
             details: vec![FuDetail {
-                name: "副底",
+                name: "Base fu",
                 fu: 20,
             }],
         };
@@ -1415,7 +1415,7 @@ mod tests {
         let fu_result = FuResult {
             total: 30,
             details: vec![FuDetail {
-                name: "副底",
+                name: "Base fu",
                 fu: 20,
             }],
         };
@@ -1457,7 +1457,7 @@ mod tests {
         let fu_result = FuResult {
             total: 30,
             details: vec![FuDetail {
-                name: "副底",
+                name: "Base fu",
                 fu: 20,
             }],
         };

--- a/crates/mahjong-server/src/simulation.rs
+++ b/crates/mahjong-server/src/simulation.rs
@@ -434,19 +434,30 @@ mod tests {
             run_simulation(&fast_sanma_config(2, 42)).expect("sanma simulation should complete");
 
         assert_eq!(stats.games, 2);
-        assert!(stats.rounds >= 3 * 2, "三麻の東風戦は最低3局のはず");
+        assert!(
+            stats.rounds >= 3 * 2,
+            "three-player East-only games should have at least three hands"
+        );
 
         // Three players means placements 1-3 only; the dummy seat
         // (config 3) must never place.
         for rank in 0..3 {
             let total: u32 = stats.per_cpu.iter().map(|c| c.placements[rank]).sum();
-            assert_eq!(total, stats.games, "{}着の合計がゲーム数と不一致", rank + 1);
+            assert_eq!(
+                total,
+                stats.games,
+                "total finishes at rank {} do not match the game count",
+                rank + 1
+            );
         }
         let fourth_total: u32 = stats.per_cpu.iter().map(|c| c.placements[3]).sum();
-        assert_eq!(fourth_total, 0, "三麻で4着が発生している");
+        assert_eq!(
+            fourth_total, 0,
+            "a fourth-place finish occurred in a three-player game"
+        );
         assert_eq!(
             stats.per_cpu[3].placements, [0; 4],
-            "ダミー席が集計されている"
+            "the dummy seat was included in the statistics"
         );
 
         // Total final scores cannot exceed games x starting score x 3
@@ -459,7 +470,10 @@ mod tests {
     fn test_sanma_simulation_is_deterministic_with_same_seed() {
         let first = run_simulation(&fast_sanma_config(1, 7)).expect("first run should complete");
         let second = run_simulation(&fast_sanma_config(1, 7)).expect("second run should complete");
-        assert_eq!(first, second, "同一シードの三麻結果が一致しない");
+        assert_eq!(
+            first, second,
+            "three-player results differ for the same seed"
+        );
     }
 
     #[test]
@@ -467,11 +481,19 @@ mod tests {
         let stats = run_simulation(&fast_config(1, 42)).expect("simulation should complete");
 
         assert_eq!(stats.games, 1);
-        assert!(stats.rounds >= 4, "東風戦は最低4局のはず");
+        assert!(
+            stats.rounds >= 4,
+            "East-only games should have at least four hands"
+        );
 
         for rank in 0..4 {
             let total: u32 = stats.per_cpu.iter().map(|c| c.placements[rank]).sum();
-            assert_eq!(total, stats.games, "{}着の合計がゲーム数と不一致", rank + 1);
+            assert_eq!(
+                total,
+                stats.games,
+                "total finishes at rank {} do not match the game count",
+                rank + 1
+            );
         }
 
         // Total final scores cannot exceed games x starting score x 4
@@ -484,7 +506,7 @@ mod tests {
     fn test_simulation_is_deterministic_with_same_seed() {
         let first = run_simulation(&fast_config(2, 7)).expect("first run should complete");
         let second = run_simulation(&fast_config(2, 7)).expect("second run should complete");
-        assert_eq!(first, second, "同一シードの結果が一致しない");
+        assert_eq!(first, second, "results differ for the same seed");
     }
 
     #[test]
@@ -496,7 +518,7 @@ mod tests {
         let b = run_simulation(&fast_config(2, 2)).expect("run b should complete");
         assert_ne!(
             a, b,
-            "異なるシードで結果が完全一致（シードが効いていない疑い）"
+            "results are identical for different seeds; the seed may have no effect"
         );
     }
 

--- a/crates/mahjong-server/src/table.rs
+++ b/crates/mahjong-server/src/table.rs
@@ -493,16 +493,16 @@ mod tests {
         assert!(
             events.iter().any(|(seat, e)| *seat == 0
                 && matches!(e, ServerEvent::HandUpdated { hand } if *hand == expected_hand)),
-            "HandUpdated が送られていない"
+            "HandUpdated was not sent"
         );
         assert!(
             events.iter().any(|(seat, e)| *seat == 0
                 && matches!(e, ServerEvent::TileDrawn { tile, .. } if tile.get() == Tile::Z5)),
-            "TileDrawn が再送されていない"
+            "TileDrawn was not resent"
         );
         assert!(
             events.iter().all(|(seat, _)| *seat == 0),
-            "他プレイヤーへイベントが送られている"
+            "an event was sent to another player"
         );
     }
 
@@ -528,13 +528,13 @@ mod tests {
             events
                 .iter()
                 .any(|(seat, e)| *seat == 0 && matches!(e, ServerEvent::HandUpdated { .. })),
-            "HandUpdated が送られていない"
+            "HandUpdated was not sent"
         );
         assert!(
             !events
                 .iter()
                 .any(|(_, e)| matches!(e, ServerEvent::TileDrawn { .. })),
-            "ツモ牌が無いのに TileDrawn が送られている"
+            "TileDrawn was sent without a drawn tile"
         );
     }
 
@@ -570,12 +570,12 @@ mod tests {
             events
                 .iter()
                 .any(|(seat, e)| *seat == 0 && matches!(e, ServerEvent::HandUpdated { .. })),
-            "HandUpdated が送られていない"
+            "HandUpdated was not sent"
         );
         assert!(
             events.iter().any(|(seat, e)| *seat == 0
                 && matches!(e, ServerEvent::TileDrawn { tile, .. } if tile.get() == Tile::Z5)),
-            "TileDrawn が再送されていない"
+            "TileDrawn was not resent"
         );
     }
 
@@ -780,11 +780,7 @@ mod tests {
         // Three consecutive noten draws must end a three-player
         // East-only game.
         for i in 0..3 {
-            assert!(
-                !table.is_game_over,
-                "{}局目の前にゲームが終了している",
-                i + 1
-            );
+            assert!(!table.is_game_over, "game ended before hand {}", i + 1);
             table.start_round();
             let round = table.current_round_mut().unwrap();
             round.phase = TurnPhase::RoundOver;
@@ -794,7 +790,10 @@ mod tests {
             table.finish_round();
         }
 
-        assert!(table.is_game_over, "三麻の東風戦が3局で終了しない");
+        assert!(
+            table.is_game_over,
+            "three-player East-only game did not end after three hands"
+        );
     }
 
     #[test]
@@ -838,7 +837,7 @@ mod tests {
         }
         assert!(
             table.is_game_over,
-            "{max_rounds}局回してもゲームが終了しない"
+            "game did not end after {max_rounds} hands"
         );
         max_rounds
     }


### PR DESCRIPTION
## Summary

- Translate test failure diagnostics, assertions, and non-localized fixture names to English.
- Translate internal Rust diagnostics and browser-side HTML/JavaScript errors to English.
- Replace hard-coded Japanese fu breakdown labels with English names.
- Preserve Japanese strings used by `Lang::Ja` UI rendering and tests that explicitly verify Japanese display output.

## Why

Developer-facing diagnostics and test data contained Japanese strings outside the localization paths. Keeping those strings in English makes failures consistent with the project's source-code conventions while retaining the Japanese UI.

## Impact

Test failures and internal diagnostics are now reported in English. Japanese UI text selected through localization is unchanged.

## Validation

- `cargo fmt`
- `cargo clippy --all-targets --all-features`
- `cargo build --all-targets --all-features`
- `cargo test --all-targets --all-features`
- `git diff --check`

Closes #364