### PR TITLE
Improve exhaustive draw reveal flow

### DIFF
--- a/crates/mahjong-client/src/game/events.rs
+++ b/crates/mahjong-client/src/game/events.rs
@@ -84,6 +84,7 @@ impl GameState {
                     OtherPlayerHand::new(),
                     OtherPlayerHand::new(),
                 ];
+                self.exhaustive_draw_reveal = None;
                 self.last_discarder = None;
                 self.call_banners = [None; 4];
                 self.turn_player = None;
@@ -595,8 +596,10 @@ impl GameState {
                 let mut msg = tr.draw_headline(reason);
 
                 if !tenpai.is_empty() {
-                    let tenpai_names: Vec<String> =
-                        tenpai.iter().map(|w| self.wind_to_name(*w)).collect();
+                    let tenpai_names: Vec<String> = tenpai
+                        .iter()
+                        .map(|wind| self.player_display_name(*wind))
+                        .collect();
                     msg.push('\n');
                     msg.push_str(&tr.tenpai_list(&tenpai_names.join(", ")));
                 }

--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -15,7 +15,7 @@ use crate::i18n::{Key, Translator};
 use mahjong_server::cpu::client::{CpuConfig, CpuLevel, CpuPersonality};
 use mahjong_server::protocol::net::CpuSpec;
 use mahjong_server::protocol::{
-    AvailableCall, CallType, ClientAction, PlayerHandInfo, ServerEvent,
+    AvailableCall, CallType, ClientAction, DrawReason, PlayerHandInfo, ServerEvent,
 };
 
 mod events;
@@ -36,6 +36,8 @@ pub const CALL_HOLD_SECS: f64 = 0.9;
 pub const WIN_HOLD_SECS: f64 = 1.2;
 /// Seconds a declaration banner stays visible.
 pub const CALL_BANNER_SECS: f64 = 1.5;
+/// Seconds each player has to declare tenpai or noten at an exhaustive draw.
+pub const DRAW_REVEAL_STEP_SECS: f64 = 1.0;
 /// Delay before the automatic riichi tsumogiri, so the drawn tile is
 /// visible first.
 pub const RIICHI_AUTO_DISCARD_SECS: f64 = 1.0;
@@ -58,6 +60,13 @@ struct Declaration {
     hold_secs: f64,
     /// Whether the event itself is also held (wins, nine terminals)
     before_apply: bool,
+}
+
+/// Dealer-first tenpai/noten reveal shown before an exhaustive-draw result.
+struct ExhaustiveDrawReveal {
+    players: Vec<PlayerHandInfo>,
+    tenpai: Vec<Wind>,
+    next_player: usize,
 }
 
 /// Value of one riichi deposit stick, in points. Mirrors the server's
@@ -345,6 +354,8 @@ pub struct GameState {
     event_hold_until: f64,
     /// Whether the front event's banner has been shown (pre-apply hold)
     head_announced: bool,
+    /// Player-by-player reveal while an exhaustive-draw event stays queued
+    exhaustive_draw_reveal: Option<ExhaustiveDrawReveal>,
     /// The time last passed to [`process_events`](Self::process_events)
     /// or `handle_input`; used as the animation start time.
     clock: f64,
@@ -473,6 +484,7 @@ impl GameState {
             pending_events: VecDeque::new(),
             event_hold_until: 0.0,
             head_announced: false,
+            exhaustive_draw_reveal: None,
             clock: 0.0,
             lang: crate::persistence::load_lang().unwrap_or(Lang::Ja),
         }
@@ -614,6 +626,8 @@ impl GameState {
     /// ([`WIN_HOLD_SECS`] for wins), so the "call-out" is seen before its
     /// effect and players notice the declaration. Wins and nine terminals
     /// also hold the event itself (the result-screen transition).
+    /// Exhaustive draws stay queued while each player declares tenpai or
+    /// noten in dealer-first turn order.
     pub fn process_events(&mut self, now: f64) {
         self.clock = now;
 
@@ -627,6 +641,23 @@ impl GameState {
         loop {
             if now < self.event_hold_until || self.pending_events.is_empty() {
                 return;
+            }
+
+            if self.exhaustive_draw_reveal.is_none()
+                && !self.head_announced
+                && let Some(reveal) = self.exhaustive_draw_reveal_for(&self.pending_events[0])
+            {
+                self.exhaustive_draw_reveal = Some(reveal);
+                self.head_announced = true;
+                self.available_calls.clear();
+                self.can_tsumo = false;
+                self.can_riichi = false;
+                self.turn_player = None;
+                self.is_my_turn = false;
+            }
+
+            if self.exhaustive_draw_reveal.is_some() && self.show_next_exhaustive_draw_player(now) {
+                continue;
             }
 
             if !self.head_announced
@@ -670,6 +701,70 @@ impl GameState {
             self.head_announced = false;
             self.handle_event(event);
         }
+    }
+
+    /// Builds the dealer-first reveal sequence for an exhaustive draw.
+    fn exhaustive_draw_reveal_for(&self, event: &ServerEvent) -> Option<ExhaustiveDrawReveal> {
+        let ServerEvent::RoundDraw {
+            reason: DrawReason::Exhaustive,
+            tenpai,
+            player_hands,
+            ..
+        } = event
+        else {
+            return None;
+        };
+        if self.phase != GamePhase::Playing {
+            return None;
+        }
+
+        let mut players = player_hands.clone();
+        players.sort_by_key(|info| info.wind.to_index());
+        Some(ExhaustiveDrawReveal {
+            players,
+            tenpai: tenpai.clone(),
+            next_player: 0,
+        })
+    }
+
+    /// Shows one tenpai/noten declaration and schedules the next one.
+    ///
+    /// Returns false after the final player's one-second hold has elapsed,
+    /// allowing the queued result event to be applied.
+    fn show_next_exhaustive_draw_player(&mut self, now: f64) -> bool {
+        let step = self.exhaustive_draw_reveal.as_mut().and_then(|reveal| {
+            let player = reveal.players.get(reveal.next_player)?.clone();
+            reveal.next_player += 1;
+            let is_tenpai = reveal.tenpai.contains(&player.wind);
+            Some((player, is_tenpai))
+        });
+        let Some((player, is_tenpai)) = step else {
+            self.exhaustive_draw_reveal = None;
+            self.call_banners = [None; 4];
+            return false;
+        };
+
+        // A declaration lasts exactly one step, so adjacent players never
+        // overlap even though ordinary call banners live longer.
+        self.call_banners = [None; 4];
+        let relative_idx = self.relative_player_index(player.wind);
+        self.call_banners[relative_idx] = Some(CallBanner {
+            label: if is_tenpai { Key::Tenpai } else { Key::Noten },
+            shown_at: now,
+        });
+
+        let revealed_winds = if is_tenpai {
+            vec![player.wind]
+        } else {
+            Vec::new()
+        };
+        self.update_other_player_hands_on_draw(
+            std::slice::from_ref(&player),
+            &revealed_winds,
+            None,
+        );
+        self.event_hold_until = now + DRAW_REVEAL_STEP_SECS;
+        true
     }
 
     /// The declaration display for an event, when it has one.
@@ -735,15 +830,6 @@ impl GameState {
                 before_apply: true,
             }),
             _ => None,
-        }
-    }
-
-    /// Seat name for winners and deal-in players
-    /// (Japanese 「東家」, English "East").
-    fn wind_to_name(&self, wind: Wind) -> String {
-        match self.lang {
-            Lang::Ja => format!("{}家", wind.name(Lang::Ja)),
-            Lang::En => wind.name(Lang::En).to_string(),
         }
     }
 

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -1218,6 +1218,152 @@ fn test_round_won_deferred_until_banner_hold_elapses() {
 }
 
 #[test]
+fn test_exhaustive_draw_reveals_players_one_at_a_time_in_turn_order() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+
+    // The protocol payload order is not part of the presentation contract.
+    let player_hands = [Wind::West, Wind::North, Wind::South, Wind::East]
+        .into_iter()
+        .map(|wind| PlayerHandInfo {
+            wind,
+            hand: vec![Tile::new(Tile::M1); 13],
+            melds: vec![],
+            pei: vec![],
+        })
+        .collect();
+    state.queue_event(ServerEvent::RoundDraw {
+        scores: [28_000, 22_000, 28_000, 22_000],
+        reason: DrawReason::Exhaustive,
+        tenpai: vec![Wind::East, Wind::West],
+        riichi_sticks: 0,
+        player_hands,
+        declarer: None,
+    });
+    state.process_events(100.0);
+
+    assert_eq!(state.phase, GamePhase::Playing);
+    assert_eq!(state.scores, [25_000; 4]);
+    assert_eq!(
+        state.call_banners[0].map(|banner| banner.label),
+        Some(Key::Tenpai)
+    );
+    assert_eq!(state.call_banners.iter().flatten().count(), 1);
+    assert!(!state.other_players[0].revealed);
+    assert!(!state.other_players[1].revealed);
+    assert!(!state.other_players[2].revealed);
+
+    state.process_events(100.0 + DRAW_REVEAL_STEP_SECS / 2.0);
+    assert_eq!(state.phase, GamePhase::Playing);
+    assert_eq!(
+        state.call_banners[0].map(|banner| banner.label),
+        Some(Key::Tenpai)
+    );
+
+    state.process_events(100.0 + DRAW_REVEAL_STEP_SECS);
+    assert_eq!(
+        state.call_banners[1].map(|banner| banner.label),
+        Some(Key::Noten)
+    );
+    assert_eq!(state.call_banners.iter().flatten().count(), 1);
+    assert!(!state.other_players[0].revealed);
+
+    state.process_events(100.0 + DRAW_REVEAL_STEP_SECS * 2.0);
+    assert_eq!(
+        state.call_banners[2].map(|banner| banner.label),
+        Some(Key::Tenpai)
+    );
+    assert_eq!(state.call_banners.iter().flatten().count(), 1);
+    assert!(state.other_players[1].revealed);
+    assert_eq!(state.other_players[1].hand, vec![Tile::new(Tile::M1); 13]);
+
+    state.process_events(100.0 + DRAW_REVEAL_STEP_SECS * 3.0);
+    assert_eq!(
+        state.call_banners[3].map(|banner| banner.label),
+        Some(Key::Noten)
+    );
+    assert_eq!(state.call_banners.iter().flatten().count(), 1);
+    assert_eq!(state.phase, GamePhase::Playing);
+
+    state.process_events(100.0 + DRAW_REVEAL_STEP_SECS * 4.0);
+    assert_eq!(state.phase, GamePhase::RoundResult);
+    assert_eq!(state.scores, [28_000, 22_000, 28_000, 22_000]);
+    assert!(state.call_banners.iter().all(Option::is_none));
+    let result_message = state
+        .result_message
+        .as_deref()
+        .expect("draw result message");
+    assert!(result_message.contains("テンパイ: あなた, CPU2"));
+    assert!(!result_message.contains("東家"));
+}
+
+#[test]
+fn test_sanma_exhaustive_draw_reveal_stops_after_three_players() {
+    let mut state = GameState::new();
+    state.handle_event(sanma_game_started(Wind::West));
+
+    let player_hands = [Wind::West, Wind::South, Wind::East]
+        .into_iter()
+        .map(|wind| PlayerHandInfo {
+            wind,
+            hand: vec![Tile::new(Tile::P1); 13],
+            melds: vec![],
+            pei: vec![],
+        })
+        .collect();
+    state.queue_event(ServerEvent::RoundDraw {
+        scores: [35_000, 35_000, 35_000, 0],
+        reason: DrawReason::Exhaustive,
+        tenpai: vec![Wind::South],
+        riichi_sticks: 0,
+        player_hands,
+        declarer: None,
+    });
+
+    state.process_events(100.0);
+    assert_eq!(
+        state.call_banners[1].map(|banner| banner.label),
+        Some(Key::Noten)
+    );
+
+    state.process_events(100.0 + DRAW_REVEAL_STEP_SECS);
+    assert_eq!(
+        state.call_banners[2].map(|banner| banner.label),
+        Some(Key::Tenpai)
+    );
+    assert!(state.other_players[1].revealed);
+
+    state.process_events(100.0 + DRAW_REVEAL_STEP_SECS * 2.0);
+    assert_eq!(
+        state.call_banners[0].map(|banner| banner.label),
+        Some(Key::Noten)
+    );
+
+    state.process_events(100.0 + DRAW_REVEAL_STEP_SECS * 3.0);
+    assert_eq!(state.phase, GamePhase::RoundResult);
+    assert!(state.call_banners.iter().all(Option::is_none));
+}
+
+#[test]
+fn test_abortive_draw_skips_tenpai_reveal_hold() {
+    let mut state = GameState::new();
+    state.handle_event(game_started_4p(Wind::East, 0));
+
+    state.queue_event(ServerEvent::RoundDraw {
+        scores: [25_000; 4],
+        reason: DrawReason::FourWinds,
+        tenpai: vec![],
+        riichi_sticks: 0,
+        player_hands: vec![],
+        declarer: None,
+    });
+    state.process_events(100.0);
+
+    assert_eq!(state.phase, GamePhase::RoundResult);
+    assert!(state.call_banners.iter().all(Option::is_none));
+}
+
+#[test]
 fn test_round_won_separates_honba_and_deposits_from_hand_points() {
     let mut state = GameState::new();
     state.handle_event(game_started_4p(Wind::East, 0));

--- a/crates/mahjong-client/src/i18n/mod.rs
+++ b/crates/mahjong-client/src/i18n/mod.rs
@@ -223,13 +223,9 @@ impl Translator {
         }
     }
 
-    /// Draw heading (JA 「流局（{reason}）」 / EN "Draw ({reason})").
+    /// Draw-reason heading shown below the generic draw label.
     pub fn draw_headline(&self, reason: DrawReason) -> String {
-        let reason = self.draw_reason(reason);
-        match self.lang {
-            Lang::Ja => format!("流局（{reason}）"),
-            Lang::En => format!("Draw ({reason})"),
-        }
+        self.draw_reason(reason).to_string()
     }
 
     /// Tenpai-players line (JA 「テンパイ: {names}」 / EN "Tenpai: {names}").
@@ -455,6 +451,10 @@ pub enum Key {
     Next,
     /// Draw
     RoundDraw,
+    /// Tenpai declaration at an exhaustive draw
+    Tenpai,
+    /// Noten declaration at an exhaustive draw
+    Noten,
     /// Game over
     GameOver,
     /// Play again
@@ -895,6 +895,14 @@ impl Key {
                 Lang::Ja => "流局",
                 Lang::En => "Draw",
             },
+            Key::Tenpai => match lang {
+                Lang::Ja => "テンパイ",
+                Lang::En => "Tenpai",
+            },
+            Key::Noten => match lang {
+                Lang::Ja => "ノーテン",
+                Lang::En => "Noten",
+            },
             Key::GameOver => match lang {
                 Lang::Ja => "ゲーム終了",
                 Lang::En => "Game Over",
@@ -1087,6 +1095,15 @@ mod tests {
     fn key_resolves_both_languages() {
         assert_eq!(Key::StartGame.text(Lang::Ja), "対局開始");
         assert_eq!(Key::StartGame.text(Lang::En), "Start Game");
+    }
+
+    #[test]
+    fn draw_headline_uses_only_the_reason_below_the_generic_label() {
+        let ja = Translator::new(Lang::Ja);
+        let en = Translator::new(Lang::En);
+        assert_eq!(ja.draw_headline(DrawReason::Exhaustive), "荒牌流局");
+        assert_eq!(ja.draw_headline(DrawReason::FourWinds), "四風連打");
+        assert_eq!(en.draw_headline(DrawReason::Exhaustive), "Exhaustive draw");
     }
 
     #[test]

--- a/crates/mahjong-client/src/renderer/banners.rs
+++ b/crates/mahjong-client/src/renderer/banners.rs
@@ -1,7 +1,8 @@
 //! Declaration banners (speech bubbles) for calls, riichi, wins, etc.
 //!
 //! Whenever a player would call out (pon, chii, kan, riichi, pei, ron,
-//! tsumo, nine terminals) a bubble appears near their hand for a while.
+//! tsumo, nine terminals, tenpai, noten) a bubble appears near their hand
+//! for a while.
 //! `GameState::process_events` creates and expires the banners; this
 //! module only draws `state.call_banners`.
 


### PR DESCRIPTION
## Summary

- announce tenpai or noten one player at a time before an exhaustive-draw result
- reveal tenpai hands in dealer-first draw order while keeping noten hands concealed
- support four-player and three-player reveal sequences
- simplify draw result headings to show only the draw reason below the generic Draw label
- show tenpai players by display name instead of seat wind
- add Japanese and English banner labels and regression coverage

## Why

The previous result transition did not give players enough time to inspect simultaneous declarations and revealed hands. The result panel also repeated the generic draw label, and its tenpai list used seat winds while other result views used player names.

## User impact

Exhaustive draws now present each player's status for one second in dealer-first turn order before opening the result panel. Abortive draws retain their existing immediate result flow.

## Validation

- `cargo fmt`
- `cargo build`
- `cargo test`
- `cargo clippy`
- `git diff --check`

Fixes #368