### PR TITLE
Automate itch.io HTML5 deployment

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,4 +29,33 @@ jobs:
     - name: Run tests
       run: cargo test --workspace --all-targets --all-features --locked --verbose
     - name: Build web client
+      env:
+        MAHJONG_SERVER_URL: ${{ vars.MAHJONG_SERVER_URL }}
       run: bash scripts/vercel-build.sh
+    - name: Check itch.io deployment configuration
+      id: itch-config
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      shell: bash
+      env:
+        BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
+        ITCH_TARGET: ${{ vars.ITCH_TARGET }}
+        MAHJONG_SERVER_URL: ${{ vars.MAHJONG_SERVER_URL }}
+      run: |
+        if [[ -n "$BUTLER_API_KEY" && -n "$ITCH_TARGET" && -n "$MAHJONG_SERVER_URL" ]]; then
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::Skipping itch.io deployment because BUTLER_API_KEY, ITCH_TARGET, or MAHJONG_SERVER_URL is not configured."
+        fi
+    - name: Set up butler
+      if: steps.itch-config.outputs.enabled == 'true'
+      uses: remarkablegames/setup-butler@v3
+    - name: Deploy web client to itch.io
+      if: steps.itch-config.outputs.enabled == 'true'
+      env:
+        BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
+        ITCH_TARGET: ${{ vars.ITCH_TARGET }}
+      run: >
+        butler push public "${ITCH_TARGET}:html5"
+        --userversion "$GITHUB_SHA"
+        --if-changed

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Implementation for Japanese Riichi Mahjong Game in Rust.
   - Games start with 35,000 points; an East-only game is East 1–3, and a hanchan is East 1 through South 3.
 - A choice of East-only or hanchan games in both four-player and three-player modes.
 - Flexible per-game rule configuration. Examples: open Tan'yao, whether simultaneous ron wins are allowed, swap-calling, abortive draws, yakuman liability payment, double yakuman, and pei dora or tsumo loss in three-player games.
-- Included scripts and configuration for deploying the static web client to Vercel and the online multiplayer server to Fly.io.
+- Included scripts and configuration for deploying the static web client to Vercel or itch.io and the online multiplayer server to Fly.io.
 
 ## Structure
 
@@ -156,6 +156,35 @@ uses the bundle shipped with that resolved package version.
 
 To point the deployed web client at your online server, set the `MAHJONG_SERVER_URL` environment variable in the Vercel project (for example `wss://your-app.fly.dev/ws`). The build injects it into `window.MAHJONG_SERVER_URL`. If it is unset, the client falls back to `ws://127.0.0.1:8080/ws` (local development only).
 
