### PR TITLE
Make the round result panel translucent

### DIFF
--- a/crates/mahjong-client/src/renderer/result.rs
+++ b/crates/mahjong-client/src/renderer/result.rs
@@ -121,7 +121,7 @@ pub(super) fn draw_result(state: &GameState, font: Option<&Font>, tile_textures:
         0.0,
         DESIGN_W,
         DESIGN_H,
-        Color::new(0.0, 0.0, 0.0, 0.78),
+        Color::new(0.0, 0.0, 0.0, 0.82),
     );
 
     if state.current_win_result().is_some() {
@@ -142,7 +142,7 @@ pub(super) fn draw_overlay_panel(panel_w: f32, panel_h: f32) -> (f32, f32, f32) 
         panel_w,
         panel_h,
         12.0,
-        theme::rgba(0x050e08, 0.97),
+        theme::rgba(0x050e08, 0.5),
         theme::GOLD_DK,
     );
     (panel_x, panel_y, panel_x + panel_w)


### PR DESCRIPTION
## Summary

- make the round result panel background translucent
- retain a dark full-screen backdrop so result details remain readable

## Why

The opaque result panel hides the final table state. Letting the table show through makes it possible to review discards after a win without leaving the result screen.

## User impact

Players can inspect the table and discards behind the round result details while the winning hand, yaku, and score remain legible.

## Validation

- `cargo fmt`
- `cargo build`
- `cargo test`
- `cargo clippy -- -D warnings`
- `git diff --check`

Closes #366