### PR TITLE
Improve game-over actions and online rematch flow

### DIFF
--- a/crates/mahjong-client/src/adapter/mod.rs
+++ b/crates/mahjong-client/src/adapter/mod.rs
@@ -41,3 +41,72 @@ pub trait GameAdapter {
         None
     }
 }
+
+/// The active in-game adapter, kept as an enum so an online connection
+/// can move back to the lobby after the final results.
+pub enum ActiveAdapter {
+    Local(Box<LocalAdapter>),
+    Remote(Box<RemoteAdapter>),
+}
+
+impl ActiveAdapter {
+    /// Recovers the remote connection when an online game returns to its
+    /// room. A local adapter has no lobby connection to recover.
+    pub fn into_remote(self) -> Option<RemoteAdapter> {
+        match self {
+            ActiveAdapter::Local(_) => None,
+            ActiveAdapter::Remote(remote) => Some(*remote),
+        }
+    }
+}
+
+impl GameAdapter for ActiveAdapter {
+    fn send_action(&mut self, action: ClientAction) {
+        match self {
+            ActiveAdapter::Local(adapter) => adapter.send_action(action),
+            ActiveAdapter::Remote(adapter) => adapter.send_action(action),
+        }
+    }
+
+    fn poll_events(&mut self) -> Vec<ServerEvent> {
+        match self {
+            ActiveAdapter::Local(adapter) => adapter.poll_events(),
+            ActiveAdapter::Remote(adapter) => adapter.poll_events(),
+        }
+    }
+
+    fn tick(&mut self) {
+        match self {
+            ActiveAdapter::Local(adapter) => adapter.tick(),
+            ActiveAdapter::Remote(adapter) => adapter.tick(),
+        }
+    }
+
+    fn request_next_round(&mut self) {
+        match self {
+            ActiveAdapter::Local(adapter) => adapter.request_next_round(),
+            ActiveAdapter::Remote(adapter) => adapter.request_next_round(),
+        }
+    }
+
+    fn is_game_over(&self) -> bool {
+        match self {
+            ActiveAdapter::Local(adapter) => adapter.is_game_over(),
+            ActiveAdapter::Remote(adapter) => adapter.is_game_over(),
+        }
+    }
+
+    fn status_text(&self, lang: Lang) -> Option<String> {
+        match self {
+            ActiveAdapter::Local(adapter) => adapter.status_text(lang),
+            ActiveAdapter::Remote(adapter) => adapter.status_text(lang),
+        }
+    }
+
+    fn turn_remaining_secs(&self) -> Option<u32> {
+        match self {
+            ActiveAdapter::Local(adapter) => adapter.turn_remaining_secs(),
+            ActiveAdapter::Remote(adapter) => adapter.turn_remaining_secs(),
+        }
+    }
+}