+## itch.io deployment
+
+The GitHub Actions workflow can upload the generated `public/` directory to
+itch.io with [butler](https://itch.io/docs/butler/). It deploys only after all
+checks pass on a push to `main`; pull requests never deploy. If the required
+configuration is absent, the deployment steps are skipped.
+
+One-time setup:
+
+1. Create the itch.io project page. Set its game kind to HTML.
+2. Add a GitHub Actions repository secret named `BUTLER_API_KEY`. Obtain the
+   key through `butler login` or the itch.io API keys settings page and keep it
+   out of logs.
+3. Add an Actions repository variable named `ITCH_TARGET` in
+   `creator/game-slug` format (for example, the page
+   `https://creator.itch.io/riichi-mahjong-rs` uses
+   `creator/riichi-mahjong-rs`).
+4. Add an Actions repository variable named `MAHJONG_SERVER_URL` with the
+   production WebSocket endpoint (for example,
+   `wss://your-app.fly.dev/ws`). This is required for online play; without it,
+   the itch.io build uses the local-development fallback.
+5. After the first workflow upload creates the `html5` channel, open the
+   itch.io project editor, mark that upload as HTML5 / Playable in browser,
+   configure its embed options, and save the page.
+
+The workflow passes `public/` directly to `butler push`, so no ZIP archive is
+created in CI. Subsequent successful pushes to `main` update the same `html5`
+channel, and unchanged web builds are skipped.
+
 ## Online multiplayer server
 
 `mahjong-net-server` hosts room-code online matches. The static web client (above) and the game server are deployed separately: Vercel only serves static files, so the WebSocket server needs its own host.
@@ -170,7 +199,8 @@ Environment variables:
 
 - `PORT`: listen port (default `8080`).
 - `RUST_LOG`: log filter (for example `mahjong_net_server=debug`).
-- `ALLOWED_ORIGIN`: if set, only WebSocket connections with a matching `Origin` header are accepted (for example `https://your-app.vercel.app`). If unset, all origins are allowed. Note that **native clients do not send an `Origin` header and are rejected (HTTP 403) while this is set** — leave it unset if you need native clients to connect, and rely on browser clients plus the built-in rate limiting otherwise.
+- `ALLOWED_ORIGINS`: comma-separated exact `Origin` values allowed to open WebSocket connections (for example `https://your-app.vercel.app,https://html-classic.itch.zone`). If neither Origin setting is present, all origins are allowed.
+- `ALLOWED_ORIGIN`: legacy single-Origin setting. When present, its value is added to `ALLOWED_ORIGINS` for backward compatibility. Note that **native clients do not send an `Origin` header and are rejected (HTTP 403) while either setting contains an Origin** — leave both unset if you need native clients to connect, and rely on browser clients plus the built-in rate limiting otherwise.
 - `INTERNAL_PORT`: port of the private machine-to-machine listener used for room lookups in multi-machine deployments (default `8081`). On Fly it binds to the 6PN private address (`FLY_PRIVATE_IP`), locally to `127.0.0.1`.
 - `MAHJONG_PEERS`: comma-separated `host:port` list of peer internal listeners, overriding the default peer discovery via `<FLY_APP_NAME>.internal` DNS. Useful for testing the multi-machine setup locally.
 
@@ -190,8 +220,8 @@ The repository includes a `Dockerfile` and `fly.toml`. TLS (`wss://`) is termina
 # one-time: create the app (edit the app name in fly.toml or let fly launch set it)
 fly launch --no-deploy
 
-# (optional) restrict accepted origins to your web client
-fly secrets set ALLOWED_ORIGIN=https://your-app.vercel.app
+# (optional) restrict accepted origins to your web clients
+fly secrets set ALLOWED_ORIGINS=https://your-app.vercel.app,https://html-classic.itch.zone
 
 # deploy
 fly deploy

--- a/crates/mahjong-net-server/src/connection.rs
+++ b/crates/mahjong-net-server/src/connection.rs
@@ -78,9 +78,9 @@ pub async fn ws_handler(
     Query(query): Query<WsQuery>,
     headers: HeaderMap,
 ) -> Response {
-    // Origin restriction, only when ALLOWED_ORIGIN is set.
+    // A missing Origin must not bypass a configured browser allowlist.
     let origin = headers.get(header::ORIGIN).and_then(|v| v.to_str().ok());
-    if !origin_allowed(state.allowed_origin.as_deref(), origin) {
+    if !origin_allowed(state.allowed_origins.as_deref(), origin) {
         tracing::warn!(?origin, "rejected connection from disallowed origin");
         return StatusCode::FORBIDDEN.into_response();
     }
@@ -138,12 +138,14 @@ async fn maybe_replay(state: &AppState, code: &str, headers: &HeaderMap) -> Opti
     )
 }
 
-/// Whether the Origin is allowed: None allows all, Some requires an
-/// exact Origin-header match.
-fn origin_allowed(allowed: Option<&str>, origin: Option<&str>) -> bool {
+/// Whether the Origin is allowed.
+///
+/// `None` allows all clients. A configured list requires an exact
+/// match and rejects clients without an Origin header.
+fn origin_allowed(allowed: Option<&[String]>, origin: Option<&str>) -> bool {
     match allowed {
         None => true,
-        Some(allowed) => origin == Some(allowed),
+        Some(allowed) => origin.is_some_and(|origin| allowed.iter().any(|item| item == origin)),
     }
 }
 
@@ -532,11 +534,24 @@ mod tests {
 
     #[test]
     fn test_origin_allowed_requires_exact_match() {
-        let allowed = Some("https://mahjong.example.com");
-        assert!(origin_allowed(allowed, Some("https://mahjong.example.com")));
+        let allowed = vec![
+            "https://mahjong.example.com".to_string(),
+            "https://html.example.com".to_string(),
+        ];
+        assert!(origin_allowed(
+            Some(&allowed),
+            Some("https://mahjong.example.com")
+        ));
+        assert!(origin_allowed(
+            Some(&allowed),
+            Some("https://html.example.com")
+        ));
         // Mismatches and missing headers are rejected.
-        assert!(!origin_allowed(allowed, Some("https://evil.example.com")));
-        assert!(!origin_allowed(allowed, None));
+        assert!(!origin_allowed(
+            Some(&allowed),
+            Some("https://evil.example.com")
+        ));
+        assert!(!origin_allowed(Some(&allowed), None));
     }
 
     #[test]

--- a/crates/mahjong-net-server/src/lib.rs
+++ b/crates/mahjong-net-server/src/lib.rs
@@ -39,27 +39,49 @@ pub struct AppState {
     pub lobby: Lobby,
     /// Per-IP join rate limiter
     pub rate_limiter: RateLimiter,
-    /// Allowed Origin; None allows all
-    pub allowed_origin: Option<String>,
+    /// Allowed browser Origins; `None` allows all
+    pub allowed_origins: Option<Vec<String>>,
     /// Peer (other machine) discovery and lookup
     pub peers: Peers,
 }
 
 /// Builds the shared state from environment variables.
 ///
-/// When `ALLOWED_ORIGIN` is set, only WebSocket connections from that
-/// Origin are accepted (otherwise all are). Peer configuration is
+/// `ALLOWED_ORIGINS` accepts a comma-separated list of exact Origins.
+/// The legacy `ALLOWED_ORIGIN` value is added to that list when set. If
+/// neither contains an Origin, all are accepted. Peer configuration is
 /// described at [`Peers::from_env`].
 pub fn build_state(config: RoomConfig) -> AppState {
-    let allowed_origin = std::env::var("ALLOWED_ORIGIN")
-        .ok()
-        .filter(|s| !s.is_empty());
+    let allowed_origins = std::env::var("ALLOWED_ORIGINS").ok();
+    let allowed_origin = std::env::var("ALLOWED_ORIGIN").ok();
     AppState {
         lobby: Lobby::new(config),
         rate_limiter: RateLimiter::new(),
-        allowed_origin,
+        allowed_origins: parse_allowed_origins(
+            allowed_origins.as_deref(),
+            allowed_origin.as_deref(),
+        ),
         peers: Peers::from_env(),
     }
+}
+
+fn parse_allowed_origins(
+    allowed_origins: Option<&str>,
+    allowed_origin: Option<&str>,
+) -> Option<Vec<String>> {
+    let mut origins = Vec::new();
+    for origin in allowed_origins
+        .into_iter()
+        .flat_map(|value| value.split(','))
+        .chain(allowed_origin)
+        .map(str::trim)
+        .filter(|origin| !origin.is_empty())
+    {
+        if !origins.iter().any(|existing| existing == origin) {
+            origins.push(origin.to_owned());
+        }
+    }
+    (!origins.is_empty()).then_some(origins)
 }
 
 /// Builds the public router: `/ws` for WebSocket, `/healthz` for
@@ -95,5 +117,38 @@ async fn internal_room_lookup(Path(code): Path<String>, State(state): State<AppS
     match (state.peers.machine_id(), state.lobby.get(&code)) {
         (Some(id), Some(_)) => (StatusCode::OK, id.to_string()).into_response(),
         _ => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_allowed_origins;
+
+    #[test]
+    fn test_parse_allowed_origins_combines_current_and_legacy_settings() {
+        assert_eq!(
+            parse_allowed_origins(
+                Some("https://web.example.com, https://html.example.com"),
+                Some("https://legacy.example.com"),
+            ),
+            Some(vec![
+                "https://web.example.com".to_string(),
+                "https://html.example.com".to_string(),
+                "https://legacy.example.com".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_parse_allowed_origins_ignores_empty_and_duplicate_values() {
+        assert_eq!(
+            parse_allowed_origins(
+                Some(" ,https://web.example.com,https://web.example.com, "),
+                Some(""),
+            ),
+            Some(vec!["https://web.example.com".to_string()])
+        );
+        assert_eq!(parse_allowed_origins(Some(" , "), None), None);
+        assert_eq!(parse_allowed_origins(None, None), None);
     }
 }

--- a/crates/mahjong-net-server/tests/multi_machine.rs
+++ b/crates/mahjong-net-server/tests/multi_machine.rs
@@ -68,7 +68,7 @@ async fn start_two_machines() -> (Machine, Machine) {
     let state = |machine_id: &str, peer: String| AppState {
         lobby: Lobby::new(RoomConfig::default()),
         rate_limiter: RateLimiter::new(),
-        allowed_origin: None,
+        allowed_origins: None,
         peers: Peers::with_static(Some(machine_id), vec![peer]),
     };
 
@@ -294,7 +294,7 @@ async fn test_create_room_completes_with_lying_peer() {
     let state = AppState {
         lobby: Lobby::new(RoomConfig::default()),
         rate_limiter: RateLimiter::new(),
-        allowed_origin: None,
+        allowed_origins: None,
         peers: Peers::with_static(Some("machinea"), vec![liar_addr]),
     };
     let internal = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -32,7 +32,7 @@
   - 35,000 点持ち。東風戦は東 1〜3 局、半荘戦は東 1〜南 3 局
 - 四人麻雀・三人麻雀ともに、東風戦と半荘戦を対局ごとに選択可能
 - 細かなルールを対局ごとに柔軟に設定可能。例：喰いタン、複数ロンの可否（頭ハネ）、喰い替え、各種途中流局、役満の包、ダブル役満、三人麻雀の北抜きやツモ損
-- 同梱のスクリプトと設定により、静的 Web クライアントを Vercel、オンライン対戦サーバを Fly.io にデプロイ可能
+- 同梱のスクリプトと設定により、静的 Web クライアントを Vercel または itch.io、オンライン対戦サーバを Fly.io にデプロイ可能
 
 ## 構成
 
@@ -153,6 +153,35 @@ Vercel のビルドでは次の処理を行います。
 
 デプロイした Web クライアントをオンラインサーバへ接続させるには、Vercel プロジェクトの環境変数 `MAHJONG_SERVER_URL` を設定します（例: `wss://your-app.fly.dev/ws`）。ビルド時に `window.MAHJONG_SERVER_URL` へ注入されます。未設定の場合は `ws://127.0.0.1:8080/ws`（ローカル開発用）にフォールバックします。
 
+## itch.io デプロイ
+
+GitHub Actions のワークフローは、生成した `public/` ディレクトリを
+[butler](https://itch.io/docs/butler/) で itch.io へアップロードできます。
+`main` への push ですべてのチェックに成功したときだけデプロイし、Pull
+Request では実行しません。必要な設定がない場合、デプロイ処理はスキップします。
+
+初回のみ、次の設定が必要です。
+
+1. itch.io でプロジェクトページを作成し、ゲームの種類を HTML にします。
+2. GitHub Actions の Repository secret `BUTLER_API_KEY` を追加します。
+   `butler login` または itch.io の API keys 設定画面で取得し、ログには
+   出力しないでください。
+3. Actions の Repository variable `ITCH_TARGET` を
+   `作者名/ゲームのURLスラッグ` 形式で追加します。たとえばページが
+   `https://creator.itch.io/riichi-mahjong-rs` なら
+   `creator/riichi-mahjong-rs` です。
+4. Actions の Repository variable `MAHJONG_SERVER_URL` に本番の
+   WebSocket エンドポイント（例: `wss://your-app.fly.dev/ws`）を設定します。
+   オンライン対戦にはこの設定が必要です。未設定の場合、itch.io 版は
+   ローカル開発用の接続先へフォールバックします。
+5. 最初のワークフロー実行で `html5` チャンネルが作られた後、itch.io の
+   プロジェクト編集画面で、そのアップロードを HTML5 / Playable in browser
+   に指定し、埋め込み設定を行って保存します。
+
+ワークフローは `public/` を直接 `butler push` に渡すため、CI で ZIP を作る
+必要はありません。以後、`main` への push が成功するたびに同じ `html5`
+チャンネルを更新し、Web ビルドの内容が同一の場合はアップロードを省略します。
+
 ## オンライン対戦サーバ
 
 `mahjong-net-server` はルームコード制のオンライン対戦をホストします。静的 Web クライアントとゲームサーバは別々にデプロイします（Vercel は静的配信のみのため、WebSocket サーバは別ホストが必要）。
@@ -167,7 +196,8 @@ cargo run -p mahjong-net-server
 
 - `PORT`: リッスンポート（デフォルト `8080`）
 - `RUST_LOG`: ログフィルタ（例: `mahjong_net_server=debug`）
-- `ALLOWED_ORIGIN`: 設定すると、`Origin` ヘッダが一致する WebSocket 接続のみ許可（例: `https://your-app.vercel.app`）。未設定なら全許可。**ネイティブクライアントは `Origin` ヘッダを送らないため、設定中は弾かれます（HTTP 403）** — ネイティブから接続したい場合は未設定にし、ブラウザクライアント + 組み込みのレート制限で運用してください
+- `ALLOWED_ORIGINS`: WebSocket 接続を許可する完全一致の `Origin` をカンマ区切りで指定（例: `https://your-app.vercel.app,https://html-classic.itch.zone`）。どちらの Origin 設定もなければ全許可
+- `ALLOWED_ORIGIN`: 従来の単一 Origin 設定。後方互換性のため、設定した値は `ALLOWED_ORIGINS` に追加されます。**どちらかの設定に Origin が含まれる場合、`Origin` ヘッダを送らないネイティブクライアントは弾かれます（HTTP 403）** — ネイティブから接続したい場合は両方とも未設定にし、ブラウザクライアント + 組み込みのレート制限で運用してください
 - `INTERNAL_PORT`: 複数マシン構成でルーム所在を照会し合う、マシン間専用リスナーのポート（デフォルト `8081`）。Fly 上ではプライベートネットワーク（6PN）のアドレス（`FLY_PRIVATE_IP`）に、ローカルでは `127.0.0.1` に bind します
 - `MAHJONG_PEERS`: ピアの内部リスナーをカンマ区切りの `host:port` で指定し、デフォルトのピア発見（`<FLY_APP_NAME>.internal` DNS）を上書きします。複数マシン構成をローカルで試すときに使います
 
@@ -188,7 +218,7 @@ MAHJONG_SERVER_URL=ws://127.0.0.1:8080/ws cargo run -p mahjong-client
 fly launch --no-deploy
 
 # （任意）接続を許可する Origin を Web クライアントに制限
-fly secrets set ALLOWED_ORIGIN=https://your-app.vercel.app
+fly secrets set ALLOWED_ORIGINS=https://your-app.vercel.app,https://html-classic.itch.zone
 
 # デプロイ
 fly deploy


### PR DESCRIPTION
## Summary

- deploy the generated HTML5/WASM build to itch.io with butler after successful `main` CI runs
- inject the production WebSocket URL while keeping pull requests and unconfigured repositories from deploying
- support multiple exact WebSocket origins through `ALLOWED_ORIGINS` while preserving `ALLOWED_ORIGIN`
- document the GitHub, itch.io, and Fly.io setup in English and Japanese

## Why

Publishing the browser client to itch.io otherwise requires manually packaging and uploading every release. The existing single-origin WebSocket setting also cannot authorize both the Vercel client and itch.io's HTML iframe at the same time.

## Impact

Once `BUTLER_API_KEY`, `ITCH_TARGET`, and `MAHJONG_SERVER_URL` are configured, successful pushes to `main` update the itch.io `html5` channel. Deployments are skipped for pull requests, missing configuration, and unchanged web builds.

Operators can configure multiple comma-separated browser origins with `ALLOWED_ORIGINS`. Existing `ALLOWED_ORIGIN` deployments remain compatible.

## Validation

- `cargo build --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`
- release WASM build with WebSocket URL injection
- GitHub Actions YAML parse
- `git diff --check`

Closes #373