--- a/crates/mahjong-client/src/adapter/remote.rs
+++ b/crates/mahjong-client/src/adapter/remote.rs
@@ -46,6 +46,10 @@ pub struct RoomView {
     pub length: GameLength,
     /// CPU configs for empty seats (None from old servers)
     pub cpu_configs: Option<[CpuSpec; 3]>,
+    /// Whether the room is between completed games
+    pub post_game: bool,
+    /// Seats whose players have returned from the final results
+    pub returned_to_lobby: [bool; 4],
 }
 
 impl RoomView {
@@ -62,6 +66,18 @@ impl RoomView {
     /// Player count (4 or 3).
     pub fn player_count(&self) -> usize {
         self.rules.player_count()
+    }
+
+    /// Whether every seated human is available for a rematch.
+    pub fn can_start(&self) -> bool {
+        !self.post_game
+            || self
+                .seats
+                .iter()
+                .enumerate()
+                .take(self.player_count())
+                .filter(|(_, seat)| matches!(seat, SeatInfo::Human { .. }))
+                .all(|(seat, _)| self.returned_to_lobby[seat])
     }
 }
 
@@ -222,6 +238,16 @@ impl RemoteAdapter {
     pub fn leave_room(&mut self) {
         self.send(&ClientMessage::LeaveRoom);
         self.room = None;
+    }
+
+    /// Returns the connection to the room after the final results.
+    pub fn return_to_lobby(&mut self) {
+        self.send(&ClientMessage::ReturnToLobby);
+        self.game_started = false;
+        self.game_over = false;
+        self.ready_sent = false;
+        self.events.clear();
+        self.turn_deadline = None;
     }
 
     /// The current connection state.
@@ -401,6 +427,8 @@ impl RemoteAdapter {
                 rules,
                 length,
                 cpu_configs,
+                post_game,
+                returned_to_lobby,
             } => {
                 self.room_code = Some(code.clone());
                 // Pull the humans' connection states from the seats.
@@ -418,11 +446,14 @@ impl RemoteAdapter {
                     rules,
                     length,
                     cpu_configs,
+                    post_game,
+                    returned_to_lobby,
                 });
             }
             ServerMessage::Event(event) => {
                 if matches!(event, ServerEvent::GameStarted { .. }) {
                     self.game_started = true;
+                    self.game_over = false;
                     // A new hand begins; the next-hand ack may be
                     // sent again.
                     self.ready_sent = false;
@@ -439,6 +470,7 @@ impl RemoteAdapter {
                 for event in events {
                     if matches!(event, ServerEvent::GameStarted { .. }) {
                         self.game_started = true;
+                        self.game_over = false;
                         self.ready_sent = false;
                     }
                     self.events.push(event);
@@ -594,6 +626,7 @@ pub fn error_code_message(code: ErrorCode, lang: Lang) -> &'static str {
             ErrorCode::NotHost => "ホストのみ操作できます",
             ErrorCode::NotInRoom => "ルームに参加していません",
             ErrorCode::GameInProgress => "対局中のため参加できません",
+            ErrorCode::PlayersNotReady => "結果を確認中のプレイヤーがいます",
             ErrorCode::InvalidAction => "無効な操作です",
             ErrorCode::BadMessage => "不正なメッセージです",
             ErrorCode::RateLimited => "操作が頻繁すぎます。しばらく待ってください",
@@ -605,6 +638,7 @@ pub fn error_code_message(code: ErrorCode, lang: Lang) -> &'static str {
             ErrorCode::NotHost => "Only the host can do that",
             ErrorCode::NotInRoom => "You are not in a room",
             ErrorCode::GameInProgress => "Cannot join: a game is in progress",
+            ErrorCode::PlayersNotReady => "A player is still reviewing the results",
             ErrorCode::InvalidAction => "Invalid action",
             ErrorCode::BadMessage => "Malformed message",
             ErrorCode::RateLimited => "Too many actions; please wait a moment",
@@ -720,6 +754,8 @@ mod tests {
             rules: Settings::new(),
             length: GameLength::EastOnly,
             cpu_configs: None,
+            post_game: false,
+            returned_to_lobby: [false; 4],
         }
     }
 
@@ -815,6 +851,8 @@ mod tests {
             rules: Settings::new(),
             length: GameLength::Hanchan,
             cpu_configs: None,
+            post_game: false,
+            returned_to_lobby: [false; 4],
         };
         handle.push_msg(&msg);
         adapter.tick();
@@ -904,6 +942,8 @@ mod tests {
             rules: Settings::new(),
             length: GameLength::EastOnly,
             cpu_configs: Some(specs),
+            post_game: false,
+            returned_to_lobby: [false; 4],
         };
         handle.push_msg(&msg);
         adapter.tick();
@@ -1138,6 +1178,81 @@ mod tests {
         });
         adapter.tick();
         assert!(adapter.is_game_over());
+    }
+
+    #[test]
+    fn test_return_to_lobby_sends_intent_and_resets_game_flags() {
+        let (mut adapter, handle) = create_adapter();
+        handle.push_msg(&ServerMessage::Event(game_started_event()));
+        handle.push_msg(&ServerMessage::GameOver {
+            final_scores: [30000, 25000, 25000, 20000],
+        });
+        adapter.tick();
+        assert!(adapter.game_started());
+        assert!(adapter.is_game_over());
+
+        adapter.return_to_lobby();
+
+        assert!(!adapter.game_started());
+        assert!(!adapter.is_game_over());
+        assert!(matches!(
+            handle.sent().last(),
+            Some(ClientMessage::ReturnToLobby)
+        ));
+    }
+
+    #[test]
+    fn test_post_game_room_waits_for_every_seated_human() {
+        let (mut adapter, handle) = create_adapter();
+        handle.push_msg(&ServerMessage::RoomState {
+            code: "ABC234".to_string(),
+            seats: [
+                SeatInfo::Human {
+                    name: "Host".to_string(),
+                    connected: true,
+                },
+                SeatInfo::Human {
+                    name: "Guest".to_string(),
+                    connected: true,
+                },
+                SeatInfo::Empty,
+                SeatInfo::Empty,
+            ],
+            host_seat: 0,
+            your_seat: 0,
+            rules: Settings::new(),
+            length: GameLength::EastOnly,
+            cpu_configs: None,
+            post_game: true,
+            returned_to_lobby: [true, false, false, false],
+        });
+        adapter.tick();
+        assert!(!adapter.room().expect("room").can_start());
+
+        handle.push_msg(&ServerMessage::RoomState {
+            code: "ABC234".to_string(),
+            seats: [
+                SeatInfo::Human {
+                    name: "Host".to_string(),
+                    connected: true,
+                },
+                SeatInfo::Human {
+                    name: "Guest".to_string(),
+                    connected: true,
+                },
+                SeatInfo::Empty,
+                SeatInfo::Empty,
+            ],
+            host_seat: 0,
+            your_seat: 0,
+            rules: Settings::new(),
+            length: GameLength::EastOnly,
+            cpu_configs: None,
+            post_game: true,
+            returned_to_lobby: [true, true, false, false],
+        });
+        adapter.tick();
+        assert!(adapter.room().expect("room").can_start());
     }
 
     #[test]

--- a/crates/mahjong-client/src/game/mod.rs
+++ b/crates/mahjong-client/src/game/mod.rs
@@ -286,6 +286,9 @@ pub struct GameState {
     pub turn_player: Option<Wind>,
     /// Game phase
     pub phase: GamePhase,
+    /// Origin of the active match; retained through the final-results
+    /// screen so its actions can differ between local and online play.
+    pub match_kind: Option<MatchKind>,
     /// Available calls
     pub available_calls: Vec<AvailableCall>,
     /// The tile the calls are on
@@ -373,6 +376,13 @@ pub enum MenuOrigin {
     Online,
 }
 
+/// Transport context of the active match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchKind {
+    Local,
+    Online,
+}
+
 /// Game phase.
 #[derive(Debug, Clone, PartialEq)]
 pub enum GamePhase {
@@ -433,6 +443,7 @@ impl GameState {
             is_my_turn: false,
             turn_player: None,
             phase: GamePhase::TopMenu,
+            match_kind: None,
             available_calls: Vec::new(),
             call_target_tile: None,
             call_discarder: None,
@@ -488,6 +499,20 @@ impl GameState {
             clock: 0.0,
             lang: crate::persistence::load_lang().unwrap_or(Lang::Ja),
         }
+    }
+
+    /// Creates a clean match state while retaining the user's menu and
+    /// room preferences for the next navigation target.
+    pub fn fresh_for_navigation(&self, phase: GamePhase) -> Self {
+        let mut next = Self::new();
+        next.lang = self.lang;
+        next.setup_state = self.setup_state.clone();
+        next.online_state = self.online_state.clone();
+        next.online_state.turn_remaining = None;
+        next.online_state.status_line = None;
+        next.online_state.status_is_error = false;
+        next.phase = phase;
+        next
     }
 
     /// Whether this is a three-player game.

--- a/crates/mahjong-client/src/game/setup.rs
+++ b/crates/mahjong-client/src/game/setup.rs
@@ -357,6 +357,11 @@ pub struct RoomViewUi {
     pub is_host: bool,
     /// The room's game mode
     pub mode: GameMode,
+    /// Whether this lobby follows a completed game
+    pub post_game: bool,
+    /// Whether the host can start without interrupting another player's
+    /// final-results screen
+    pub can_start: bool,
 }
 
 /// State of the pre-game setup screen.
@@ -444,5 +449,22 @@ impl SetupState {
     pub fn build_cpu_specs(&self) -> [CpuSpec; 3] {
         self.build_configs()
             .map(|config| CpuSpec::from_config(&config))
+    }
+
+    /// Loads the server's host-relative CPU choices after host migration.
+    pub fn apply_cpu_specs(&mut self, specs: [CpuSpec; 3]) {
+        for (index, spec) in specs.into_iter().enumerate() {
+            self.cpu_levels[index] = match spec.level {
+                CpuLevel::Weak => 0,
+                CpuLevel::Normal => 1,
+                CpuLevel::Strong => 2,
+            };
+            self.cpu_personalities[index] = match spec.personality {
+                CpuPersonality::Balanced => 0,
+                CpuPersonality::Speedy => 1,
+                CpuPersonality::HighValue => 2,
+                CpuPersonality::Defensive => 3,
+            };
+        }
     }
 }

--- a/crates/mahjong-client/src/game/tests.rs
+++ b/crates/mahjong-client/src/game/tests.rs
@@ -1,6 +1,47 @@
 //! Unit tests for the game state.
 
 use super::*;
+
+#[test]
+fn fresh_navigation_state_keeps_preferences_and_resets_match_data() {
+    let mut state = GameState::new();
+    state.setup_state.mode = GameMode::ThreeHanchan;
+    state.setup_state.cpu_levels = [2, 0, 1];
+    state.online_state.name_input = "Player".to_string();
+    state.scores = [40000, 30000, 20000, 10000];
+    state.match_kind = Some(MatchKind::Local);
+
+    let next = state.fresh_for_navigation(GamePhase::ModeSelect(MenuOrigin::Local));
+
+    assert_eq!(next.setup_state.mode, GameMode::ThreeHanchan);
+    assert_eq!(next.setup_state.cpu_levels, [2, 0, 1]);
+    assert_eq!(next.online_state.name_input, "Player");
+    assert_eq!(next.scores, [25000; 4]);
+    assert_eq!(next.match_kind, None);
+    assert_eq!(next.phase, GamePhase::ModeSelect(MenuOrigin::Local));
+}
+
+#[test]
+fn cpu_specs_can_be_inherited_by_a_migrated_host() {
+    let mut setup = SetupState::new();
+    setup.apply_cpu_specs([
+        CpuSpec {
+            level: CpuLevel::Strong,
+            personality: CpuPersonality::Defensive,
+        },
+        CpuSpec {
+            level: CpuLevel::Weak,
+            personality: CpuPersonality::Speedy,
+        },
+        CpuSpec {
+            level: CpuLevel::Normal,
+            personality: CpuPersonality::HighValue,
+        },
+    ]);
+
+    assert_eq!(setup.cpu_levels, [2, 0, 1]);
+    assert_eq!(setup.cpu_personalities, [3, 1, 2]);
+}
 use mahjong_core::scoring::score::{DoraLabel, ScoreItem, ScoreRank};
 use mahjong_core::settings::{AllLastRule, BankruptcyRule, Settings};
 use mahjong_core::winning_hand::name::Kind;

--- a/crates/mahjong-client/src/i18n/mod.rs
+++ b/crates/mahjong-client/src/i18n/mod.rs
@@ -457,8 +457,16 @@ pub enum Key {
     Noten,
     /// Game over
     GameOver,
-    /// Play again
-    PlayAgain,
+    /// Start a fresh local match with the same settings
+    SameSettingsRematch,
+    /// Return to match setup
+    ChangeMatchSettings,
+    /// Return to the current online room
+    ReturnToRoom,
+    /// Leave the room for the online menu
+    OnlineMenu,
+    /// Leave the results for the title screen
+    BackToTitle,
     /// Win button
     Win,
     /// Waiting-for-others hint
@@ -515,6 +523,10 @@ pub enum Key {
     EmptySeatsCpu,
     /// Waiting-for-host caption
     WaitingHost,
+    /// Start another game in the same room
+    StartRematch,
+    /// Waiting for players who are still reading the final results
+    WaitingResultReview,
     /// Leave button
     Leave,
     /// "You" seat marker
@@ -523,6 +535,8 @@ pub enum Key {
     MarkerHost,
     /// "Offline" seat marker
     MarkerDisconnected,
+    /// "Reviewing results" seat marker
+    MarkerReviewingResults,
     /// Connecting caption
     Connecting,
     /// Disconnected caption
@@ -907,9 +921,25 @@ impl Key {
                 Lang::Ja => "ゲーム終了",
                 Lang::En => "Game Over",
             },
-            Key::PlayAgain => match lang {
-                Lang::Ja => "もう一度",
-                Lang::En => "Play Again",
+            Key::SameSettingsRematch => match lang {
+                Lang::Ja => "同じ設定で再戦",
+                Lang::En => "Rematch with Same Settings",
+            },
+            Key::ChangeMatchSettings => match lang {
+                Lang::Ja => "対局設定を変更",
+                Lang::En => "Change Match Settings",
+            },
+            Key::ReturnToRoom => match lang {
+                Lang::Ja => "ルームに戻る",
+                Lang::En => "Return to Room",
+            },
+            Key::OnlineMenu => match lang {
+                Lang::Ja => "オンラインメニューへ",
+                Lang::En => "Online Menu",
+            },
+            Key::BackToTitle => match lang {
+                Lang::Ja => "タイトルへ",
+                Lang::En => "Title Screen",
             },
             Key::Win => match lang {
                 Lang::Ja => "和了",
@@ -1025,6 +1055,14 @@ impl Key {
                 Lang::Ja => "ホストの開始を待っています...",
                 Lang::En => "Waiting for the host to start...",
             },
+            Key::StartRematch => match lang {
+                Lang::Ja => "再戦を開始",
+                Lang::En => "Start Rematch",
+            },
+            Key::WaitingResultReview => match lang {
+                Lang::Ja => "結果を確認中のプレイヤーを待っています...",
+                Lang::En => "Waiting for players reviewing the results...",
+            },
             Key::Leave => match lang {
                 Lang::Ja => "退出",
                 Lang::En => "Leave",
@@ -1040,6 +1078,10 @@ impl Key {
             Key::MarkerDisconnected => match lang {
                 Lang::Ja => "（切断中）",
                 Lang::En => " (offline)",
+            },
+            Key::MarkerReviewingResults => match lang {
+                Lang::Ja => "（結果確認中）",
+                Lang::En => " (reviewing results)",
             },
             Key::Connecting => match lang {
                 Lang::Ja => "サーバに接続中...",

--- a/crates/mahjong-client/src/main.rs
+++ b/crates/mahjong-client/src/main.rs
@@ -21,13 +21,16 @@ mod transport;
 #[cfg(target_arch = "wasm32")]
 mod wasm_rng;
 
-use adapter::{ConnStatus, GameAdapter, LocalAdapter, RemoteAdapter, RoomView, error_code_message};
-use game::{GameMode, GamePhase, GameState, MenuOrigin, PlayerLabel, RoomViewUi};
+use adapter::{
+    ActiveAdapter, ConnStatus, GameAdapter, LocalAdapter, RemoteAdapter, RoomView,
+    error_code_message,
+};
+use game::{GameMode, GamePhase, GameState, MatchKind, MenuOrigin, PlayerLabel, RoomViewUi};
 use mahjong_core::settings::Lang;
 use mahjong_server::protocol::net::SeatInfo;
 use renderer::{
-    ModeSelectAction, OnlineLobbyAction, OnlineMenuAction, RuleSettingsAction, SetupAction,
-    TileTextures, TopMenuAction,
+    GameOverAction, ModeSelectAction, OnlineLobbyAction, OnlineMenuAction, RuleSettingsAction,
+    SetupAction, TileTextures, TopMenuAction,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -103,13 +106,13 @@ fn build_seat_labels(room: &RoomView, lang: Lang) -> [String; 4] {
         if i >= room.player_count() {
             return String::new();
         }
-        let who = match &room.seats[i] {
+        let mut who = match &room.seats[i] {
             SeatInfo::Empty => match room.cpu_configs {
                 // Attach the CPU config that would fill the seat, using
-                // the server's config_for_seat rule (seats 1-3 map to
-                // configs[0..3]).
+                // the server's host-relative config_for_seat rule.
                 Some(configs) => {
-                    let spec = configs[i.saturating_sub(1).min(2)];
+                    let relative = (i + room.player_count() - room.host_seat) % room.player_count();
+                    let spec = configs[relative.saturating_sub(1).min(2)];
                     tr.empty_seat_cpu_label(spec.level, spec.personality)
                 }
                 None => tr.get(i18n::Key::EmptySeat).to_string(),
@@ -123,6 +126,12 @@ fn build_seat_labels(room: &RoomView, lang: Lang) -> [String; 4] {
                 }
             }
         };
+        if room.post_game
+            && matches!(&room.seats[i], SeatInfo::Human { .. })
+            && !room.returned_to_lobby[i]
+        {
+            who.push_str(tr.get(i18n::Key::MarkerReviewingResults));
+        }
         let mut marks = String::new();
         if i == room.your_seat {
             marks.push_str(tr.get(i18n::Key::MarkerYou));
@@ -155,11 +164,27 @@ fn build_online_player_labels(room: &RoomView) -> [PlayerLabel; 4] {
 /// Copies the remote adapter's state for UI display.
 fn sync_online_ui(remote: &mut RemoteAdapter, state: &mut GameState) {
     let lang = state.lang;
+    let was_host = state
+        .online_state
+        .room
+        .as_ref()
+        .is_some_and(|room| room.is_host);
+    if let Some(room) = remote.room()
+        && room.is_host()
+        && !was_host
+        && let Some(specs) = room.cpu_configs
+    {
+        // A migrated host inherits the room's choices instead of silently
+        // replacing them with that client's unrelated local defaults.
+        state.setup_state.apply_cpu_specs(specs);
+    }
     state.online_state.room = remote.room().map(|room| RoomViewUi {
         code: room.code.clone(),
         seat_labels: build_seat_labels(room, lang),
         is_host: room.is_host(),
         mode: GameMode::from_parts(room.three_player(), room.length),
+        post_game: room.post_game,
+        can_start: room.can_start(),
     });
 
     if let Some(err) = remote.take_error() {
@@ -195,6 +220,33 @@ fn sync_online_ui(remote: &mut RemoteAdapter, state: &mut GameState) {
     }
 }
 
+/// Builds a completely new local driver while retaining the selected
+/// match and CPU settings in `state`.
+fn start_local_match(
+    state: &mut GameState,
+    mut configs: [mahjong_server::cpu::client::CpuConfig; 3],
+) -> ActiveAdapter {
+    let settings = state.setup_state.build_game_settings();
+    // A rematch is a fresh game, so CPU seats and the starting dealer
+    // receive the same randomization as the initial start.
+    let cpu_count = settings.rules.player_count() - 1;
+    mahjong_server::cpu::client::shuffle_cpu_configs(&mut configs[..cpu_count]);
+    state.set_local_players(&configs);
+    state.match_kind = Some(MatchKind::Local);
+
+    let mut adapter = LocalAdapter::with_settings(settings, configs);
+    adapter.start_game();
+    for event in adapter.poll_events() {
+        state.queue_event(event);
+    }
+    state.process_events(get_time());
+    ActiveAdapter::Local(Box::new(adapter))
+}
+
+fn take_remote_adapter(adapter: &mut Option<ActiveAdapter>) -> Option<RemoteAdapter> {
+    adapter.take().and_then(ActiveAdapter::into_remote)
+}
+
 #[macroquad::main(window_conf)]
 async fn main() {
     #[cfg(target_arch = "wasm32")]
@@ -228,7 +280,7 @@ async fn main() {
     renderer::prewarm_fonts(font.as_ref(), &mut loading_screen).await;
 
     // The in-game adapter (local or remote).
-    let mut adapter: Option<Box<dyn GameAdapter>> = None;
+    let mut adapter: Option<ActiveAdapter> = None;
     // The lobby-stage remote connection, handed to `adapter` at
     // game start.
     let mut online: Option<RemoteAdapter> = None;
@@ -284,7 +336,10 @@ async fn main() {
                     let your_seat = room.your_seat;
                     game_state.set_online_players(&labels, your_seat);
                 }
-                adapter = Some(Box::new(online.take().expect("checked above")));
+                game_state.match_kind = Some(MatchKind::Online);
+                adapter = Some(ActiveAdapter::Remote(Box::new(
+                    online.take().expect("checked above"),
+                )));
             }
         }
 
@@ -302,6 +357,12 @@ async fn main() {
             game_state.online_state.status_is_error = game_state.online_state.status_line.is_some();
             // Turn timer (online only).
             game_state.online_state.turn_remaining = adp.turn_remaining_secs();
+            if adp.is_game_over() && game_state.phase == GamePhase::RoundResult {
+                // The final result has already been acknowledged; waiting
+                // for another click would make the visible "Next" action
+                // appear to do nothing on network latency or local finish.
+                game_state.phase = GamePhase::GameOver;
+            }
         }
 
         match game_state.phase {
@@ -365,26 +426,8 @@ async fn main() {
                     renderer::handle_setup_input(&mut game_state, font.as_ref(), origin)
                 {
                     match action {
-                        SetupAction::StartLocal(mut configs) => {
-                            let settings = game_state.setup_state.build_game_settings();
-                            // Shuffle the participating CPUs' seats
-                            // (GameDriver::start_game randomizes the
-                            // dealer). Must happen before
-                            // set_local_players so labels stay aligned
-                            // with seats.
-                            let cpu_count = settings.rules.player_count() - 1;
-                            mahjong_server::cpu::client::shuffle_cpu_configs(
-                                &mut configs[..cpu_count],
-                            );
-                            game_state.set_local_players(&configs);
-                            let mut new_adapter = LocalAdapter::with_settings(settings, configs);
-                            new_adapter.start_game();
-                            let events = new_adapter.poll_events();
-                            for event in events {
-                                game_state.queue_event(event);
-                            }
-                            game_state.process_events(get_time());
-                            adapter = Some(Box::new(new_adapter));
+                        SetupAction::StartLocal(configs) => {
+                            adapter = Some(start_local_match(&mut game_state, configs));
                         }
                         SetupAction::ApplyOnline => {
                             // Send the CPU configs so everyone's lobby
@@ -493,16 +536,64 @@ async fn main() {
                             game_state.phase = GamePhase::GameOver;
                         } else {
                             adp.request_next_round();
+                            if adp.is_game_over() {
+                                game_state.phase = GamePhase::GameOver;
+                            }
                         }
                     }
                 }
             }
 
             GamePhase::GameOver => {
-                if is_mouse_button_pressed(MouseButton::Left) {
-                    game_state = GameState::new();
-                    adapter = None;
-                    online = None;
+                if let Some(action) = renderer::handle_game_over_input(&game_state) {
+                    match action {
+                        GameOverAction::RematchLocal => {
+                            let configs = game_state.setup_state.build_configs();
+                            let mut next =
+                                game_state.fresh_for_navigation(GamePhase::WaitingForStart);
+                            next.online_state.room = None;
+                            game_state = next;
+                            adapter = Some(start_local_match(&mut game_state, configs));
+                            online = None;
+                        }
+                        GameOverAction::ChangeSettings => {
+                            game_state = game_state
+                                .fresh_for_navigation(GamePhase::ModeSelect(MenuOrigin::Local));
+                            game_state.online_state.room = None;
+                            adapter = None;
+                            online = None;
+                        }
+                        GameOverAction::ReturnToRoom => {
+                            if let Some(mut remote) = take_remote_adapter(&mut adapter) {
+                                remote.return_to_lobby();
+                                game_state =
+                                    game_state.fresh_for_navigation(GamePhase::OnlineLobby);
+                                online = Some(remote);
+                            } else {
+                                game_state = game_state.fresh_for_navigation(GamePhase::OnlineMenu);
+                                game_state.online_state.room = None;
+                                online = None;
+                            }
+                        }
+                        GameOverAction::OnlineMenu => {
+                            if let Some(mut remote) = take_remote_adapter(&mut adapter) {
+                                remote.leave_room();
+                            }
+                            game_state = game_state.fresh_for_navigation(GamePhase::OnlineMenu);
+                            game_state.online_state.room = None;
+                            online = None;
+                        }
+                        GameOverAction::Title => {
+                            if let Some(mut remote) = take_remote_adapter(&mut adapter) {
+                                remote.leave_room();
+                            } else {
+                                adapter = None;
+                            }
+                            game_state = game_state.fresh_for_navigation(GamePhase::TopMenu);
+                            game_state.online_state.room = None;
+                            online = None;
+                        }
+                    }
                 }
             }
 

--- a/crates/mahjong-client/src/renderer/mod.rs
+++ b/crates/mahjong-client/src/renderer/mod.rs
@@ -25,6 +25,7 @@ pub use online::{
 };
 pub use overlay::OverlayClick;
 use result::*;
+pub use result::{GameOverAction, handle_game_over_input};
 use setup::*;
 use tiles::*;
 

--- a/crates/mahjong-client/src/renderer/online.rs
+++ b/crates/mahjong-client/src/renderer/online.rs
@@ -182,6 +182,34 @@ fn draw_button(font: Option<&Font>, rect: &Rect2, label: &str, accent: bool) {
     }
 }
 
+fn draw_disabled_button(font: Option<&Font>, rect: &Rect2, label: &str) {
+    theme::draw_rounded_rect(
+        rect.x,
+        rect.y,
+        rect.w,
+        rect.h,
+        8.0,
+        theme::rgba(0xffffff, 0.025),
+    );
+    theme::draw_rounded_rect_lines(
+        rect.x,
+        rect.y,
+        rect.w,
+        rect.h,
+        8.0,
+        1.0,
+        theme::rgba(0xffffff, 0.10),
+    );
+    theme::draw_text_centered(
+        font,
+        label,
+        rect.center_x(),
+        rect.y + rect.h / 2.0 + 7.0,
+        theme::font_size::SUBHEADING,
+        theme::TEXT_DIM,
+    );
+}
+
 fn draw_input_box(font: Option<&Font>, rect: &Rect2, text: &str, focused: bool) {
     theme::draw_rounded_rect(
         rect.x,
@@ -404,11 +432,33 @@ pub fn draw_online_lobby(state: &GameState, font: Option<&Font>) {
             theme::TEXT_DIM,
         );
         draw_button(font, &CPU_SETUP_BTN, tr.get(Key::CpuSetupTitle), false);
-        draw_button(font, &START_BTN, tr.get(Key::StartGame), true);
+        let start_label = if room.post_game {
+            tr.get(Key::StartRematch)
+        } else {
+            tr.get(Key::StartGame)
+        };
+        if room.can_start {
+            draw_button(font, &START_BTN, start_label, true);
+        } else {
+            draw_disabled_button(font, &START_BTN, start_label);
+            theme::draw_text_centered(
+                font,
+                tr.get(Key::WaitingResultReview),
+                cx,
+                START_BTN.y + START_BTN.h + 20.0,
+                theme::font_size::SMALL,
+                theme::TEXT_DIM,
+            );
+        }
     } else {
+        let waiting = if room.post_game && !room.can_start {
+            tr.get(Key::WaitingResultReview)
+        } else {
+            tr.get(Key::WaitingHost)
+        };
         theme::draw_text_centered(
             font,
-            tr.get(Key::WaitingHost),
+            waiting,
             cx,
             START_BTN.y + 34.0,
             theme::font_size::BODY_LARGE,
@@ -427,15 +477,13 @@ pub fn handle_online_lobby_input(state: &GameState) -> Option<OnlineLobbyAction>
     }
     let (mx, my) = super::mouse_position_design();
 
-    let is_host = state
-        .online_state
-        .room
-        .as_ref()
-        .is_some_and(|room| room.is_host);
+    let room = state.online_state.room.as_ref();
+    let is_host = room.is_some_and(|room| room.is_host);
+    let can_start = room.is_some_and(|room| room.can_start);
     if is_host && CPU_SETUP_BTN.contains(mx, my) {
         return Some(OnlineLobbyAction::OpenCpuSettings);
     }
-    if is_host && START_BTN.contains(mx, my) {
+    if is_host && can_start && START_BTN.contains(mx, my) {
         return Some(OnlineLobbyAction::StartGame);
     }
     if LEAVE_BTN.contains(mx, my) {

--- a/crates/mahjong-client/src/renderer/result.rs
+++ b/crates/mahjong-client/src/renderer/result.rs
@@ -1,6 +1,7 @@
 //! Result and game-over overlay rendering.
 
 use super::*;
+use crate::game::MatchKind;
 
 const YAKU_FONT_SIZE: u16 = theme::font_size::LABEL;
 pub(super) const YAKU_ROW_HEIGHT: f32 = 22.0;
@@ -20,6 +21,87 @@ const RESULT_INDICATOR_GAP: f32 = 2.0;
 const RESULT_INDICATOR_LABEL_GAP: f32 = 6.0;
 const RESULT_INDICATOR_SECTION_GAP: f32 = 18.0;
 const WIN_PANEL_BASE_HEIGHT: f32 = 340.0;
+const GAME_OVER_PANEL_W: f32 = 620.0;
+const GAME_OVER_PANEL_H: f32 = 520.0;
+
+#[derive(Debug, Clone, Copy)]
+struct GameOverButton {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+}
+
+impl GameOverButton {
+    fn contains(self, x: f32, y: f32) -> bool {
+        x >= self.x && x < self.x + self.w && y >= self.y && y < self.y + self.h
+    }
+
+    fn center_x(self) -> f32 {
+        self.x + self.w / 2.0
+    }
+}
+
+const GAME_OVER_PRIMARY: GameOverButton = GameOverButton {
+    x: 470.0,
+    y: 472.0,
+    w: 340.0,
+    h: 52.0,
+};
+const GAME_OVER_SECONDARY: GameOverButton = GameOverButton {
+    x: 470.0,
+    y: 538.0,
+    w: 340.0,
+    h: 46.0,
+};
+const GAME_OVER_TITLE: GameOverButton = GameOverButton {
+    x: 540.0,
+    y: 588.0,
+    w: 200.0,
+    h: 28.0,
+};
+
+/// Action selected on the final-results screen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GameOverAction {
+    RematchLocal,
+    ChangeSettings,
+    ReturnToRoom,
+    OnlineMenu,
+    Title,
+}
+
+fn game_over_action_at(state: &GameState, x: f32, y: f32) -> Option<GameOverAction> {
+    let online = state.match_kind == Some(MatchKind::Online);
+    if GAME_OVER_PRIMARY.contains(x, y) {
+        return Some(if online {
+            GameOverAction::ReturnToRoom
+        } else {
+            GameOverAction::RematchLocal
+        });
+    }
+    if GAME_OVER_SECONDARY.contains(x, y) {
+        return Some(if online {
+            GameOverAction::OnlineMenu
+        } else {
+            GameOverAction::ChangeSettings
+        });
+    }
+    if GAME_OVER_TITLE.contains(x, y) {
+        return Some(GameOverAction::Title);
+    }
+    None
+}
+
+/// Handles explicit final-results buttons; clicks elsewhere preserve the
+/// standings for review.
+pub fn handle_game_over_input(state: &GameState) -> Option<GameOverAction> {
+    if !is_mouse_button_pressed(MouseButton::Left) {
+        return None;
+    }
+    let (x, y) = super::mouse_position_design();
+    game_over_action_at(state, x, y)
+}
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct WinHandLayout {
@@ -501,8 +583,8 @@ pub(super) fn draw_draw_panel(state: &GameState, font: Option<&Font>) {
 pub(super) fn draw_game_over(state: &GameState, font: Option<&Font>) {
     draw_setup_background();
 
-    let panel_w = 620.0;
-    let panel_h = 420.0;
+    let panel_w = GAME_OVER_PANEL_W;
+    let panel_h = GAME_OVER_PANEL_H;
     let panel_x = (DESIGN_W - panel_w) / 2.0;
     let panel_y = (DESIGN_H - panel_h) / 2.0;
     theme::draw_panel(
@@ -602,15 +684,17 @@ pub(super) fn draw_game_over(state: &GameState, font: Option<&Font>) {
         ry += row_h + row_gap;
     }
 
-    let btn_w = 200.0;
-    let btn_h = 50.0;
-    let btn_x = cx - btn_w / 2.0;
-    let btn_y = panel_y + panel_h - btn_h - 24.0;
+    let online = state.match_kind == Some(MatchKind::Online);
+    let primary_label = if online {
+        tr.get(Key::ReturnToRoom)
+    } else {
+        tr.get(Key::SameSettingsRematch)
+    };
     theme::draw_gradient_button(
-        btn_x,
-        btn_y,
-        btn_w,
-        btn_h,
+        GAME_OVER_PRIMARY.x,
+        GAME_OVER_PRIMARY.y,
+        GAME_OVER_PRIMARY.w,
+        GAME_OVER_PRIMARY.h,
         8.0,
         theme::rgb_pub(0x9a7a1a),
         theme::rgb_pub(0x6a5210),
@@ -619,10 +703,83 @@ pub(super) fn draw_game_over(state: &GameState, font: Option<&Font>) {
     );
     theme::draw_text_centered(
         font,
-        tr.get(Key::PlayAgain),
-        cx,
-        btn_y + 31.0,
+        primary_label,
+        GAME_OVER_PRIMARY.center_x(),
+        GAME_OVER_PRIMARY.y + 33.0,
         theme::font_size::BODY_LARGE,
         theme::GOLD_LT,
     );
+
+    theme::draw_rounded_rect(
+        GAME_OVER_SECONDARY.x,
+        GAME_OVER_SECONDARY.y,
+        GAME_OVER_SECONDARY.w,
+        GAME_OVER_SECONDARY.h,
+        8.0,
+        theme::rgba(0xffffff, 0.05),
+    );
+    theme::draw_rounded_rect_lines(
+        GAME_OVER_SECONDARY.x,
+        GAME_OVER_SECONDARY.y,
+        GAME_OVER_SECONDARY.w,
+        GAME_OVER_SECONDARY.h,
+        8.0,
+        1.0,
+        theme::rgba(0xc8a227, 0.3),
+    );
+    let secondary_label = if online {
+        tr.get(Key::OnlineMenu)
+    } else {
+        tr.get(Key::ChangeMatchSettings)
+    };
+    theme::draw_text_centered(
+        font,
+        secondary_label,
+        GAME_OVER_SECONDARY.center_x(),
+        GAME_OVER_SECONDARY.y + 29.0,
+        theme::font_size::BODY,
+        theme::TEXT,
+    );
+
+    theme::draw_text_centered(
+        font,
+        tr.get(Key::BackToTitle),
+        GAME_OVER_TITLE.center_x(),
+        GAME_OVER_TITLE.y + 22.0,
+        theme::font_size::BODY,
+        theme::TEXT_DIM,
+    );
+}
+
+#[cfg(test)]
+mod game_over_tests {
+    use super::*;
+
+    #[test]
+    fn game_over_actions_depend_on_match_kind_and_ignore_background() {
+        let mut state = GameState::new();
+        assert_eq!(
+            game_over_action_at(&state, 640.0, 490.0),
+            Some(GameOverAction::RematchLocal)
+        );
+        assert_eq!(
+            game_over_action_at(&state, 640.0, 550.0),
+            Some(GameOverAction::ChangeSettings)
+        );
+        assert_eq!(game_over_action_at(&state, 100.0, 100.0), None);
+
+        state.match_kind = Some(MatchKind::Online);
+        assert_eq!(
+            game_over_action_at(&state, 640.0, 490.0),
+            Some(GameOverAction::ReturnToRoom)
+        );
+        assert_eq!(
+            game_over_action_at(&state, 640.0, 550.0),
+            Some(GameOverAction::OnlineMenu)
+        );
+        assert_eq!(
+            game_over_action_at(&state, 640.0, 600.0),
+            Some(GameOverAction::Title)
+        );
+    }
 }

--- a/crates/mahjong-net-server/src/room.rs
+++ b/crates/mahjong-net-server/src/room.rs
@@ -126,13 +126,17 @@ struct Room {
     settings: GameSettings,
     config: RoomConfig,
     seats: [Option<Seat>; 4],
+    /// The seat currently allowed to configure and start the room.
+    host_seat: usize,
     driver: Option<GameDriver>,
     /// Whether the room awaits result-screen confirmations
     awaiting_ready: bool,
     /// Per-seat next-hand confirmations
     ready: [bool; 4],
-    /// Whether GameOver has been sent
-    game_over_sent: bool,
+    /// Whether the completed game is waiting in the rematch lobby.
+    post_game: bool,
+    /// Players who have closed the final-results screen.
+    returned_to_lobby: [bool; 4],
     /// Deadline for auto-advancing to the next hand
     ready_deadline: Option<Instant>,
     /// Deadline for discarding the room
@@ -158,10 +162,16 @@ struct Room {
 
 /// The CPU config for a seat.
 ///
-/// Seats 1-3 (the host's right, across, left) map to `configs[0..3]` in
-/// order; seat 0 (the host) reuses `configs[0]` for its shadow CPU.
-fn config_for_seat(configs: &[CpuConfig; 3], seat: usize) -> CpuConfig {
-    let idx = seat.saturating_sub(1).min(2);
+/// Seats to the host's right, across, and left map to `configs[0..3]`;
+/// the host reuses `configs[0]` for its shadow CPU.
+fn config_for_seat(
+    configs: &[CpuConfig; 3],
+    seat: usize,
+    host_seat: usize,
+    player_count: usize,
+) -> CpuConfig {
+    let relative = (seat + player_count - host_seat) % player_count;
+    let idx = relative.saturating_sub(1).min(2);
     configs[idx].clone()
 }
 
@@ -178,10 +188,12 @@ pub async fn run_room(
         settings,
         config,
         seats: [None, None, None, None],
+        host_seat: HOST_SEAT,
         driver: None,
         awaiting_ready: false,
         ready: [false; 4],
-        game_over_sent: false,
+        post_game: false,
+        returned_to_lobby: [false; 4],
         ready_deadline: None,
         close_deadline: Some(Instant::now() + config.lobby_timeout),
         action_deadline: None,
@@ -242,9 +254,10 @@ fn deadline_or_far(deadline: Option<Instant>) -> Instant {
 }
 
 impl Room {
-    /// Whether the game has started.
-    fn game_started(&self) -> bool {
-        self.driver.is_some()
+    /// Whether a game is actively running rather than waiting in either
+    /// lobby state.
+    fn game_in_progress(&self) -> bool {
+        self.driver.is_some() && !self.post_game
     }
 
     /// Player count (4 or 3; the three-player seat 3 stays empty).
@@ -312,7 +325,7 @@ impl Room {
     }
 
     /// Handles a join or reconnect: mid-game a matching token reclaims
-    /// its disconnected seat; before the game a new joiner takes an
+    /// its disconnected seat; either lobby accepts a new player in an
     /// empty seat.
     fn try_join(
         &mut self,
@@ -320,7 +333,7 @@ impl Room {
         token: String,
         tx: mpsc::Sender<ServerMessage>,
     ) -> Result<JoinOutcome, ErrorCode> {
-        if self.game_started() {
+        if self.game_in_progress() {
             let seat = self
                 .seats
                 .iter()
@@ -355,6 +368,11 @@ impl Room {
             conn_gen,
             history: Vec::new(),
         });
+        if self.post_game {
+            // A player joining the rematch lobby is already past the
+            // result screen and must not block the host's start button.
+            self.returned_to_lobby[seat] = true;
+        }
         tracing::info!(code = self.code, seat, "player joined");
         Ok(JoinOutcome {
             seat,
@@ -367,10 +385,7 @@ impl Room {
     fn handle_reconnect(&mut self, seat: usize) {
         // The abandonment deadline is armed only while nobody is connected;
         // keeping it would expire an active game after a successful reconnect.
-        // A finished game's deadline remains a deliberate result-screen cap.
-        if !self.game_over_sent {
-            self.close_deadline = None;
-        }
+        self.close_deadline = None;
         if let Some(driver) = self.driver.as_mut() {
             driver.set_cpu_controlled(seat, false);
         }
@@ -396,7 +411,7 @@ impl Room {
             }
             ClientMessage::StartGame { cpu_configs } => self.handle_start_game(seat, cpu_configs),
             ClientMessage::Action(action) => {
-                if !self.game_started() || self.awaiting_ready {
+                if !self.game_in_progress() || self.awaiting_ready {
                     self.send_error(seat, ErrorCode::InvalidAction, "no action expected now");
                     return;
                 }
@@ -427,6 +442,7 @@ impl Room {
                     self.advance_round();
                 }
             }
+            ClientMessage::ReturnToLobby => self.handle_return_to_lobby(seat),
             // Hello/CreateRoom/JoinRoom/LeaveRoom were handled by the
             // connection task.
             _ => {
@@ -437,11 +453,11 @@ impl Room {
 
     /// Stores the host's CPU configs and shares them with every lobby.
     fn handle_set_cpu_configs(&mut self, seat: usize, cpu_configs: [CpuSpec; 3]) {
-        if seat != HOST_SEAT {
+        if seat != self.host_seat {
             self.send_error(seat, ErrorCode::NotHost, "only the host can configure CPUs");
             return;
         }
-        if self.game_started() {
+        if self.game_in_progress() {
             self.send_error(seat, ErrorCode::GameInProgress, "game already started");
             return;
         }
@@ -450,12 +466,20 @@ impl Room {
     }
 
     fn handle_start_game(&mut self, seat: usize, cpu_configs: Option<[CpuSpec; 3]>) {
-        if seat != HOST_SEAT {
+        if seat != self.host_seat {
             self.send_error(seat, ErrorCode::NotHost, "only the host can start");
             return;
         }
-        if self.game_started() {
+        if self.game_in_progress() {
             self.send_error(seat, ErrorCode::GameInProgress, "game already started");
+            return;
+        }
+        if self.post_game && !self.all_post_game_humans_ready() {
+            self.send_error(
+                seat,
+                ErrorCode::PlayersNotReady,
+                "a player is still reviewing the final results",
+            );
             return;
         }
 
@@ -470,7 +494,7 @@ impl Room {
 
         let mut driver = GameDriver::new(self.settings.clone());
         for s in 0..self.player_count() {
-            let config = config_for_seat(&self.cpu_configs, s);
+            let config = config_for_seat(&self.cpu_configs, s, self.host_seat, self.player_count());
             if self.seats[s].is_some() {
                 // Human seats get a resident shadow CPU for instant
                 // substitution on disconnect.
@@ -482,6 +506,11 @@ impl Room {
         driver.set_cpu_action_delay(self.config.cpu_action_delay.as_secs_f64());
         driver.start_game();
         self.driver = Some(driver);
+        self.post_game = false;
+        self.returned_to_lobby = [false; 4];
+        self.awaiting_ready = false;
+        self.ready = [false; 4];
+        self.ready_deadline = None;
         // Start the clock for the CPU delay; now_secs() feeds it
         // from here on.
         self.game_clock = Some(Instant::now());
@@ -491,6 +520,49 @@ impl Room {
         tracing::info!(code = self.code, "game started");
         self.broadcast_room_state();
         self.progress_game();
+    }
+
+    /// Marks a player as available for a same-room rematch.
+    fn handle_return_to_lobby(&mut self, seat: usize) {
+        if !self.post_game {
+            self.send_error(
+                seat,
+                ErrorCode::InvalidAction,
+                "the room is not awaiting a rematch",
+            );
+            return;
+        }
+        self.returned_to_lobby[seat] = true;
+        self.close_deadline = Some(Instant::now() + self.config.lobby_timeout);
+        self.broadcast_room_state();
+    }
+
+    /// Whether every human still occupying a seat has returned from the
+    /// final-results screen.
+    fn all_post_game_humans_ready(&self) -> bool {
+        (0..self.player_count())
+            .filter(|&seat| self.seats[seat].is_some())
+            .all(|seat| self.returned_to_lobby[seat])
+    }
+
+    /// Turns mid-game disconnected seats into ordinary lobby vacancies
+    /// and preserves a host among the players who remain online.
+    fn prepare_post_game_lobby(&mut self) {
+        for seat in 0..self.player_count() {
+            if self.seats[seat]
+                .as_ref()
+                .is_some_and(|player| player.tx.is_none())
+            {
+                self.seats[seat] = None;
+            }
+        }
+        if self.seats[self.host_seat].is_none()
+            && let Some(next_host) = self.seats[..self.player_count()]
+                .iter()
+                .position(Option::is_some)
+        {
+            self.host_seat = next_host;
+        }
     }
 
     /// Delivers the last action's results, checks for hand end, and
@@ -521,7 +593,7 @@ impl Room {
     /// Whether a tick is needed for CPU progress (draws, pending
     /// delayed actions).
     fn needs_game_tick(&self) -> bool {
-        if self.awaiting_ready || self.game_over_sent {
+        if self.awaiting_ready || self.post_game {
             return false;
         }
         self.driver.as_ref().is_some_and(|d| d.needs_tick())
@@ -551,7 +623,7 @@ impl Room {
             self.clear_action_deadline();
             return;
         };
-        if self.awaiting_ready || self.game_over_sent {
+        if self.awaiting_ready || self.post_game {
             self.clear_action_deadline();
             return;
         }
@@ -654,7 +726,7 @@ impl Room {
         let Some(driver) = self.driver.as_ref() else {
             return;
         };
-        if self.awaiting_ready || self.game_over_sent {
+        if self.awaiting_ready || self.post_game {
             return;
         }
         let round_over = driver
@@ -690,10 +762,17 @@ impl Room {
         if driver.is_game_over() {
             let final_scores = driver.table().scores;
             self.broadcast(ServerMessage::GameOver { final_scores });
-            self.game_over_sent = true;
+            self.post_game = true;
+            self.returned_to_lobby = [false; 4];
+            self.prepare_post_game_lobby();
             self.clear_action_deadline();
-            // Close once everyone is gone; set the deadline as a backstop.
-            self.close_deadline = Some(Instant::now() + self.config.abandoned_timeout);
+            // The post-game room follows the same lifetime as the initial
+            // lobby, giving players time to review results before returning.
+            self.close_deadline = Some(Instant::now() + self.config.lobby_timeout);
+            self.broadcast_room_state();
+            if !self.any_connected_human() {
+                self.closing = true;
+            }
             tracing::info!(code = self.code, "game over");
         } else {
             self.progress_game();
@@ -718,11 +797,32 @@ impl Room {
 
     /// Handles a leave or disconnect.
     fn handle_departure(&mut self, seat: usize) {
+        // Post-game seats are no longer protected by CPU substitution;
+        // leaving makes room for a replacement player or a CPU next game.
+        if self.post_game {
+            let was_host = seat == self.host_seat;
+            self.seats[seat] = None;
+            self.returned_to_lobby[seat] = false;
+            tracing::info!(code = self.code, seat, "player left rematch lobby");
+            let Some(next_host) = self.seats[..self.player_count()]
+                .iter()
+                .position(Option::is_some)
+            else {
+                self.closing = true;
+                return;
+            };
+            if was_host {
+                self.host_seat = next_host;
+            }
+            self.broadcast_room_state();
+            return;
+        }
+
         // Pre-game: vacate the seat; the host leaving closes the room.
-        if !self.game_started() {
+        if !self.game_in_progress() {
             self.seats[seat] = None;
             tracing::info!(code = self.code, seat, "player left");
-            if seat == HOST_SEAT {
+            if seat == self.host_seat {
                 self.broadcast_error(ErrorCode::NotInRoom, "room closed by host");
                 self.closing = true;
                 return;
@@ -732,15 +832,6 @@ impl Room {
                 return;
             }
             self.broadcast_room_state();
-            return;
-        }
-
-        // Post-game: vacate; close once empty.
-        if self.game_over_sent {
-            self.seats[seat] = None;
-            if self.seats.iter().all(|s| s.is_none()) {
-                self.closing = true;
-            }
             return;
         }
 
@@ -796,10 +887,11 @@ impl Room {
                 connected: seat.tx.is_some(),
             },
             None => {
-                if self.game_started() && s < self.player_count() {
+                if self.game_in_progress() && s < self.player_count() {
                     // Same level/personality rule as the game-start
                     // assignment.
-                    let config = config_for_seat(&self.cpu_configs, s);
+                    let config =
+                        config_for_seat(&self.cpu_configs, s, self.host_seat, self.player_count());
                     SeatInfo::Cpu {
                         level: config.level,
                         personality: config.personality,
@@ -830,13 +922,15 @@ impl Room {
         let msg = ServerMessage::RoomState {
             code: self.code.clone(),
             seats: seats_info.clone(),
-            host_seat: HOST_SEAT,
+            host_seat: self.host_seat,
             your_seat: seat,
             rules: self.settings.rules.clone(),
             length: self.settings.length,
             cpu_configs: Some(std::array::from_fn(|i| {
                 CpuSpec::from_config(&self.cpu_configs[i])
             })),
+            post_game: self.post_game,
+            returned_to_lobby: self.returned_to_lobby,
         };
         self.send_to_seat(seat, msg);
     }
@@ -905,10 +999,12 @@ mod tests {
                 None,
                 None,
             ],
+            host_seat: HOST_SEAT,
             driver: None,
             awaiting_ready: false,
             ready: [false; 4],
-            game_over_sent: false,
+            post_game: false,
+            returned_to_lobby: [false; 4],
             ready_deadline: None,
             close_deadline: None,
             action_deadline: None,
@@ -969,14 +1065,72 @@ mod tests {
     }
 
     #[test]
-    fn reconnect_keeps_post_game_deadline() {
+    fn post_game_rematch_waits_for_result_return() {
         let mut room = room_with_connection(7);
-        let deadline = Instant::now() + Duration::from_secs(1);
-        room.game_over_sent = true;
-        room.close_deadline = Some(deadline);
+        let (tx, _rx) = mpsc::channel(8);
+        room.seats[1] = Some(Seat {
+            token: "guest-token".to_string(),
+            name: "guest".to_string(),
+            tx: Some(tx),
+            conn_gen: 8,
+            history: Vec::new(),
+        });
+        room.post_game = true;
 
-        room.handle_reconnect(HOST_SEAT);
+        room.handle_start_game(HOST_SEAT, None);
+        assert!(room.driver.is_none());
 
-        assert_eq!(room.close_deadline, Some(deadline));
+        room.handle_return_to_lobby(HOST_SEAT);
+        assert!(room.returned_to_lobby[HOST_SEAT]);
+        room.handle_start_game(HOST_SEAT, None);
+        assert!(room.driver.is_none());
+
+        room.handle_return_to_lobby(1);
+        room.handle_start_game(HOST_SEAT, None);
+
+        assert!(room.driver.is_some());
+        assert!(!room.post_game);
+        assert_eq!(room.returned_to_lobby, [false; 4]);
+    }
+
+    #[test]
+    fn post_game_guest_departure_unblocks_rematch() {
+        let mut room = room_with_connection(7);
+        let (tx, _rx) = mpsc::channel(4);
+        room.seats[1] = Some(Seat {
+            token: "guest-token".to_string(),
+            name: "guest".to_string(),
+            tx: Some(tx),
+            conn_gen: 8,
+            history: Vec::new(),
+        });
+        room.post_game = true;
+
+        room.handle_return_to_lobby(HOST_SEAT);
+        room.handle_departure(1);
+        room.handle_start_game(HOST_SEAT, None);
+
+        assert!(room.driver.is_some());
+        assert!(!room.closing);
+    }
+
+    #[test]
+    fn post_game_host_departure_transfers_control() {
+        let mut room = room_with_connection(7);
+        let (tx, _rx) = mpsc::channel(4);
+        room.seats[1] = Some(Seat {
+            token: "guest-token".to_string(),
+            name: "guest".to_string(),
+            tx: Some(tx),
+            conn_gen: 8,
+            history: Vec::new(),
+        });
+        room.post_game = true;
+
+        room.handle_departure(HOST_SEAT);
+
+        assert!(!room.closing);
+        assert!(room.seats[HOST_SEAT].is_none());
+        assert_eq!(room.host_seat, 1);
     }
 }

--- a/crates/mahjong-net-server/tests/integration.rs
+++ b/crates/mahjong-net-server/tests/integration.rs
@@ -342,6 +342,53 @@ async fn test_ready_timeout_auto_advances() {
     .expect("test timed out");
 }
 
+/// A player can leave the final results, return to the same room, and
+/// start a fresh game without recreating the room.
+#[tokio::test]
+async fn test_post_game_lobby_starts_rematch() {
+    tokio::time::timeout(Duration::from_secs(120), async {
+        let addr = start_server(fast_config()).await;
+
+        let mut host = TestClient::connect(addr).await;
+        host.hello("Host").await;
+        host.create_room().await;
+        host.send(&ClientMessage::StartGame { cpu_configs: None })
+            .await;
+        host.play_until_game_over(true).await;
+
+        host.send(&ClientMessage::ReturnToLobby).await;
+        loop {
+            if let ServerMessage::RoomState {
+                post_game,
+                returned_to_lobby,
+                ..
+            } = host.recv().await
+                && post_game
+                && returned_to_lobby[0]
+            {
+                break;
+            }
+        }
+
+        host.send(&ClientMessage::StartGame { cpu_configs: None })
+            .await;
+        loop {
+            if let ServerMessage::Event(ServerEvent::GameStarted {
+                scores,
+                round_number,
+                ..
+            }) = host.recv().await
+            {
+                assert_eq!(scores, [25000; 4]);
+                assert_eq!(round_number, 0);
+                break;
+            }
+        }
+    })
+    .await
+    .expect("test timed out");
+}
+
 /// The host's CPU configs must reach the seats.
 #[tokio::test]
 async fn test_host_chosen_cpu_configs_apply() {

--- a/crates/mahjong-server/src/protocol/net.rs
+++ b/crates/mahjong-server/src/protocol/net.rs
@@ -18,7 +18,8 @@ use crate::table::GameLength;
 /// `Settings`).
 /// v4: structured Nagashi Mangan round-end events.
 /// v5: double-yakuman settings and dedicated special-yakuman score items.
-pub const PROTOCOL_VERSION: u32 = 5;
+/// v6: post-game lobby state and same-room rematches.
+pub const PROTOCOL_VERSION: u32 = 6;
 
 /// A CPU's level and personality.
 ///
@@ -103,6 +104,10 @@ pub enum ClientMessage {
     /// The player has reviewed the result screen and is ready for
     /// the next hand
     ReadyNextRound,
+
+    /// The player has left the final-results screen and returned to the
+    /// room for a possible rematch.
+    ReturnToLobby,
 }
 
 /// Messages from the server to a client.
@@ -140,6 +145,15 @@ pub enum ServerMessage {
         /// to `None`.
         #[serde(default)]
         cpu_configs: Option<[CpuSpec; 3]>,
+        /// Whether the room is between completed games.
+        #[serde(default)]
+        post_game: bool,
+        /// Seats whose players have left the final-results screen.
+        ///
+        /// Only meaningful while `post_game` is true. Empty seats are
+        /// ignored when deciding whether the host can start a rematch.
+        #[serde(default)]
+        returned_to_lobby: [bool; 4],
     },
 
     /// An in-game event
@@ -212,6 +226,8 @@ pub enum ErrorCode {
     NotInRoom,
     /// Rejected because a game is in progress
     GameInProgress,
+    /// A rematch cannot start while a player is still reviewing results
+    PlayersNotReady,
     /// Invalid action (wrong turn, wrong phase, ...)
     InvalidAction,
     /// Unparseable message
@@ -324,6 +340,7 @@ mod tests {
             }),
             ClientMessage::Action(ClientAction::Riichi { tile: None }),
             ClientMessage::ReadyNextRound,
+            ClientMessage::ReturnToLobby,
         ];
 
         for msg in messages {
@@ -378,6 +395,8 @@ mod tests {
                         personality: CpuPersonality::HighValue,
                     },
                 ]),
+                post_game: true,
+                returned_to_lobby: [true, false, true, false],
             },
             ServerMessage::Event(ServerEvent::TileDrawn {
                 tile: Tile::new(Tile::P5),
@@ -442,6 +461,7 @@ mod tests {
             ErrorCode::NotHost,
             ErrorCode::NotInRoom,
             ErrorCode::GameInProgress,
+            ErrorCode::PlayersNotReady,
             ErrorCode::InvalidAction,
             ErrorCode::BadMessage,
             ErrorCode::RateLimited,
@@ -478,7 +498,16 @@ mod tests {
         let json = r#"{"RoomState":{"code":"ABC234","seats":["Empty","Empty","Empty","Empty"],"host_seat":0,"your_seat":1}}"#;
         let decoded = ServerMessage::from_json(json).expect("decode");
         match decoded {
-            ServerMessage::RoomState { cpu_configs, .. } => assert_eq!(cpu_configs, None),
+            ServerMessage::RoomState {
+                cpu_configs,
+                post_game,
+                returned_to_lobby,
+                ..
+            } => {
+                assert_eq!(cpu_configs, None);
+                assert!(!post_game);
+                assert_eq!(returned_to_lobby, [false; 4]);
+            }
             _ => panic!("variant changed"),
         }
     }


### PR DESCRIPTION
## Summary

- replace the ambiguous game-over action with explicit local rematch, setup, online-room, online-menu, and title actions
- start local rematches from a fresh game state while preserving rules and CPU preferences
- add an online post-game lobby with result-review readiness, safe same-room rematches, seat vacancies, and host migration
- bump the network protocol to v6 and add regression and integration coverage

## Why

The previous "Play Again" button returned to the title screen, which did not match its label and forced local players through setup again. Online play also could not safely restart because participants may still be reviewing results or may leave after the game.

## User impact

Local players can immediately rematch with the same settings, change match settings, or return to the title screen. Online players return to their room, can see who is still reviewing results, and can start a fresh rematch once all remaining human players are ready. Background clicks no longer dismiss the final standings.

## Validation

- `cargo build --workspace`
- `cargo test --workspace --all-targets`
- `cargo test -p mahjong-client --bin mahjong-client`
- `cargo test -p mahjong-net-server --lib`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo check -p mahjong-client --target wasm32-unknown-unknown`

Closes #370